### PR TITLE
feat(mobile): add core data models and domain glossary(#203)

### DIFF
--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -1,5 +1,9 @@
 # Roots & Recipes — Mobile App
 
+## Domain Glossary
+
+See [`docs/glossary.md`](docs/glossary.md) for definitions of **Dish**, **Dish Genre**, **Dish Variety**, and **Recipe** — and why they are grouped under the Dish umbrella.
+
 ## Goal
 
 Implement the mobile client for Roots & Recipes, a cross-generational recipe sharing platform. The app lets users discover, create, and share heritage recipes with features like ingredient substitution, unit conversion, allergen filtering, and step-by-step cooking mode.

--- a/mobile/docs/glossary.md
+++ b/mobile/docs/glossary.md
@@ -1,0 +1,55 @@
+# Domain Glossary
+
+## Dish (umbrella term)
+
+**Dish** is the umbrella concept grouping three related but distinct entities: **Dish Genre**, **Dish Variety**, and **Recipe**. When the app searches or filters by allergen, ingredient, or region, results can include any of these three — that is why they are unified under the Dish concept.
+
+---
+
+## Dish Genre
+
+The broadest category. A Dish Genre names a class of food at the highest level of abstraction.
+
+**Examples**: Soup, Kebap, Pasta, Salad, Dessert, Pastry
+
+---
+
+## Dish Variety
+
+A specific type within a Dish Genre, typically distinguished by region, culture, or preparation style.
+
+**Examples**: Adana Kebap, Urfa Kebap, Mercimek Çorbası, Tagliatelle al Ragù
+
+A Dish Variety belongs to exactly one Dish Genre.
+
+---
+
+## Recipe
+
+A concrete, step-by-step preparation guide for a Dish Variety. Recipes are authored either by the community (home cooks) or by experts (chefs, cultural authorities).
+
+- **Community recipe**: submitted by a regular user
+- **Expert/Cultural recipe**: submitted by a verified expert or sourced from cultural archives
+
+A Dish Variety can have multiple Recipes.
+
+---
+
+## Hierarchy
+
+```
+Dish Genre
+  └── Dish Variety (one or many per Genre)
+        └── Recipe (one or many per Variety, community or expert)
+```
+
+---
+
+## Why they are grouped under "Dish"
+
+Allergen filtering, ingredient search, and region-based discovery can surface results at any level of this hierarchy. A search for "gluten-free" may return:
+- A Genre (e.g., Salads — generally gluten-free)
+- A Variety (e.g., a specific regional dish known to be gluten-free)
+- A Recipe (e.g., a specific preparation that avoids gluten)
+
+Grouping all three under the Dish umbrella lets the system return mixed results in a single list without the user needing to understand the hierarchy.

--- a/mobile/src/types/comment.ts
+++ b/mobile/src/types/comment.ts
@@ -1,0 +1,29 @@
+import type { ISODateString } from './common';
+import type { User } from './user';
+
+export interface Comment {
+  id: string;
+  recipeId: string;
+  author: Pick<User, 'id' | 'firstName' | 'lastName' | 'profilePictureUrl'>;
+  text: string;
+  createdAt: ISODateString;
+}
+
+export interface Rating {
+  id: string;
+  recipeId: string;
+  userId: string;
+  score: 1 | 2 | 3 | 4 | 5;
+}
+
+export interface RatingSummary {
+  average: number;
+  totalCount: number;
+  distribution: {
+    1: number;
+    2: number;
+    3: number;
+    4: number;
+    5: number;
+  };
+}

--- a/mobile/src/types/common.ts
+++ b/mobile/src/types/common.ts
@@ -1,0 +1,41 @@
+export type ISODateString = string;
+
+export type UserRole = 'LEARNER' | 'COOK' | 'EXPERT';
+
+export type RecipeType = 'COMMUNITY' | 'CULTURAL';
+
+export type DietaryTag =
+  | 'VEGAN'
+  | 'VEGETARIAN'
+  | 'HALAL'
+  | 'KOSHER'
+  | 'GLUTEN_FREE'
+  | 'HEARTY';
+
+export type AllergenTag =
+  | 'PEANUTS'
+  | 'DAIRY'
+  | 'SHELLFISH'
+  | 'GLUTEN'
+  | 'TREE_NUTS';
+
+export type MeasurementUnit =
+  | 'g'
+  | 'kg'
+  | 'ml'
+  | 'L'
+  | 'cup'
+  | 'tbsp'
+  | 'tsp'
+  | 'piece'
+  | 'pinch'
+  | 'oz'
+  | 'lb';
+
+export type SortOption = 'BEST_RATING' | 'MOST_RECENT' | 'BY_REGION';
+
+export interface Origin {
+  country: string;
+  city?: string;
+  district?: string;
+}

--- a/mobile/src/types/dish.ts
+++ b/mobile/src/types/dish.ts
@@ -1,0 +1,19 @@
+import type { Origin } from './common';
+import type { Recipe } from './recipe';
+
+export interface DishGenre {
+  id: string;
+  name: string;
+  description: string;
+  imageUrl?: string;
+}
+
+export interface DishVariety {
+  id: string;
+  name: string;
+  description: string;
+  origin: Origin;
+  genreId: string;
+}
+
+export type Dish = DishGenre | DishVariety | Recipe;

--- a/mobile/src/types/draft.ts
+++ b/mobile/src/types/draft.ts
@@ -1,0 +1,27 @@
+import type { ISODateString, DietaryTag, AllergenTag, RecipeType } from './common';
+import type { Ingredient, Tool } from './ingredient';
+import type { Step } from './step';
+
+export interface RecipeDraft {
+  localId: string;
+  serverId?: string;
+  title?: string;
+  type?: RecipeType;
+  originCountry?: string;
+  originRegion?: string;
+  description?: string;
+  story?: string;
+  tags: DietaryTag[];
+  allergens: AllergenTag[];
+  images: string[];
+  videoUrl?: string;
+  servings?: number;
+  prepTime?: string;
+  cookTime?: string;
+  ingredients: Ingredient[];
+  tools: Tool[];
+  steps: Step[];
+  dishVarietyId?: string;
+  currentStep: 1 | 2 | 3 | 4;
+  lastSavedAt?: ISODateString;
+}

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -1,0 +1,9 @@
+export type { ISODateString, UserRole, RecipeType, DietaryTag, AllergenTag, MeasurementUnit, SortOption, Origin } from './common';
+export type { User } from './user';
+export type { Ingredient, Tool } from './ingredient';
+export type { Step } from './step';
+export type { Recipe, RecipeCard, RecipeStatus } from './recipe';
+export type { Dish, DishVariety, DishGenre } from './dish';
+export type { Comment, Rating, RatingSummary } from './comment';
+export type { UserSettings, UnitSystem } from './settings';
+export type { RecipeDraft } from './draft';

--- a/mobile/src/types/ingredient.ts
+++ b/mobile/src/types/ingredient.ts
@@ -1,0 +1,18 @@
+import type { AllergenTag, MeasurementUnit } from './common';
+
+export interface Ingredient {
+  id: string;
+  name: string;
+  quantity: number;
+  unit: MeasurementUnit;
+  allergens: AllergenTag[];
+  substitutionAvailable: boolean;
+  substitutes: string[];
+}
+
+export interface Tool {
+  id: string;
+  name: string;
+  description?: string;
+  imageUrl?: string;
+}

--- a/mobile/src/types/recipe.ts
+++ b/mobile/src/types/recipe.ts
@@ -1,0 +1,48 @@
+import type { ISODateString, DietaryTag, AllergenTag, RecipeType, Origin } from './common';
+import type { User } from './user';
+import type { Ingredient, Tool } from './ingredient';
+import type { Step } from './step';
+
+export type RecipeStatus = 'PUBLISHED' | 'DRAFT';
+
+export interface Recipe {
+  id: string;
+  title: string;
+  description: string;
+  story: string;
+  type: RecipeType;
+  author: User;
+  images: string[];
+  videoUrl?: string;
+  rating: number;
+  ratingCount: number;
+  prepTime: string;
+  cookTime: string;
+  servings: number;
+  ingredients: Ingredient[];
+  tools: Tool[];
+  steps: Step[];
+  origin: Origin;
+  dishVarietyId: string;
+  tags: DietaryTag[];
+  allergens: AllergenTag[];
+  status: RecipeStatus;
+  createdAt: ISODateString;
+  updatedAt: ISODateString;
+}
+
+export interface RecipeCard {
+  id: string;
+  title: string;
+  thumbnailUrl: string;
+  author: Pick<User, 'id' | 'firstName' | 'lastName'>;
+  rating: number;
+  ratingCount: number;
+  region: string;
+  dishVarietyId: string;
+  dishVarietyName: string;
+  type: RecipeType;
+  tags: DietaryTag[];
+  status: RecipeStatus;
+  updatedAt: ISODateString;
+}

--- a/mobile/src/types/settings.ts
+++ b/mobile/src/types/settings.ts
@@ -1,0 +1,13 @@
+import type { AllergenTag, DietaryTag } from './common';
+
+export type UnitSystem = 'METRIC' | 'IMPERIAL';
+
+export interface UserSettings {
+  userId: string;
+  unitSystem: UnitSystem;
+  language: string;
+  region: string;
+  allergenProfile: AllergenTag[];
+  dietaryPreferences: DietaryTag[];
+  email: string;
+}

--- a/mobile/src/types/step.ts
+++ b/mobile/src/types/step.ts
@@ -1,0 +1,8 @@
+export interface Step {
+  stepNumber: number;
+  title: string;
+  description: string;
+  imageUrl?: string;
+  durationMinutes?: number;
+  videoTimestamp?: number;
+}

--- a/mobile/src/types/user.ts
+++ b/mobile/src/types/user.ts
@@ -1,0 +1,14 @@
+import type { ISODateString, UserRole } from './common';
+
+export interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: UserRole;
+  region: string;
+  preferredLanguage: string;
+  profilePictureUrl?: string;
+  bio?: string;
+  memberSince: ISODateString;
+}


### PR DESCRIPTION
### What does this PR do?                                     

  Defines all core TypeScript data models under mobile/src/types/ and adds a domain glossary documenting the Dish hierarchy (Genre → Variety → Recipe).                                                     
   
  Models added:                                                                                                                                                                                             
  - DishGenre, DishVariety, Dish (union type: DishGenre | DishVariety | Recipe)
  - Recipe, RecipeCard — full detail and list-view summary shapes                                                                                                                                           
  - Ingredient, Tool, Step — sub-entities of Recipe              
  - Origin — structured geographic type (country, city?, district?) used by both Recipe and DishVariety                                                                                                     
  - User, Comment, Rating, RatingSummary                                                               
  - UserSettings, RecipeDraft (4-step wizard state)                                                                                                                                                         
  - index.ts — barrel re-export of all types       
                                                                                                                                                                                                            
###   How to test                                                                                                                                                                                               
   
  Run from the mobile/ directory:                                                                                                                                                                           
                                                            
  cd mobile                                                                                                                                                                                                 
  npx tsc --noEmit                                          
  Should complete with zero errors.

###   Related issue

  Closes https://github.com/bounswe/bounswe2026group10/issues/203 