### PR TITLE
Add profileId to AuthenticatedRequest for profile FK resolution

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -48,6 +48,7 @@ export const requireAuth = async (
 
   (req as AuthenticatedRequest).user = {
     userId: userData.user.id,
+    profileId: profile.id as string,
     email: userData.user.email ?? "",
     username: profile.username as string,
     role: profile.role as UserRole,

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -9,7 +9,8 @@ export const USER_ROLES: UserRole[] = ["learner", "cook", "expert"];
 // ─── Authenticated User ────────────────────────────────────────────────────────
 
 export interface AuthenticatedUser {
-  userId: string;
+  userId: string;    // auth.users.id
+  profileId: string; // profiles.id — used as FK in recipes, ratings, comments, etc.
   email: string;
   username: string;
   role: UserRole;


### PR DESCRIPTION
`requireAuth` already fetches the profile row to get `username` and `role`, 
but was not storing `profiles.id`. All domain tables (`recipes`, `ratings`, 
`comments`, etc.) use `profiles.id` as FK, not `auth.users.id`. This adds 
`profileId` to `req.user` with no extra DB query.
Closes #208