### PR TITLE
[Backend/Feature] Recipe Discovery APIs: Region Filter, Allergen Filter, and Dish Hierarchy

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,9 @@ import cors from "cors";
 import helmet from "helmet";
 import authRouter from "./routes/auth.js";
 import recipesRouter from "./routes/recipes.js";
+import dishGenresRouter from "./routes/dish-genres.js";
+import dishVarietiesRouter from "./routes/dish-varieties.js";
+import discoveryRouter from "./routes/discovery.js";
 
 const app = express();
 const PORT = process.env["PORT"] ?? 3000;
@@ -30,6 +33,9 @@ app.get("/meta/regions", (_req, res) => {
 // ─── API Routes ───────────────────────────────────────────────────────────────
 app.use("/auth", authRouter);
 app.use("/recipes", recipesRouter);
+app.use("/dish-genres", dishGenresRouter);
+app.use("/dish-varieties", dishVarietiesRouter);
+app.use("/discovery", discoveryRouter);
 
 // ─── 404 Handler ─────────────────────────────────────────────────────────────
 app.use((_req, res) => {

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -1,0 +1,167 @@
+import { Router } from "express";
+import { z } from "zod";
+import { supabase } from "../config/supabase.js";
+import { validate } from "../middleware/validate.js";
+import { successResponse, errorResponse } from "../utils/response.js";
+
+const router = Router();
+
+// ─── Zod Schema ───────────────────────────────────────────────────────────────
+
+const discoveryQuerySchema = z.object({
+  region: z.string().optional(),
+  // Comma-separated allergen IDs to exclude (e.g. "1,2,3")
+  excludeAllergens: z.string().optional(),
+  genreId: z.coerce.number().int().positive().optional(),
+  varietyId: z.coerce.number().int().positive().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+// ─── GET /discovery/recipes ───────────────────────────────────────────────────
+// Returns published recipes with composable filters:
+//   ?region=Turkey
+//   ?excludeAllergens=1,2,3   (allergen IDs)
+//   ?genreId=1
+//   ?varietyId=1
+//   ?page=1&limit=20
+router.get(
+  "/recipes",
+  validate(discoveryQuerySchema, "query"),
+  async (req, res) => {
+    const { region, excludeAllergens, genreId, varietyId, page, limit } =
+      req.query as z.infer<typeof discoveryQuerySchema>;
+
+    // ── Step 1: Resolve variety IDs to exclude based on allergens ─────────────
+    let excludedRecipeIds: number[] = [];
+
+    if (excludeAllergens) {
+      const allergenIds = excludeAllergens
+        .split(",")
+        .map(Number)
+        .filter((n) => Number.isInteger(n) && n > 0);
+
+      if (allergenIds.length > 0) {
+        // Find ingredient IDs that carry any of the excluded allergens
+        const { data: allergenIngredientRows, error: allergenErr } =
+          await supabase
+            .from("ingredient_allergens")
+            .select("ingredient_id")
+            .in("allergen_id", allergenIds);
+
+        if (allergenErr) {
+          return res
+            .status(500)
+            .json(errorResponse("DB_ERROR", allergenErr.message));
+        }
+
+        const excludedIngredientIds = [
+          ...new Set(allergenIngredientRows?.map((r) => r.ingredient_id) ?? []),
+        ];
+
+        if (excludedIngredientIds.length > 0) {
+          // Find recipe IDs that use those ingredients
+          const { data: recipeIngredientRows, error: riErr } = await supabase
+            .from("recipe_ingredients")
+            .select("recipe_id")
+            .in("ingredient_id", excludedIngredientIds);
+
+          if (riErr) {
+            return res
+              .status(500)
+              .json(errorResponse("DB_ERROR", riErr.message));
+          }
+
+          excludedRecipeIds = [
+            ...new Set(
+              recipeIngredientRows?.map((r) => r.recipe_id) ?? []
+            ),
+          ];
+        }
+      }
+    }
+
+    // ── Step 2: Resolve variety IDs when filtering by genre ───────────────────
+    let varietyIdsForGenre: number[] | null = null;
+
+    if (genreId !== undefined) {
+      const { data: varietyRows, error: genreErr } = await supabase
+        .from("dish_varieties")
+        .select("id")
+        .eq("genre_id", genreId);
+
+      if (genreErr) {
+        return res
+          .status(500)
+          .json(errorResponse("DB_ERROR", genreErr.message));
+      }
+
+      varietyIdsForGenre = varietyRows?.map((v) => v.id) ?? [];
+
+      // No varieties in this genre → return empty result immediately
+      if (varietyIdsForGenre.length === 0) {
+        return res.status(200).json(
+          successResponse({
+            recipes: [],
+            pagination: { page, limit, total: 0 },
+          })
+        );
+      }
+    }
+
+    // ── Step 3: Build the main recipe query ───────────────────────────────────
+    let query = supabase
+      .from("recipes")
+      .select(
+        `id, title, type, region, average_rating, rating_count,
+         created_at, updated_at,
+         dish_variety:dish_varieties!recipes_dish_variety_id_fkey(
+           id, name,
+           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)
+         ),
+         profile:profiles!recipes_profile_id_fkey(id, username)`,
+        { count: "exact" }
+      )
+      .eq("is_published", true);
+
+    if (region) {
+      query = query.eq("region", region);
+    }
+
+    if (varietyId !== undefined) {
+      query = query.eq("dish_variety_id", varietyId);
+    } else if (varietyIdsForGenre !== null) {
+      query = query.in("dish_variety_id", varietyIdsForGenre);
+    }
+
+    if (excludedRecipeIds.length > 0) {
+      query = query.not("id", "in", `(${excludedRecipeIds.join(",")})`);
+    }
+
+    // ── Step 4: Pagination ────────────────────────────────────────────────────
+    const from = (page - 1) * limit;
+    const to = from + limit - 1;
+    query = query.range(from, to).order("average_rating", { ascending: false });
+
+    const { data: recipes, error: recipesError, count } = await query;
+
+    if (recipesError) {
+      return res
+        .status(500)
+        .json(errorResponse("DB_ERROR", recipesError.message));
+    }
+
+    return res.status(200).json(
+      successResponse({
+        recipes,
+        pagination: {
+          page,
+          limit,
+          total: count ?? 0,
+        },
+      })
+    );
+  }
+);
+
+export default router;

--- a/backend/src/routes/dish-genres.ts
+++ b/backend/src/routes/dish-genres.ts
@@ -1,0 +1,37 @@
+import { Router } from "express";
+import { supabase } from "../config/supabase.js";
+import { successResponse, errorResponse } from "../utils/response.js";
+
+const router = Router();
+
+// ─── GET /dish-genres ─────────────────────────────────────────────────────────
+// Returns all dish genres with their nested varieties.
+router.get("/", async (_req, res) => {
+  const { data: genres, error: genreError } = await supabase
+    .from("dish_genres")
+    .select("id, name, description, image_url")
+    .order("name");
+
+  if (genreError) {
+    return res.status(500).json(errorResponse("DB_ERROR", genreError.message));
+  }
+
+  const { data: varieties, error: varietyError } = await supabase
+    .from("dish_varieties")
+    .select("id, name, genre_id")
+    .order("name");
+
+  if (varietyError) {
+    return res.status(500).json(errorResponse("DB_ERROR", varietyError.message));
+  }
+
+  // Nest varieties under their parent genre
+  const result = genres.map((genre) => ({
+    ...genre,
+    varieties: varieties.filter((v) => v.genre_id === genre.id),
+  }));
+
+  return res.status(200).json(successResponse(result));
+});
+
+export default router;

--- a/backend/src/routes/dish-varieties.ts
+++ b/backend/src/routes/dish-varieties.ts
@@ -1,0 +1,83 @@
+import { Router } from "express";
+import { supabase } from "../config/supabase.js";
+import { successResponse, errorResponse } from "../utils/response.js";
+
+const router = Router();
+
+// ─── GET /dish-varieties ──────────────────────────────────────────────────────
+// Returns all dish varieties. Optionally filtered by genreId.
+// Query params: ?genreId=<number>
+router.get("/", async (req, res) => {
+  const genreId = req.query["genreId"];
+
+  let query = supabase
+    .from("dish_varieties")
+    .select(
+      `id, name, description, genre_id,
+       dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)`
+    )
+    .order("name");
+
+  if (genreId !== undefined) {
+    const parsed = Number(genreId);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return res
+        .status(400)
+        .json(errorResponse("VALIDATION_ERROR", "genreId must be a positive integer."));
+    }
+    query = query.eq("genre_id", parsed);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return res.status(500).json(errorResponse("DB_ERROR", error.message));
+  }
+
+  return res.status(200).json(successResponse(data));
+});
+
+// ─── GET /dish-varieties/:id ──────────────────────────────────────────────────
+// Returns a single dish variety with its published recipes.
+router.get("/:id", async (req, res) => {
+  const id = Number(req.params["id"]);
+
+  if (!Number.isInteger(id) || id <= 0) {
+    return res
+      .status(400)
+      .json(errorResponse("VALIDATION_ERROR", "id must be a positive integer."));
+  }
+
+  const { data: variety, error: varietyError } = await supabase
+    .from("dish_varieties")
+    .select(
+      `id, name, description, genre_id,
+       dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)`
+    )
+    .eq("id", id)
+    .single();
+
+  if (varietyError) {
+    if (varietyError.code === "PGRST116") {
+      return res
+        .status(404)
+        .json(errorResponse("NOT_FOUND", "Dish variety not found."));
+    }
+    return res.status(500).json(errorResponse("DB_ERROR", varietyError.message));
+  }
+
+  const { data: recipes, error: recipesError } = await supabase
+    .from("recipes")
+    .select("id, title, type, average_rating, rating_count, region, created_at, updated_at")
+    .eq("dish_variety_id", id)
+    .eq("is_published", true)
+    .order("average_rating", { ascending: false });
+
+  if (recipesError) {
+    return res.status(500).json(errorResponse("DB_ERROR", recipesError.message));
+  }
+
+  return res.status(200).json(successResponse({ ...variety, recipes }));
+});
+
+export default router;


### PR DESCRIPTION
## What does this PR do?

Implements the backend discovery endpoints for the recipe discovery page.

- `GET /dish-genres` — returns all dish genres with nested varieties
- `GET /dish-varieties` — lists all varieties, filterable by `?genreId=`
- `GET /dish-varieties/:id` — returns a single variety with its published recipes
- `GET /discovery/recipes` — composable discovery endpoint supporting:
  - `?region=Turkey` — filter by cuisine region
  - `?excludeAllergens=1,2,3` — exclude recipes containing ingredients with those allergens (resolved via `ingredient_allergens` join)
  - `?genreId=1` — filter by dish genre
  - `?varietyId=1` — filter by dish variety
  - `?page=1&limit=20` — pagination (max 100)

All filters are optional and can be combined in a single request.

## How to test
```bash
cd backend
npm run dev
```

- `GET /dish-genres` → returns genres array with nested varieties
- `GET /dish-varieties?genreId=1` → returns varieties for that genre
- `GET /discovery/recipes?region=Turkey&excludeAllergens=1` → returns filtered published recipes
- `GET /discovery/recipes?genreId=1&page=1&limit=5` → returns paginated results

## Related issue

Closes #155