### PR TITLE
[Backend/Fix] Fix query param validation in GET /discovery/recipes

### DIFF
--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { z } from "zod";
 import { supabase } from "../config/supabase.js";
-import { validate } from "../middleware/validate.js";
 import { successResponse, errorResponse } from "../utils/response.js";
 
 const router = Router();
@@ -25,12 +24,15 @@ const discoveryQuerySchema = z.object({
 //   ?genreId=1
 //   ?varietyId=1
 //   ?page=1&limit=20
-router.get(
-  "/recipes",
-  validate(discoveryQuerySchema, "query"),
-  async (req, res) => {
-    const { region, excludeAllergens, genreId, varietyId, page, limit } =
-      req.query as z.infer<typeof discoveryQuerySchema>;
+router.get("/recipes", async (req, res) => {
+    const parsed = discoveryQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      const message = parsed.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ");
+      return res.status(400).json(errorResponse("VALIDATION_ERROR", message));
+    }
+    const { region, excludeAllergens, genreId, varietyId, page, limit } = parsed.data;
 
     // ── Step 1: Resolve variety IDs to exclude based on allergens ─────────────
     let excludedRecipeIds: number[] = [];


### PR DESCRIPTION
## What does this PR do?

`validate` middleware only validates `req.body`, but `GET /discovery/recipes`
uses query string parameters. Switched to `discoveryQuerySchema.safeParse(req.query)`
directly in the handler so filters are properly validated and typed.

## How to test
```bash
cd backend
npm run dev
```

- `GET /discovery/recipes?region=Turkey` → should return filtered results
- `GET /discovery/recipes?limit=abc` → should return 400 VALIDATION_ERROR

## Related issue

Related to #155