### PR TITLE
 [Backend/Feature] Recipe Listing API by Dish Variety (#157, #239)

### DIFF
--- a/backend/src/__tests__/discovery.test.ts
+++ b/backend/src/__tests__/discovery.test.ts
@@ -234,6 +234,148 @@ describe("GET /dish-varieties/:id", () => {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+describe("GET /dish-varieties/:id/recipes", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockCommunityRecipes = [
+    { id: 10, title: "Community A", type: "community", average_rating: 4.8, rating_count: 20, created_at: "2024-01-01", updated_at: "2024-01-01", creator: { id: "p1", username: "cook1" } },
+    { id: 11, title: "Community B", type: "community", average_rating: 3.5, rating_count: 8, created_at: "2024-01-02", updated_at: "2024-01-02", creator: { id: "p2", username: "cook2" } },
+  ];
+  const mockExpertRecipe = { id: 20, title: "Expert Recipe", type: "cultural", average_rating: 4.9, rating_count: 50, created_at: "2024-01-03", updated_at: "2024-01-03", creator: { id: "p3", username: "expert1" } };
+
+  it("returns expertRecipe and communityRecipes separated", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return chainable({ data: { id: 1 }, error: null });
+      if (table === "recipes") return chainable({ data: [mockExpertRecipe, ...mockCommunityRecipes], error: null });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.expertRecipe).not.toBeNull();
+    expect(res.body.data.expertRecipe.type).toBe("cultural");
+    expect(res.body.data.communityRecipes).toHaveLength(2);
+    expect(res.body.data.communityRecipes.every((r: any) => r.type === "community")).toBe(true);
+  });
+
+  it("returns community recipes sorted by rating descending", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return chainable({ data: { id: 1 }, error: null });
+      if (table === "recipes") return chainable({ data: mockCommunityRecipes, error: null });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(200);
+    const ratings = res.body.data.communityRecipes.map((r: any) => r.average_rating);
+    expect(ratings[0]).toBeGreaterThanOrEqual(ratings[1]);
+  });
+
+  it("returns null expertRecipe when no cultural recipe exists", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return chainable({ data: { id: 1 }, error: null });
+      if (table === "recipes") return chainable({ data: mockCommunityRecipes, error: null });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.expertRecipe).toBeNull();
+    expect(res.body.data.communityRecipes).toHaveLength(2);
+  });
+
+  it("returns empty communityRecipes when no community recipes exist", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return chainable({ data: { id: 1 }, error: null });
+      if (table === "recipes") return chainable({ data: [mockExpertRecipe], error: null });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.expertRecipe).not.toBeNull();
+    expect(res.body.data.communityRecipes).toHaveLength(0);
+  });
+
+  it("returns empty expertRecipe and empty communityRecipes when no recipes exist", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return chainable({ data: { id: 1 }, error: null });
+      if (table === "recipes") return chainable({ data: [], error: null });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.expertRecipe).toBeNull();
+    expect(res.body.data.communityRecipes).toHaveLength(0);
+  });
+
+  it("returns 404 when dish variety not found", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+    });
+
+    const res = await request(app).get("/dish-varieties/999/recipes");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 400 for non-integer id", async () => {
+    const res = await request(app).get("/dish-varieties/abc/recipes");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 for id = 0", async () => {
+    const res = await request(app).get("/dish-varieties/0/recipes");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 500 on variety db error", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties")
+        return chainable({ data: null, error: { message: "DB timeout" } });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("returns 500 on recipes db error", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return chainable({ data: { id: 1 }, error: null });
+      if (table === "recipes") return chainable({ data: null, error: { message: "DB timeout" } });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("includes creator info in recipe items", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return chainable({ data: { id: 1 }, error: null });
+      if (table === "recipes") return chainable({ data: mockCommunityRecipes, error: null });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(200);
+    const recipe = res.body.data.communityRecipes[0];
+    expect(recipe.creator).toBeDefined();
+    expect(recipe.creator.username).toBe("cook1");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 describe("GET /discovery/recipes", () => {
   beforeEach(() => jest.clearAllMocks());
 

--- a/backend/src/routes/dish-varieties.ts
+++ b/backend/src/routes/dish-varieties.ts
@@ -76,7 +76,7 @@ router.get("/:id", async (req, res) => {
 
   const { data: recipes, error: recipesError } = await supabase
     .from("recipes")
-    .select("id, title, type, average_rating, rating_count, region, created_at, updated_at")
+    .select("id, title, type, average_rating, rating_count, created_at, updated_at")
     .eq("dish_variety_id", id)
     .eq("is_published", true)
     .order("average_rating", { ascending: false });
@@ -86,6 +86,54 @@ router.get("/:id", async (req, res) => {
   }
 
   return res.status(200).json(successResponse({ ...variety, recipes }));
+});
+
+// ─── GET /dish-varieties/:id/recipes ─────────────────────────────────────────
+// Returns published recipes for a dish variety, separated into:
+//   - expertRecipe: the cultural recipe (type = "cultural"), or null
+//   - communityRecipes: all community recipes sorted by rating descending
+router.get("/:id/recipes", async (req, res) => {
+  const id = Number(req.params["id"]);
+
+  if (!Number.isInteger(id) || id <= 0) {
+    return res
+      .status(400)
+      .json(errorResponse("VALIDATION_ERROR", "id must be a positive integer."));
+  }
+
+  const { error: varietyError } = await supabase
+    .from("dish_varieties")
+    .select("id")
+    .eq("id", id)
+    .single();
+
+  if (varietyError) {
+    if (varietyError.code === "PGRST116") {
+      return res
+        .status(404)
+        .json(errorResponse("NOT_FOUND", "Dish variety not found."));
+    }
+    return res.status(500).json(errorResponse("DB_ERROR", varietyError.message));
+  }
+
+  const { data: recipes, error: recipesError } = await supabase
+    .from("recipes")
+    .select(
+      `id, title, type, average_rating, rating_count, created_at, updated_at,
+       creator:profiles!recipes_creator_id_fkey(id, username)`
+    )
+    .eq("dish_variety_id", id)
+    .eq("is_published", true)
+    .order("average_rating", { ascending: false });
+
+  if (recipesError) {
+    return res.status(500).json(errorResponse("DB_ERROR", recipesError.message));
+  }
+
+  const expertRecipe = recipes.find((r) => r.type === "cultural") ?? null;
+  const communityRecipes = recipes.filter((r) => r.type === "community");
+
+  return res.status(200).json(successResponse({ expertRecipe, communityRecipes }));
 });
 
 export default router;


### PR DESCRIPTION
## Summary

Implements the recipe listing endpoint for a given dish variety, with accompanying unit tests.

- Adds `GET /dish-varieties/:id/recipes` that returns published recipes split
  into `expertRecipe` (cultural type) and `communityRecipes` (community type,
  sorted by `average_rating` descending)
- Fixes a `recipes.region` column error in the existing `GET /dish-varieties/:id`
  endpoint (region lives on `dish_varieties`, not `recipes`)
- Adds 11 unit tests covering happy path, edge cases (no expert recipe, no
  community recipes, empty variety), 404, 400 validation, and 500 DB errors

## Closes

Closes #157
Closes #239

## Test plan

- [ ] `npx jest discovery` passes all 36 tests
- [ ] `GET /dish-varieties/:id/recipes` returns `{ expertRecipe, communityRecipes }` structure
- [ ] Community recipes are ordered by rating descending
- [ ] Returns 404 when variety ID does not exist
- [ ] Returns 400 for invalid (non-integer / zero) ID
