### PR TITLE
[Backend/Feature] Recipe Star Rating Endpoints (#175, #241)

### DIFF
--- a/backend/src/__tests__/recipes.test.ts
+++ b/backend/src/__tests__/recipes.test.ts
@@ -474,3 +474,278 @@ describe("Recipe Endpoints (Creation & Publishing)", () => {
     });
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Recipe Rating Endpoints", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // Reuse the same setupMocks helper pattern from the file top-level mock
+  const setupMocks = (
+    role: string,
+    profileId = "profile-123",
+    recipeFromMock?: (table: string) => any
+  ) => {
+    (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+      data: { user: { id: "user-123", email: "test@example.com" } },
+      error: null,
+    });
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") {
+        const mockSingle = jest.fn().mockResolvedValue({
+          data: { id: profileId, username: "tester", role },
+          error: null,
+        });
+        const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      }
+      if (recipeFromMock) return recipeFromMock(table);
+      return { select: jest.fn(), insert: jest.fn(), upsert: jest.fn(), delete: jest.fn() };
+    });
+  };
+
+  // ─── Chainable mock helper ─────────────────────────────────────────────────
+  const chainable = (resolved: { data: any; error: any }) => {
+    const mock: any = {};
+    const methods = ["select", "eq", "single", "upsert", "delete", "order"];
+    methods.forEach((m) => { mock[m] = jest.fn().mockReturnValue(mock); });
+    mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+    return mock;
+  };
+
+  // ─── POST /recipes/:id/ratings ─────────────────────────────────────────────
+
+  describe("POST /recipes/:id/ratings", () => {
+    it("returns 401 when unauthenticated", async () => {
+      const res = await request(app)
+        .post("/recipes/recipe-1/ratings")
+        .send({ score: 4 });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 400 for score = 0", async () => {
+      setupMocks("cook");
+      const res = await request(app)
+        .post("/recipes/recipe-1/ratings")
+        .set("Authorization", "Bearer valid_token")
+        .send({ score: 0 });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for score = 6", async () => {
+      setupMocks("cook");
+      const res = await request(app)
+        .post("/recipes/recipe-1/ratings")
+        .set("Authorization", "Bearer valid_token")
+        .send({ score: 6 });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for non-numeric score", async () => {
+      setupMocks("cook");
+      const res = await request(app)
+        .post("/recipes/recipe-1/ratings")
+        .set("Authorization", "Bearer valid_token")
+        .send({ score: "great" });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 404 when recipe not found", async () => {
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes")
+          return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      });
+
+      const res = await request(app)
+        .post("/recipes/nonexistent/ratings")
+        .set("Authorization", "Bearer valid_token")
+        .send({ score: 4 });
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 403 when rating own recipe", async () => {
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes")
+          return chainable({ data: { id: "recipe-1", creator_id: "profile-123" }, error: null });
+      });
+
+      const res = await request(app)
+        .post("/recipes/recipe-1/ratings")
+        .set("Authorization", "Bearer valid_token")
+        .send({ score: 5 });
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe("FORBIDDEN");
+    });
+
+    it("returns 200 on successful rating (happy path)", async () => {
+      const mockRating = {
+        id: "rating-1", recipe_id: "recipe-1", profile_id: "profile-123",
+        score: 4, created_at: "2024-01-01", updated_at: "2024-01-01",
+      };
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes")
+          return chainable({ data: { id: "recipe-1", creator_id: "profile-999" }, error: null });
+        if (table === "ratings")
+          return chainable({ data: mockRating, error: null });
+      });
+
+      const res = await request(app)
+        .post("/recipes/recipe-1/ratings")
+        .set("Authorization", "Bearer valid_token")
+        .send({ score: 4 });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.score).toBe(4);
+    });
+
+    it("allows upsert — same user rating twice returns 200", async () => {
+      const mockRating = {
+        id: "rating-1", recipe_id: "recipe-1", profile_id: "profile-123",
+        score: 5, created_at: "2024-01-01", updated_at: "2024-01-02",
+      };
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes")
+          return chainable({ data: { id: "recipe-1", creator_id: "profile-999" }, error: null });
+        if (table === "ratings")
+          return chainable({ data: mockRating, error: null });
+      });
+
+      const res = await request(app)
+        .post("/recipes/recipe-1/ratings")
+        .set("Authorization", "Bearer valid_token")
+        .send({ score: 5 });
+      expect(res.status).toBe(200);
+      expect(res.body.data.score).toBe(5);
+    });
+
+    it("returns 500 on db error during upsert", async () => {
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes")
+          return chainable({ data: { id: "recipe-1", creator_id: "profile-999" }, error: null });
+        if (table === "ratings")
+          return chainable({ data: null, error: { message: "DB timeout" } });
+      });
+
+      const res = await request(app)
+        .post("/recipes/recipe-1/ratings")
+        .set("Authorization", "Bearer valid_token")
+        .send({ score: 3 });
+      expect(res.status).toBe(500);
+      expect(res.body.error.code).toBe("DB_ERROR");
+    });
+  });
+
+  // ─── GET /recipes/:id/ratings/me ───────────────────────────────────────────
+
+  describe("GET /recipes/:id/ratings/me", () => {
+    it("returns 401 when unauthenticated", async () => {
+      const res = await request(app).get("/recipes/recipe-1/ratings/me");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns existing rating when user has rated", async () => {
+      const mockRating = { id: "rating-1", score: 4, created_at: "2024-01-01", updated_at: "2024-01-01" };
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "ratings")
+          return chainable({ data: mockRating, error: null });
+      });
+
+      const res = await request(app)
+        .get("/recipes/recipe-1/ratings/me")
+        .set("Authorization", "Bearer valid_token");
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.score).toBe(4);
+    });
+
+    it("returns null when user has not rated yet", async () => {
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "ratings")
+          return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      });
+
+      const res = await request(app)
+        .get("/recipes/recipe-1/ratings/me")
+        .set("Authorization", "Bearer valid_token");
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeNull();
+    });
+
+    it("returns 500 on db error", async () => {
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "ratings")
+          return chainable({ data: null, error: { message: "DB timeout" } });
+      });
+
+      const res = await request(app)
+        .get("/recipes/recipe-1/ratings/me")
+        .set("Authorization", "Bearer valid_token");
+      expect(res.status).toBe(500);
+      expect(res.body.error.code).toBe("DB_ERROR");
+    });
+  });
+
+  // ─── DELETE /recipes/:id/ratings/me ────────────────────────────────────────
+
+  describe("DELETE /recipes/:id/ratings/me", () => {
+    it("returns 401 when unauthenticated", async () => {
+      const res = await request(app).delete("/recipes/recipe-1/ratings/me");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when rating does not exist", async () => {
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "ratings")
+          return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      });
+
+      const res = await request(app)
+        .delete("/recipes/recipe-1/ratings/me")
+        .set("Authorization", "Bearer valid_token");
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 204 on successful delete", async () => {
+      // First call (select to verify existence) succeeds, second call (delete) succeeds
+      let callCount = 0;
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "ratings") {
+          callCount++;
+          if (callCount === 1) return chainable({ data: { id: "rating-1" }, error: null });
+          return chainable({ data: null, error: null });
+        }
+      });
+
+      const res = await request(app)
+        .delete("/recipes/recipe-1/ratings/me")
+        .set("Authorization", "Bearer valid_token");
+      expect(res.status).toBe(204);
+    });
+
+    it("returns 500 on db error during delete", async () => {
+      let callCount = 0;
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "ratings") {
+          callCount++;
+          if (callCount === 1) return chainable({ data: { id: "rating-1" }, error: null });
+          return chainable({ data: null, error: { message: "DB timeout" } });
+        }
+      });
+
+      const res = await request(app)
+        .delete("/recipes/recipe-1/ratings/me")
+        .set("Authorization", "Bearer valid_token");
+      expect(res.status).toBe(500);
+      expect(res.body.error.code).toBe("DB_ERROR");
+    });
+  });
+});

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -478,6 +478,147 @@ router.post("/:id/publish", requireAuth, async (req, res): Promise<void> => {
   );
 });
 
+// ─── Rating Schema ────────────────────────────────────────────────────────────
+
+const ratingSchema = z.object({
+  score: z
+    .number({ message: "Score must be a number." })
+    .int({ message: "Score must be an integer." })
+    .min(1, { message: "Score must be at least 1." })
+    .max(5, { message: "Score must be at most 5." }),
+});
+
+// ─── POST /recipes/:id/ratings ────────────────────────────────────────────────
+
+/**
+ * Submit or update a star rating for a recipe.
+ * Upsert logic: one rating per user per recipe.
+ * Cannot rate your own recipe.
+ * DB trigger update_recipe_rating() recalculates average_rating + rating_count automatically.
+ */
+router.post(
+  "/:id/ratings",
+  requireAuth,
+  validate(ratingSchema),
+  async (req, res): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const recipeId = req.params["id"];
+    const { score } = req.body as z.infer<typeof ratingSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    // 1. Verify recipe exists and check ownership
+    const { data: recipe, error: fetchError } = await supabase
+      .from("recipes")
+      .select("id, creator_id")
+      .eq("id", recipeId)
+      .single();
+
+    if (fetchError) {
+      if (fetchError.code === "PGRST116") {
+        res.status(404).json(errorResponse("NOT_FOUND", "Recipe not found."));
+        return;
+      }
+      res.status(500).json(errorResponse("DB_ERROR", fetchError.message));
+      return;
+    }
+
+    // 2. Cannot rate your own recipe
+    if ((recipe as any).creator_id === user.profileId) {
+      res.status(403).json(errorResponse("FORBIDDEN", "You cannot rate your own recipe."));
+      return;
+    }
+
+    // 3. Upsert rating (updates existing if same user already rated)
+    const { data, error: upsertError } = await userClient
+      .from("ratings")
+      .upsert(
+        { recipe_id: recipeId, user_id: user.profileId, score },
+        { onConflict: "recipe_id,user_id" }
+      )
+      .select("id, recipe_id, user_id, score, created_at, updated_at")
+      .single();
+
+    if (upsertError) {
+      res.status(500).json(errorResponse("DB_ERROR", upsertError.message));
+      return;
+    }
+
+    res.status(200).json(successResponse(data));
+  }
+);
+
+// ─── GET /recipes/:id/ratings/me ─────────────────────────────────────────────
+
+/**
+ * Get the current user's rating for a recipe.
+ * Returns null (with 200) if the user hasn't rated yet.
+ */
+router.get("/:id/ratings/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+  const recipeId = req.params["id"];
+
+  const { data, error } = await supabase
+    .from("ratings")
+    .select("id, score, created_at, updated_at")
+    .eq("recipe_id", recipeId)
+    .eq("user_id", user.profileId)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      res.status(200).json(successResponse(null));
+      return;
+    }
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse(data));
+});
+
+// ─── DELETE /recipes/:id/ratings/me ──────────────────────────────────────────
+
+/**
+ * Delete the current user's rating for a recipe.
+ * DB trigger update_recipe_rating() recalculates average_rating + rating_count automatically.
+ */
+router.delete("/:id/ratings/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+  const recipeId = req.params["id"];
+  const userClient = createUserClient(user.accessToken);
+
+  // 1. Check if rating exists
+  const { error: fetchError } = await userClient
+    .from("ratings")
+    .select("id")
+    .eq("recipe_id", recipeId)
+    .eq("user_id", user.profileId)
+    .single();
+
+  if (fetchError) {
+    if (fetchError.code === "PGRST116") {
+      res.status(404).json(errorResponse("NOT_FOUND", "Rating not found."));
+      return;
+    }
+    res.status(500).json(errorResponse("DB_ERROR", fetchError.message));
+    return;
+  }
+
+  // 2. Delete it
+  const { error: deleteError } = await userClient
+    .from("ratings")
+    .delete()
+    .eq("recipe_id", recipeId)
+    .eq("user_id", user.profileId);
+
+  if (deleteError) {
+    res.status(500).json(errorResponse("DB_ERROR", deleteError.message));
+    return;
+  }
+
+  res.status(204).send();
+});
+
 // ─── POST /recipes/:id/media ──────────────────────────────────────────────────
 
 const attachMediaSchema = z.object({


### PR DESCRIPTION
## Summary

Implements the full recipe star rating feature with accompanying unit tests.

- Adds `POST /recipes/:id/ratings` — upsert logic (one rating per user per recipe),
  own-recipe guard returns 403, score validated 1–5
- Adds `GET /recipes/:id/ratings/me` — returns current user's rating or null if not rated
- Adds `DELETE /recipes/:id/ratings/me` — removes rating, returns 404 if not found
- Average rating and rating count are recalculated automatically via the
  existing `update_recipe_rating()` DB trigger on INSERT/UPDATE/DELETE

## Closes

Closes #175
Closes #241

## Test plan

- [ ] `npx jest recipes` passes all 38 tests
- [ ] `POST /recipes/:id/ratings` with valid score returns 200 and rating data
- [ ] Rating same recipe twice updates existing rating (upsert)
- [ ] Rating own recipe returns 403
- [ ] Unauthenticated request returns 401
- [ ] Invalid score (0, 6, string) returns 400
- [ ] Non-existent recipe returns 404
- [ ] `GET /recipes/:id/ratings/me` returns null when not yet rated
- [ ] `DELETE /recipes/:id/ratings/me` returns 204 on success, 404 if no rating
