### PR TITLE
Add ingredient-based recipe search endpoint

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,238 @@
+# Roots & Recipes — Backend API
+
+> **IMPORTANT:** Always update this file after adding or changing anything in the backend. CLAUDE.md must stay in sync with the actual codebase at all times.
+
+## Project Overview
+
+Backend API for **Roots & Recipes**, a cross-generational recipe and food heritage platform that preserves culinary traditions by collecting recipes, cooking techniques, and food stories from experienced home cooks and communities. Built as a university project (CMPE354 — bounswe2026group10).
+
+Wiki: https://github.com/bounswe/bounswe2026group10/wiki
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Runtime | Node.js 20 |
+| Framework | Express.js 5 |
+| Language | TypeScript (strict mode) |
+| Database | PostgreSQL (hosted on Supabase) |
+| DB Client | Supabase JS SDK (PostgREST) — no ORM |
+| Validation | Zod |
+| Auth | Supabase Auth (JWT) |
+| File Storage | Supabase Storage |
+| File Uploads | Multer |
+| Security | Helmet, CORS |
+| Testing | Jest + Supertest + ts-jest |
+| Containerization | Docker (multi-stage, node:20-alpine) |
+
+## Commands
+
+```bash
+npm run dev            # Start dev server (ts-node, port 3000)
+npm run build          # Compile TypeScript to dist/
+npm start              # Run compiled JS (production)
+npm test               # Run all tests (jest --runInBand)
+npm run test:coverage  # Tests with coverage report
+```
+
+## Project Structure
+
+```
+backend/
+├── src/
+│   ├── index.ts                 # Express app setup, middleware, route mounting
+│   ├── config/
+│   │   └── supabase.ts          # Supabase client (anon + user-scoped)
+│   ├── middleware/
+│   │   ├── auth.ts              # requireAuth, requireRole middleware
+│   │   └── validate.ts          # Zod-based request body validation
+│   ├── routes/
+│   │   ├── auth.ts              # Register, login, logout, refresh, me
+│   │   ├── recipes.ts           # Recipe CRUD, publish, ratings, media attach
+│   │   ├── media.ts             # File upload (images/videos)
+│   │   ├── discovery.ts         # Recipe discovery with filters
+│   │   ├── dish-genres.ts       # Cuisine genre listing
+│   │   └── dish-varieties.ts    # Dish variety listing, search, recipes
+│   ├── types/
+│   │   └── index.ts             # TypeScript interfaces (roles, auth, response)
+│   ├── utils/
+│   │   └── response.ts          # successResponse / errorResponse helpers
+│   └── __tests__/               # Jest test suite
+│       ├── auth.test.ts
+│       ├── middleware.test.ts
+│       ├── recipes.test.ts
+│       ├── discovery.test.ts
+│       ├── media.test.ts
+│       └── health.test.ts
+├── Dockerfile
+├── jest.config.js
+├── tsconfig.json
+└── package.json
+```
+
+## Database Schema
+
+Database is managed via Supabase (no migration files in repo). Key tables:
+
+### Core Tables
+
+- **profiles** — `id`, `user_id` (FK auth.users), `username` (unique), `role`
+- **recipes** — `id`, `creator_id` (FK profiles), `dish_variety_id` (FK), `title`, `story`, `video_url`, `serving_size`, `type` (community|cultural), `is_published`, `average_rating`, `rating_count`, `created_at`, `updated_at`
+- **recipe_ingredients** — `id`, `recipe_id` (FK), `ingredient_id` (FK), `quantity`, `unit`
+- **recipe_steps** — `id`, `recipe_id` (FK), `step_order`, `description`
+- **recipe_tools** — `id`, `recipe_id` (FK), `name`
+- **recipe_media** — `id`, `recipe_id` (FK), `url`, `type` (image|video), `created_at`
+- **ratings** — `id`, `recipe_id` (FK), `user_id` (FK profiles), `score` (1-5), `created_at`, `updated_at` — unique constraint on (recipe_id, user_id)
+
+### Reference Tables
+
+- **ingredients** — `id`, `name`
+- **allergens** — `id`, `name`
+- **ingredient_allergens** — `ingredient_id` (FK), `allergen_id` (FK)
+- **dish_genres** — `id`, `name`, `description`
+- **dish_varieties** — `id`, `name`, `description`, `genre_id` (FK dish_genres), `region`
+
+### Database Triggers
+
+- `update_recipe_rating()` — auto-recalculates `average_rating` and `rating_count` on the recipes table when ratings change
+
+## API Endpoints
+
+### Health & Meta
+- `GET /health` — Health check
+- `GET /meta/regions` — Supported regions list (Turkey, Greece, Italy, Mexico, India, Japan)
+
+### Auth (`/auth`)
+- `POST /auth/register` — Register (email, password, username, role)
+- `POST /auth/login` — Login (returns access_token, refresh_token)
+- `POST /auth/logout` — Logout (auth required)
+- `POST /auth/refresh` — Refresh access token
+- `GET /auth/me` — Current user info (auth required)
+
+### Recipes (`/recipes`)
+- `GET /recipes/:id` — Recipe detail (public if published, creator-only if draft)
+- `POST /recipes` — Create recipe (cook/expert only)
+- `PATCH /recipes/:id` — Update draft (creator only, cook/expert)
+- `POST /recipes/:id/publish` — Publish draft (validates completeness)
+- `POST /recipes/:id/ratings` — Rate recipe 1-5 (cannot self-rate, upsert)
+- `GET /recipes/:id/ratings/me` — Get own rating
+- `DELETE /recipes/:id/ratings/me` — Delete own rating
+- `POST /recipes/:id/media` — Attach media to recipe (creator only)
+- `GET /recipes/:id/media` — List recipe media
+- `DELETE /recipes/:id/media/:mediaId` — Remove media (creator only)
+
+### Dish Genres (`/dish-genres`)
+- `GET /dish-genres` — All genres with nested varieties
+
+### Dish Varieties (`/dish-varieties`)
+- `GET /dish-varieties` — List varieties (optional: genreId, search filters)
+- `GET /dish-varieties/:id` — Single variety with published recipes
+- `GET /dish-varieties/:id/recipes` — Variety recipes split into expertRecipe + communityRecipes
+
+### Discovery (`/discovery`)
+- `GET /discovery/recipes` — Filtered recipe discovery
+  - Query params: `region`, `genreId`, `varietyId`, `excludeAllergens` (comma-separated IDs), `page`, `limit`
+- `GET /discovery/recipes/by-ingredients` — Recipes fully makeable with provided ingredients
+  - Query params: `ingredientIds` (comma-separated IDs, required), `page`, `limit`
+  - Only returns recipes whose every ingredient is in the provided list; partial matches excluded
+
+### Media (`/media`)
+- `POST /media/upload` — Upload file (cook/expert only, multipart/form-data)
+  - Images: JPEG/PNG/WebP, max 10 MB
+  - Videos: MP4, max 100 MB
+
+## User Roles & Permissions
+
+| Role | Permissions |
+|------|------------|
+| `learner` | View recipes, rate, browse/discover |
+| `cook` | + Create **community** recipes, upload media |
+| `expert` | + Create **cultural** recipes (in addition to community) |
+
+## Authentication Flow
+
+1. Supabase Auth handles email/password authentication
+2. Login returns JWT `access_token` + `refresh_token`
+3. Clients send `Authorization: Bearer <token>` header
+4. `requireAuth` middleware validates token via Supabase, attaches `req.user`
+5. `requireRole(...roles)` middleware restricts by role
+6. Authenticated routes create a user-scoped Supabase client (respects RLS)
+
+## Key Patterns & Conventions
+
+### Response Envelope
+All endpoints return:
+```json
+{ "success": true,  "data": <T>,   "error": null }
+{ "success": false, "data": null,  "error": { "code": "ERROR_CODE", "message": "..." } }
+```
+Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/response.ts`.
+
+### Error Codes
+- `VALIDATION_ERROR` (400) — Zod validation failure
+- `UNAUTHORIZED` (401) — Missing/invalid token
+- `FORBIDDEN` (403) — Wrong role or not owner
+- `NOT_FOUND` (404) — Resource not found
+- `CONFLICT` (409) — Duplicate username/email, already published
+- `INCOMPLETE_RECIPE` (400) — Missing fields for publish
+
+### Validation
+- Zod schemas defined inline in route files
+- `validate(schema)` middleware for request body validation
+- Manual ownership checks (creator_id === user.profileId)
+
+### Database Queries
+- Supabase PostgREST chainable query builder (no raw SQL)
+- Nested relationship selection with dot notation (e.g., `recipe_ingredients(*, ingredients(*))`)
+- User-scoped client for write operations (RLS enforcement)
+- `.single()` for expected-one results, `.maybeSingle()` for optional
+
+### Testing
+- Supabase is fully mocked with `jest.mock()`
+- Chainable mock pattern simulates PostgREST query builder
+- Supertest for HTTP-level assertions
+- Tests run sequentially (`--runInBand`)
+
+### Naming Conventions
+- **Files:** kebab-case (`dish-varieties.ts`)
+- **Variables/functions:** camelCase
+- **Types/interfaces:** PascalCase (`AuthenticatedRequest`, `UserRole`)
+- **Error codes:** UPPER_SNAKE_CASE (`VALIDATION_ERROR`)
+- **Section comments:** Unicode box-drawing characters (`─`, `└`, `├`)
+
+### Git Commit Convention
+```
+feat/fix(domain): description (#issueNumber)
+```
+Example: `feat(ratings): add recipe star rating endpoints (#175, #241)`
+
+## Environment Variables
+
+Required in `.env`:
+```
+PORT=3000
+SUPABASE_URL=<supabase-project-url>
+SUPABASE_ANON_KEY=<supabase-anon-key>
+DATABASE_URL=<postgres-connection-string>
+DIRECT_URL=<postgres-direct-connection-string>
+```
+
+## Docker
+
+```bash
+docker build -t roots-recipes-backend .
+docker run -p 3000:3000 --env-file .env roots-recipes-backend
+```
+
+Multi-stage build: TypeScript compile in builder stage, production deps only in runtime stage.
+
+## Adding New Features — Checklist
+
+1. Create/update route file in `src/routes/`
+2. Define Zod validation schemas for request bodies
+3. Use `successResponse`/`errorResponse` for all responses
+4. Add `requireAuth`/`requireRole` middleware where needed
+5. Mount the router in `src/index.ts` if new
+6. Add tests in `src/__tests__/`
+7. Run `npm test` to verify
+8. **Update this CLAUDE.md file** to reflect the changes

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -64,7 +64,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1475,7 +1474,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2140,9 +2138,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2169,7 +2167,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3286,9 +3283,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3655,7 +3652,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4867,9 +4863,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4881,7 +4877,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -5751,9 +5746,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5897,7 +5892,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5991,7 +5985,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/__tests__/discovery.test.ts
+++ b/backend/src/__tests__/discovery.test.ts
@@ -494,3 +494,194 @@ describe("GET /discovery/recipes", () => {
     expect(res.body.error.code).toBe("DB_ERROR");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("GET /discovery/recipes/by-ingredients", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockRecipes = [
+    {
+      id: 1, title: "Simple Salad", type: "community",
+      average_rating: 4.2, rating_count: 10,
+      created_at: "2024-01-01", updated_at: "2024-01-01",
+      dish_variety: { id: 1, name: "Green Salad", dish_genre: { id: 1, name: "Salad" } },
+      profile: { id: "p1", username: "cook1" },
+    },
+  ];
+
+  it("returns recipes fully covered by provided ingredients", async () => {
+    // recipe_ingredients NOT in list → no excluded recipes
+    // recipe_ingredients IN list → recipe 1 is a candidate
+    // recipes query → returns recipe 1
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_ingredients") {
+        const call = (supabase.from as jest.Mock).mock.calls.filter(
+          (c: any[]) => c[0] === "recipe_ingredients"
+        ).length;
+        if (call === 1) {
+          // First call: NOT in ingredientIds → no rows (no missing ingredients)
+          return chainable({ data: [], error: null });
+        }
+        // Second call: IN ingredientIds → recipe 1 uses these ingredients
+        return chainable({ data: [{ recipe_id: 1 }], error: null });
+      }
+      if (table === "recipes") {
+        return chainable({ data: mockRecipes, error: null, count: 1 });
+      }
+    });
+
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=1,2,3");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(res.body.data.recipes[0].title).toBe("Simple Salad");
+    expect(res.body.data.pagination).toMatchObject({ page: 1, limit: 20, total: 1 });
+  });
+
+  it("excludes recipes with ingredients not in provided list", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_ingredients") {
+        const call = (supabase.from as jest.Mock).mock.calls.filter(
+          (c: any[]) => c[0] === "recipe_ingredients"
+        ).length;
+        if (call === 1) {
+          // Recipe 1 needs ingredient 5 which is NOT in the provided list
+          return chainable({ data: [{ recipe_id: 1 }], error: null });
+        }
+        // Recipe 1 also uses ingredients in the provided list
+        return chainable({ data: [{ recipe_id: 1 }], error: null });
+      }
+    });
+
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=1,2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(0);
+    expect(res.body.data.pagination.total).toBe(0);
+  });
+
+  it("returns 400 when ingredientIds is missing", async () => {
+    const res = await request(app).get("/discovery/recipes/by-ingredients");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when ingredientIds contains no valid numbers", async () => {
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=abc,xyz");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns empty when no recipes have ingredients matching the list", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_ingredients") {
+        return chainable({ data: [], error: null });
+      }
+    });
+
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=999");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(0);
+    expect(res.body.data.pagination.total).toBe(0);
+  });
+
+  it("respects pagination params", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_ingredients") {
+        const call = (supabase.from as jest.Mock).mock.calls.filter(
+          (c: any[]) => c[0] === "recipe_ingredients"
+        ).length;
+        if (call === 1) return chainable({ data: [], error: null });
+        return chainable({ data: [{ recipe_id: 1 }], error: null });
+      }
+      if (table === "recipes") {
+        return chainable({ data: mockRecipes, error: null, count: 50 });
+      }
+    });
+
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=1,2&page=2&limit=10");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pagination).toMatchObject({ page: 2, limit: 10, total: 50 });
+  });
+
+  it("returns 400 for invalid page param", async () => {
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=1&page=0");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 for limit exceeding 100", async () => {
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=1&limit=200");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 500 on database error in exclusion query", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_ingredients") {
+        return chainable({ data: null, error: { message: "DB timeout" } });
+      }
+    });
+
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=1,2");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("returns 500 on database error in recipe fetch", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_ingredients") {
+        const call = (supabase.from as jest.Mock).mock.calls.filter(
+          (c: any[]) => c[0] === "recipe_ingredients"
+        ).length;
+        if (call === 1) return chainable({ data: [], error: null });
+        return chainable({ data: [{ recipe_id: 1 }], error: null });
+      }
+      if (table === "recipes") {
+        return chainable({ data: null, error: { message: "DB timeout" }, count: null });
+      }
+    });
+
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=1,2");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("ignores negative and zero values in ingredientIds", async () => {
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=0,-1,-5");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("handles mixed valid and invalid ingredientIds gracefully", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_ingredients") {
+        const call = (supabase.from as jest.Mock).mock.calls.filter(
+          (c: any[]) => c[0] === "recipe_ingredients"
+        ).length;
+        if (call === 1) return chainable({ data: [], error: null });
+        return chainable({ data: [{ recipe_id: 1 }], error: null });
+      }
+      if (table === "recipes") {
+        return chainable({ data: mockRecipes, error: null, count: 1 });
+      }
+    });
+
+    const res = await request(app).get("/discovery/recipes/by-ingredients?ingredientIds=1,abc,2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.recipes).toHaveLength(1);
+  });
+});

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -166,4 +166,129 @@ router.get("/recipes", async (req, res) => {
   }
 );
 
+// ─── GET /discovery/recipes/by-ingredients ───────────────────────────────────
+// Returns published recipes whose ingredients are fully covered by the provided
+// ingredient list. Partial matches are excluded.
+//   ?ingredientIds=1,2,3   (comma-separated ingredient IDs, required)
+//   ?page=1&limit=20
+
+const byIngredientsQuerySchema = z.object({
+  ingredientIds: z.string().min(1, "ingredientIds is required"),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+router.get("/recipes/by-ingredients", async (req, res) => {
+    const parsed = byIngredientsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      const message = parsed.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ");
+      return res.status(400).json(errorResponse("VALIDATION_ERROR", message));
+    }
+
+    const { page, limit } = parsed.data;
+
+    // Parse and validate ingredient IDs
+    const ingredientIds = parsed.data.ingredientIds
+      .split(",")
+      .map(Number)
+      .filter((n) => Number.isInteger(n) && n > 0);
+
+    if (ingredientIds.length === 0) {
+      return res
+        .status(400)
+        .json(errorResponse("VALIDATION_ERROR", "ingredientIds must contain at least one valid positive integer"));
+    }
+
+    // ── Step 1: Find recipes that use ingredients NOT in the provided list ────
+    // These recipes cannot be fully made with the available ingredients.
+    const { data: excludedRows, error: excludeErr } = await supabase
+      .from("recipe_ingredients")
+      .select("recipe_id")
+      .not("ingredient_id", "in", `(${ingredientIds.join(",")})`);
+
+    if (excludeErr) {
+      return res
+        .status(500)
+        .json(errorResponse("DB_ERROR", excludeErr.message));
+    }
+
+    const excludedRecipeIds = [
+      ...new Set(excludedRows?.map((r) => r.recipe_id) ?? []),
+    ];
+
+    // ── Step 2: Find published recipes that have at least one ingredient ──────
+    // (recipes with no ingredients are excluded — they have no ingredient list to match)
+    const { data: recipesWithIngredients, error: riErr } = await supabase
+      .from("recipe_ingredients")
+      .select("recipe_id")
+      .in("ingredient_id", ingredientIds);
+
+    if (riErr) {
+      return res
+        .status(500)
+        .json(errorResponse("DB_ERROR", riErr.message));
+    }
+
+    const candidateRecipeIds = [
+      ...new Set(recipesWithIngredients?.map((r) => r.recipe_id) ?? []),
+    ];
+
+    // Keep only candidates that are NOT excluded
+    const eligibleRecipeIds = candidateRecipeIds.filter(
+      (id) => !excludedRecipeIds.includes(id)
+    );
+
+    if (eligibleRecipeIds.length === 0) {
+      return res.status(200).json(
+        successResponse({
+          recipes: [],
+          pagination: { page, limit, total: 0 },
+        })
+      );
+    }
+
+    // ── Step 3: Fetch full recipe data for eligible IDs ──────────────────────
+    let query = supabase
+      .from("recipes")
+      .select(
+        `id, title, type, average_rating, rating_count,
+         created_at, updated_at,
+         dish_variety:dish_varieties!recipes_dish_variety_id_fkey(
+           id, name, region,
+           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)
+         ),
+         profile:profiles!recipes_creator_id_fkey(id, username)`,
+        { count: "exact" }
+      )
+      .eq("is_published", true)
+      .in("id", eligibleRecipeIds);
+
+    // ── Step 4: Pagination ────────────────────────────────────────────────────
+    const from = (page - 1) * limit;
+    const to = from + limit - 1;
+    query = query.range(from, to).order("average_rating", { ascending: false });
+
+    const { data: recipes, error: recipesError, count } = await query;
+
+    if (recipesError) {
+      return res
+        .status(500)
+        .json(errorResponse("DB_ERROR", recipesError.message));
+    }
+
+    return res.status(200).json(
+      successResponse({
+        recipes,
+        pagination: {
+          page,
+          limit,
+          total: count ?? 0,
+        },
+      })
+    );
+  }
+);
+
 export default router;


### PR DESCRIPTION
This pull request introduces a new feature to the backend API: the ability to discover recipes that can be fully made with a provided list of ingredient IDs. It also adds comprehensive automated tests for this feature, updates documentation, and includes some minor dependency updates.

**Key changes:**

### Feature: Recipe Discovery by Ingredients

* Adds a new endpoint `GET /discovery/recipes/by-ingredients` that returns only recipes where all required ingredients are included in the provided `ingredientIds` query parameter. The endpoint supports pagination and returns appropriate error codes for invalid input or database errors.

### Testing

* Implements a complete Jest test suite for the new endpoint in `discovery.test.ts`, covering successful retrieval, exclusion logic, pagination, input validation (including mixed/invalid IDs), and error handling for database issues.

### Documentation

* Adds and details the new endpoint in `backend/CLAUDE.md`, updating the API documentation and checklist to ensure the documentation stays in sync with the codebase.