### PR TITLE
Backend/feat(units): add GET /units search endpoint

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -59,7 +59,8 @@ backend/
 │   │   ├── dish-genres.ts       # Cuisine genre listing
 │   │   ├── dish-varieties.ts    # Dish variety listing, search, recipes
 │   │   ├── parse.ts             # Free-text recipe parser endpoint
-│   │   └── ingredients.ts       # Ingredient search/autocomplete
+│   │   ├── ingredients.ts       # Ingredient search/autocomplete
+│   │   └── units.ts             # Unit search/autocomplete
 │   ├── types/
 │   │   └── index.ts             # TypeScript interfaces (roles, auth, response)
 │   ├── utils/
@@ -73,6 +74,7 @@ backend/
 │       ├── media.test.ts
 │       ├── parse.test.ts
 │       ├── ingredients.test.ts
+│       ├── units.test.ts
 │       └── health.test.ts
 ├── Dockerfile
 ├── jest.config.js
@@ -160,6 +162,11 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - `GET /ingredients` — List/search ingredients by partial name (case-insensitive)
   - Query params: `search` (optional — filters by partial name match when provided)
   - Without `search`, returns all ingredients; supports autocomplete use case
+
+### Units (`/units`)
+- `GET /units` — List/search units by partial name (case-insensitive)
+  - Query params: `search` (optional — filters by partial name match when provided)
+  - Returns distinct unit values from `recipe_ingredients`; without `search`, returns all known units; supports autocomplete use case
 
 ### Parse (`/parse`)
 - `POST /parse/recipe-text` — Parse free-text recipe into structured components (cook/expert only)

--- a/backend/src/__tests__/units.test.ts
+++ b/backend/src/__tests__/units.test.ts
@@ -1,0 +1,91 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: { from: mockFrom },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+const chainable = (resolved: { data: any; error: any }) => {
+  const mock: any = {};
+  const methods = ["select", "ilike", "order"];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
+  return mock;
+};
+
+describe("GET /units", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns matching units for a search query", async () => {
+    const mockUnits = [{ unit: "gram" }, { unit: "grains" }];
+
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockUnits, error: null })
+    );
+
+    const res = await request(app).get("/units?search=gr");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].unit).toBe("gram");
+  });
+
+  it("returns empty array when no units match", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: [], error: null })
+    );
+
+    const res = await request(app).get("/units?search=xyz");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it("returns all units when no search parameter is given", async () => {
+    const all = [{ unit: "cup" }, { unit: "gram" }];
+    const chain = chainable({ data: all, error: null });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/units");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(chain.ilike).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates units with the same value", async () => {
+    const mockUnits = [{ unit: "gram" }, { unit: "gram" }, { unit: "kg" }];
+
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockUnits, error: null })
+    );
+
+    const res = await request(app).get("/units");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+  });
+
+  it("returns 500 on database error", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: null, error: { message: "DB connection failed" } })
+    );
+
+    const res = await request(app).get("/units?search=gr");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import discoveryRouter from "./routes/discovery.js";
 import dietaryTagsRouter from "./routes/dietary-tags.js";
 import parseRouter from "./routes/parse.js";
 import ingredientsRouter from "./routes/ingredients.js";
+import unitsRouter from "./routes/units.js";
 
 const app = express();
 const PORT = process.env["PORT"] ?? 3000;
@@ -44,6 +45,7 @@ app.use("/discovery", discoveryRouter);
 app.use("/dietary-tags", dietaryTagsRouter);
 app.use("/parse", parseRouter);
 app.use("/ingredients", ingredientsRouter);
+app.use("/units", unitsRouter);
 
 // ─── 404 Handler ─────────────────────────────────────────────────────────────
 app.use((_req, res) => {

--- a/backend/src/routes/units.ts
+++ b/backend/src/routes/units.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+import { supabase } from "../config/supabase.js";
+import { successResponse, errorResponse } from "../utils/response.js";
+
+const router = Router();
+
+// ─── GET /units ───────────────────────────────────────────────────────────────
+// Search units by partial name match (case-insensitive).
+// Query params:
+//   search — partial unit name (optional)
+// Returns distinct unit values from recipe_ingredients.
+
+router.get("/", async (req, res) => {
+  const search = (req.query["search"] as string | undefined)?.trim();
+
+  let query = supabase.from("recipe_ingredients").select("unit");
+
+  if (search) {
+    query = query.ilike("unit", `%${search}%`);
+  }
+
+  const { data, error } = await query.order("unit");
+
+  if (error) {
+    return res.status(500).json(errorResponse("DB_ERROR", error.message));
+  }
+
+  const seen = new Set<string>();
+  const unique = (data ?? []).filter((row) => {
+    if (seen.has(row.unit)) return false;
+    seen.add(row.unit);
+    return true;
+  });
+
+  return res.status(200).json(successResponse(unique));
+});
+
+export default router;


### PR DESCRIPTION
This pull request adds a new `/units` API endpoint to support searching and autocompleting measurement units used in recipes. It introduces both the route implementation and a comprehensive test suite.

**API and Route Additions:**
* Added a new `GET /units` endpoint in `units.ts` to list or search for unique measurement units from the `recipe_ingredients` table, supporting partial name matches and deduplication.

**Testing:**
* Introduced a test file `units.test.ts` with comprehensive tests for the `/units` endpoint, covering search, deduplication, error handling, and full listing scenarios.

Closes #274
Closes #275