### PR TITLE
Backend/feat(ingredients): add POST /ingredients endpoint

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -160,6 +160,10 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - `GET /ingredients` — List/search ingredients by partial name (case-insensitive)
   - Query params: `search` (optional — filters by partial name match when provided)
   - Without `search`, returns all ingredients; supports autocomplete use case
+- `POST /ingredients` — Create a new ingredient (cook/expert only)
+  - Body: `{ name: string }`
+  - Returns 409 if ingredient with same name already exists (case-insensitive)
+  - Stores name lowercased
 
 ### Parse (`/parse`)
 - `POST /parse/recipe-text` — Parse free-text recipe into structured components (cook/expert only)

--- a/backend/src/routes/ingredients.ts
+++ b/backend/src/routes/ingredients.ts
@@ -1,6 +1,10 @@
 import { Router } from "express";
-import { supabase } from "../config/supabase.js";
+import { z } from "zod";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth, requireRole } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
 import { successResponse, errorResponse } from "../utils/response.js";
+import type { AuthenticatedRequest } from "../types/index.js";
 
 const router = Router();
 
@@ -27,5 +31,51 @@ router.get("/", async (req, res) => {
 
   return res.status(200).json(successResponse(data));
 });
+
+// ─── POST /ingredients ──────────────────────────────────────────────────────
+
+const createIngredientSchema = z.object({
+  name: z.string({ message: "Name is required." }).trim().min(1, { message: "Name cannot be empty." }),
+});
+
+/**
+ * Create a new ingredient.
+ * Restricted to cook and expert roles.
+ * Returns 409 if an ingredient with the same name already exists (case-insensitive).
+ */
+router.post(
+  "/",
+  requireAuth,
+  requireRole("cook", "expert"),
+  validate(createIngredientSchema),
+  async (req, res) => {
+    const user = (req as AuthenticatedRequest).user;
+    const { name } = req.body as z.infer<typeof createIngredientSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    // Check for duplicate (case-insensitive)
+    const { data: existing } = await supabase
+      .from("ingredients")
+      .select("id")
+      .ilike("name", name)
+      .maybeSingle();
+
+    if (existing) {
+      return res.status(409).json(errorResponse("CONFLICT", "An ingredient with this name already exists."));
+    }
+
+    const { data, error } = await userClient
+      .from("ingredients")
+      .insert({ name: name.toLowerCase() })
+      .select("id, name")
+      .single();
+
+    if (error) {
+      return res.status(500).json(errorResponse("DB_ERROR", error.message));
+    }
+
+    return res.status(201).json(successResponse(data));
+  }
+);
 
 export default router;


### PR DESCRIPTION
This pull request introduces a new API endpoint to allow users with the "cook" or "expert" role to create ingredients, with validation and duplicate checking. The implementation includes input validation, authentication, and proper error handling. The most important changes are:

**API Additions:**

* Added `POST /ingredients` endpoint to create a new ingredient, restricted to users with the "cook" or "expert" role. The endpoint validates input, checks for duplicates (case-insensitive), and stores ingredient names in lowercase. Returns a 409 error if an ingredient with the same name exists.

closes  #278.