### PR TITLE
Add unit standardization endpoint and resolve related issues

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -166,6 +166,11 @@ Database is managed via Supabase (no migration files in repo). Key tables:
   - Body: `{ text: string }` (10–5000 chars)
   - Returns structured `{ title, ingredients[], steps[], tools[] }` without storing anything
   - Uses Gemini 2.5 Flash AI for text parsing
+- `POST /parse/standardize-units` — Convert informal/colloquial ingredient units and step descriptions to standard forms (cook/expert only)
+  - Body: `{ ingredients: [{ name, quantity, unit }], steps?: [{ stepOrder, description }], region?: string }`
+  - Returns `{ ingredients: [{ name, originalQuantity, originalUnit, standardQuantity, standardUnit }], steps: [{ stepOrder, originalDescription, standardDescription }] }`
+  - Region-aware: uses region hint (e.g. "Turkey") to resolve locale-specific units (çay bardağı → 100 ml) and expressions (kulak memesi kıvamı → clear description)
+  - Uses Gemini 2.5 Flash AI for conversion
 
 ## User Roles & Permissions
 
@@ -202,6 +207,7 @@ Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/r
 - `CONFLICT` (409) — Duplicate username/email, already published
 - `INCOMPLETE_RECIPE` (400) — Missing fields for publish
 - `PARSE_FAILED` (500) — AI parsing of recipe text failed
+- `STANDARDIZATION_FAILED` (500) — AI unit standardization failed
 
 ### Validation
 - Zod schemas defined inline in route files

--- a/backend/src/__tests__/parse.test.ts
+++ b/backend/src/__tests__/parse.test.ts
@@ -20,9 +20,10 @@ jest.mock("../config/supabase.js", () => {
 
 jest.mock("../services/recipe-parser.js", () => ({
   parseRecipeText: jest.fn(),
+  standardizeUnits: jest.fn(),
 }));
 
-import { parseRecipeText } from "../services/recipe-parser.js";
+import { parseRecipeText, standardizeUnits } from "../services/recipe-parser.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -178,5 +179,157 @@ describe("POST /parse/recipe-text", () => {
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe("PARSE_FAILED");
     expect(res.body.error.message).toContain("Failed to parse");
+  });
+});
+
+// ─── POST /parse/standardize-units ──────────────────────────────────────────
+
+const standardizePayload = {
+  ingredients: [
+    { name: "flour", quantity: 1, unit: "tea glass" },
+    { name: "sugar", quantity: 1, unit: "pinch" },
+  ],
+  steps: [
+    { stepOrder: 1, description: "Hamuru kulak memesi kıvamına getirin." },
+    { stepOrder: 2, description: "Göz kararı tuz ekleyin." },
+  ],
+  region: "Turkey",
+};
+
+const mockStandardizedResult = {
+  ingredients: [
+    {
+      name: "flour",
+      originalQuantity: 1,
+      originalUnit: "tea glass",
+      standardQuantity: 100,
+      standardUnit: "ml",
+    },
+    {
+      name: "sugar",
+      originalQuantity: 1,
+      originalUnit: "pinch",
+      standardQuantity: 1,
+      standardUnit: "g",
+    },
+  ],
+  steps: [
+    {
+      stepOrder: 1,
+      originalDescription: "Hamuru kulak memesi kıvamına getirin.",
+      standardDescription: "Knead the dough until it is soft and smooth, similar to the texture of an earlobe (not sticky, slightly firm).",
+    },
+    {
+      stepOrder: 2,
+      originalDescription: "Göz kararı tuz ekleyin.",
+      standardDescription: "Add salt approximately to your preference.",
+    },
+  ],
+};
+
+describe("POST /parse/standardize-units", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 if not authenticated", async () => {
+    const res = await request(app)
+      .post("/parse/standardize-units")
+      .send(standardizePayload);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 if user is a learner", async () => {
+    setupAuthMock("learner");
+
+    const res = await request(app)
+      .post("/parse/standardize-units")
+      .set("Authorization", "Bearer valid_token")
+      .send(standardizePayload);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 if ingredients array is empty", async () => {
+    setupAuthMock("cook");
+
+    const res = await request(app)
+      .post("/parse/standardize-units")
+      .set("Authorization", "Bearer valid_token")
+      .send({ ingredients: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 if ingredients is missing", async () => {
+    setupAuthMock("cook");
+
+    const res = await request(app)
+      .post("/parse/standardize-units")
+      .set("Authorization", "Bearer valid_token")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 200 with standardized ingredients and steps", async () => {
+    setupAuthMock("cook");
+    (standardizeUnits as jest.Mock).mockResolvedValue(mockStandardizedResult);
+
+    const res = await request(app)
+      .post("/parse/standardize-units")
+      .set("Authorization", "Bearer valid_token")
+      .send(standardizePayload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.ingredients).toHaveLength(2);
+    expect(res.body.data.ingredients[0].originalUnit).toBe("tea glass");
+    expect(res.body.data.ingredients[0].standardQuantity).toBe(100);
+    expect(res.body.data.ingredients[0].standardUnit).toBe("ml");
+    expect(res.body.data.steps).toHaveLength(2);
+    expect(res.body.data.steps[0].originalDescription).toContain("kulak memesi");
+    expect(res.body.data.steps[0].standardDescription).toContain("earlobe");
+    expect(standardizeUnits).toHaveBeenCalledWith(
+      standardizePayload.ingredients,
+      standardizePayload.steps,
+      "Turkey"
+    );
+  });
+
+  it("works without steps and region", async () => {
+    setupAuthMock("expert");
+    (standardizeUnits as jest.Mock).mockResolvedValue({
+      ingredients: mockStandardizedResult.ingredients,
+      steps: [],
+    });
+
+    const res = await request(app)
+      .post("/parse/standardize-units")
+      .set("Authorization", "Bearer valid_token")
+      .send({ ingredients: standardizePayload.ingredients });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients).toHaveLength(2);
+    expect(res.body.data.steps).toHaveLength(0);
+    expect(standardizeUnits).toHaveBeenCalledWith(
+      standardizePayload.ingredients,
+      undefined,
+      undefined
+    );
+  });
+
+  it("returns 500 if standardization service fails", async () => {
+    setupAuthMock("cook");
+    (standardizeUnits as jest.Mock).mockRejectedValue(new Error("Gemini timeout"));
+
+    const res = await request(app)
+      .post("/parse/standardize-units")
+      .set("Authorization", "Bearer valid_token")
+      .send(standardizePayload);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("STANDARDIZATION_FAILED");
   });
 });

--- a/backend/src/routes/parse.ts
+++ b/backend/src/routes/parse.ts
@@ -4,7 +4,7 @@ import { requireAuth, requireRole } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import type { AuthenticatedRequest } from "../types/index.js";
 import { errorResponse, successResponse } from "../utils/response.js";
-import { parseRecipeText } from "../services/recipe-parser.js";
+import { parseRecipeText, standardizeUnits } from "../services/recipe-parser.js";
 
 const router = Router();
 
@@ -49,6 +49,66 @@ router.post(
       res
         .status(500)
         .json(errorResponse("PARSE_FAILED", "Failed to parse recipe text. Please try again."));
+    }
+  }
+);
+
+// ─── Zod Schema — Standardize Units ─────────────────────────────────────────
+
+const standardizeUnitsSchema = z.object({
+  ingredients: z
+    .array(
+      z.object({
+        name: z.string().min(1),
+        quantity: z.number().positive(),
+        unit: z.string().min(1),
+      })
+    )
+    .min(1, { message: "At least one ingredient is required." })
+    .max(50, { message: "Maximum 50 ingredients allowed." }),
+  steps: z
+    .array(
+      z.object({
+        stepOrder: z.number().int().positive(),
+        description: z.string().min(1),
+      })
+    )
+    .max(50)
+    .optional(),
+  region: z.string().optional(),
+});
+
+// ─── POST /parse/standardize-units ──────────────────────────────────────────
+
+/**
+ * Convert informal/colloquial ingredient units and step descriptions
+ * to standard measurements and clear instructions.
+ * Accepts structured ingredients and optional steps (from parsing or manual entry).
+ *
+ * Auth required: Yes (cook or expert).
+ */
+router.post(
+  "/standardize-units",
+  requireAuth,
+  requireRole("cook", "expert"),
+  validate(standardizeUnitsSchema),
+  async (req, res: Response): Promise<void> => {
+    const { ingredients, steps, region } = req.body as z.infer<typeof standardizeUnitsSchema>;
+
+    try {
+      const standardized = await standardizeUnits(ingredients, steps, region);
+
+      res.status(200).json(successResponse(standardized));
+    } catch (err: any) {
+      console.error("Standardization error:", err);
+      res
+        .status(500)
+        .json(
+          errorResponse(
+            "STANDARDIZATION_FAILED",
+            "Failed to standardize recipe. Please try again."
+          )
+        );
     }
   }
 );

--- a/backend/src/services/recipe-parser.ts
+++ b/backend/src/services/recipe-parser.ts
@@ -24,6 +24,25 @@ export interface ParsedRecipe {
   tools: ParsedTool[];
 }
 
+export interface StandardizedIngredient {
+  name: string;
+  originalQuantity: number;
+  originalUnit: string;
+  standardQuantity: number;
+  standardUnit: string;
+}
+
+export interface StandardizedStep {
+  stepOrder: number;
+  originalDescription: string;
+  standardDescription: string;
+}
+
+export interface StandardizeResult {
+  ingredients: StandardizedIngredient[];
+  steps: StandardizedStep[];
+}
+
 // ─── Prompt ───────────────────────────────────────────────────────────────────
 
 const SYSTEM_PROMPT = `You are a recipe parsing assistant. Your job is to extract structured recipe data from free-text recipe narratives.
@@ -53,6 +72,64 @@ Rules:
 - Each step should be a single, actionable instruction.
 - The title should be concise and descriptive.
 - Return ONLY the JSON object, nothing else.`;
+
+const UNIT_STANDARDIZATION_PROMPT = `You are a culinary standardization assistant. Your job is to:
+1. Convert informal/colloquial ingredient measurements into standard units.
+2. Rewrite informal/colloquial step descriptions into clear, universally understood instructions.
+
+Given JSON arrays of ingredients and steps, plus an optional region hint, standardize both. Return ONLY valid JSON (no markdown fences, no commentary):
+
+{
+  "ingredients": [
+    {
+      "name": "ingredient name",
+      "originalQuantity": <original number>,
+      "originalUnit": "original unit as provided",
+      "standardQuantity": <converted number>,
+      "standardUnit": "standard unit"
+    }
+  ],
+  "steps": [
+    {
+      "stepOrder": <number>,
+      "originalDescription": "original step text",
+      "standardDescription": "rewritten step with clear, standard terms"
+    }
+  ]
+}
+
+Standard units to use for ingredients (pick the most appropriate):
+- Weight: "g", "kg"
+- Volume: "ml", "L"
+- Count: "piece", "slice", "clove", "sprig"
+- Spoons: "tsp" (5 ml), "tbsp" (15 ml)
+
+Ingredient rules:
+- Convert ALL informal/colloquial units to standard ones. Examples:
+  - "a pinch" → 1 g or 0.5 g depending on ingredient
+  - "a handful" → approximate grams for that ingredient
+  - "1 tea glass" (Turkish "çay bardağı") → 100 ml
+  - "1 water glass" (Turkish "su bardağı") → 200 ml
+  - "1 cup" → 240 ml
+  - "1 dash" → 0.5 ml
+  - "to taste" → keep as "to taste" (cannot be standardized)
+- If the unit is ALREADY standard (g, kg, ml, L, tsp, tbsp, piece), keep it as-is.
+- Use the region hint to resolve ambiguous terms (e.g., "cup" differs between US/UK/metric).
+- Be accurate — consider the ingredient's density when converting volume to weight or vice versa.
+- Round standardQuantity to at most 1 decimal place.
+
+Step rules:
+- Replace colloquial/traditional cooking expressions with clear, standard descriptions. Examples:
+  - "kulak memesi kıvamı" (Turkish: earlobe consistency) → "knead until the dough is soft and smooth, similar to the texture of an earlobe (not sticky, slightly firm)"
+  - "göz kararı ekleyin" (Turkish: add by eye) → "add approximately to your preference"
+  - "parmak testi yapın" (Turkish: do the finger test) → "press the surface lightly with your finger; if it springs back, it is ready"
+  - "ağda kıvamına gelene kadar" (Turkish: until it reaches waxing consistency) → "cook until the mixture thickens and forms a thick, sticky syrup that stretches between fingers"
+  - "altın rengi olana kadar" → "cook until golden brown"
+- Keep the meaning and intent of the original step — just make it universally understandable.
+- If a step is already clear and standard, keep it as-is in standardDescription.
+- The standardDescription should be in the same language as the original unless the original is in a non-English language, in which case translate to English.
+
+Return ONLY the JSON object, nothing else.`;
 
 // ─── Parser ───────────────────────────────────────────────────────────────────
 
@@ -123,5 +200,83 @@ export async function parseRecipeText(freeText: string): Promise<ParsedRecipe> {
     ingredients,
     steps,
     tools,
+  };
+}
+
+// ─── Standardizer ───────────────────────────────────────────────────────────
+
+/**
+ * Converts informal/colloquial ingredient units and step descriptions
+ * to standard measurements and clear instructions using Gemini AI,
+ * with optional region awareness.
+ *
+ * @param ingredients - Array of ingredients with name, quantity, unit.
+ * @param steps - Optional array of steps with stepOrder and description.
+ * @param region - Optional region hint (e.g. "Turkey", "Mexico") for locale-aware conversion.
+ * @returns Ingredients and steps with both original and standardized values.
+ */
+export async function standardizeUnits(
+  ingredients: ParsedIngredient[],
+  steps?: ParsedStep[],
+  region?: string
+): Promise<StandardizeResult> {
+  const model = genAI.getGenerativeModel({ model: GEMINI_MODEL });
+
+  const parts: string[] = [];
+  if (region) parts.push(`Region: ${region}`);
+  parts.push(`Ingredients:\n${JSON.stringify(ingredients)}`);
+  if (steps && steps.length > 0) {
+    parts.push(`Steps:\n${JSON.stringify(steps)}`);
+  }
+
+  const result = await model.generateContent({
+    contents: [
+      {
+        role: "user",
+        parts: [
+          { text: UNIT_STANDARDIZATION_PROMPT },
+          { text: `\n\n${parts.join("\n\n")}` },
+        ],
+      },
+    ],
+    generationConfig: {
+      temperature: 0.1,
+      maxOutputTokens: 16384,
+      responseMimeType: "application/json",
+    },
+  });
+
+  const response = result.response;
+  const text = response.text();
+
+  const cleaned = text
+    .replace(/```json\s*/gi, "")
+    .replace(/```\s*/g, "")
+    .trim();
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse AI response as JSON: ${cleaned.slice(0, 200)}`);
+  }
+
+  const standardizedIngredients: StandardizedIngredient[] = (parsed.ingredients ?? []).map((i: any) => ({
+    name: String(i.name ?? "unknown").toLowerCase(),
+    originalQuantity: Number(i.originalQuantity) || 1,
+    originalUnit: String(i.originalUnit ?? "piece"),
+    standardQuantity: Number(i.standardQuantity) || 1,
+    standardUnit: String(i.standardUnit ?? "piece"),
+  }));
+
+  const standardizedSteps: StandardizedStep[] = (parsed.steps ?? []).map((s: any, idx: number) => ({
+    stepOrder: Number(s.stepOrder) || idx + 1,
+    originalDescription: String(s.originalDescription ?? ""),
+    standardDescription: String(s.standardDescription ?? s.originalDescription ?? ""),
+  }));
+
+  return {
+    ingredients: standardizedIngredients,
+    steps: standardizedSteps,
   };
 }


### PR DESCRIPTION
This pull request introduces a new feature for standardizing ingredient units and step descriptions in recipes, mainly targeting the conversion of informal or regional expressions into clear, standardized forms. The core addition is the `POST /parse/standardize-units` API endpoint, which leverages Gemini AI for region-aware standardization. The changes also include comprehensive validation, error handling, and a full suite of tests for the new endpoint.