### PR TITLE
[Backend/Task] Automated recipe translation on publish (#193)

### DIFF
--- a/backend/migrations/001_recipe_translations.sql
+++ b/backend/migrations/001_recipe_translations.sql
@@ -1,0 +1,33 @@
+-- Migration: Recipe Translation Tables
+-- Issue #193 — Automated Recipe Translation on Publish
+
+-- Stores translated title and story for a recipe in a given language.
+CREATE TABLE IF NOT EXISTS recipe_translations (
+  id            uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  recipe_id     uuid        NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+  language_code text        NOT NULL,
+  title         text        NOT NULL,
+  story         text,
+  created_at    timestamptz DEFAULT now(),
+  UNIQUE (recipe_id, language_code)
+);
+
+-- Stores translated description for a recipe step in a given language.
+CREATE TABLE IF NOT EXISTS recipe_step_translations (
+  id            uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  step_id       int4        NOT NULL REFERENCES recipe_steps(id) ON DELETE CASCADE,
+  language_code text        NOT NULL,
+  description   text        NOT NULL,
+  created_at    timestamptz DEFAULT now(),
+  UNIQUE (step_id, language_code)
+);
+
+-- Stores translated unit for a recipe ingredient in a given language.
+CREATE TABLE IF NOT EXISTS recipe_ingredient_translations (
+  id                    uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  recipe_ingredient_id  int4        NOT NULL REFERENCES recipe_ingredients(id) ON DELETE CASCADE,
+  language_code         text        NOT NULL,
+  unit                  text        NOT NULL,
+  created_at            timestamptz DEFAULT now(),
+  UNIQUE (recipe_ingredient_id, language_code)
+);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.100.1",
         "cors": "^2.8.6",
+        "deepl-node": "^1.25.0",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "helmet": "^8.1.0",
@@ -64,7 +65,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1475,7 +1475,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1887,6 +1886,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1993,8 +2001,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -2169,7 +2187,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2473,7 +2490,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2639,6 +2655,60 @@
         }
       }
     },
+    "node_modules/deepl-node": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/deepl-node/-/deepl-node-1.25.0.tgz",
+      "integrity": "sha512-vOdPNZCegDS9F2GR8iwsEL+2w+Io9LBO0iECuZqWQMePZMNeNuODs6cRaiPUmVobPr6Dkt3HKiAAlZqFfl7vzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=12.0",
+        "adm-zip": "^0.5.16",
+        "axios": "^1.7.4",
+        "form-data": "^3.0.4",
+        "loglevel": ">=1.6.2",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/deepl-node/node_modules/form-data": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/deepl-node/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/deepl-node/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2653,7 +2723,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2818,7 +2887,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3040,6 +3108,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3061,7 +3149,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3078,7 +3165,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3088,7 +3174,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3333,7 +3418,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3655,7 +3739,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4333,6 +4416,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4881,7 +4977,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -5087,6 +5182,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pure-rand": {
@@ -5897,7 +6001,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5991,7 +6094,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6100,6 +6202,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.100.1",
     "cors": "^2.8.6",
+    "deepl-node": "^1.25.0",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "helmet": "^8.1.0",

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -5,6 +5,7 @@ import { requireAuth, requireRole } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import type { AuthenticatedRequest } from "../types/index.js";
 import { errorResponse, successResponse } from "../utils/response.js";
+import { translateRecipe } from "../services/translationService.js";
 
 const router = Router();
 
@@ -67,9 +68,13 @@ const updateRecipeSchema = recipeSchema.partial();
 /**
  * Get full recipe detail including ingredients, tools, steps, media, and story.
  * Published recipes are public. Unpublished recipes are only visible to their creator.
+ * Optional ?lang=en or ?lang=tr returns translated fields if a translation exists.
  */
 router.get("/:id", async (req: Request, res: Response): Promise<void> => {
-  const recipeId = req.params["id"] ?? "";
+  const recipeId = (req.params["id"] ?? "") as string;
+  const langParam = typeof req.query["lang"] === "string"
+    ? req.query["lang"].toUpperCase()
+    : null;
 
   const { data, error } = await supabase
     .from("recipes")
@@ -98,6 +103,50 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
     (a: any, b: any) => a.step_order - b.step_order
   );
 
+  // Resolve translated fields if ?lang= was requested
+  let resolvedTitle: string = data.title;
+  let resolvedStory: string | null = (data as any).story ?? null;
+  let stepTranslationMap: Record<number, string> = {};
+  let ingredientUnitMap: Record<number, string> = {};
+
+  if (langParam) {
+    const ingredientIds = (data.recipe_ingredients ?? []).map((ri: any) => ri.id);
+
+    const [recipeTransResult, stepTransResult, ingTransResult] = await Promise.all([
+      supabase
+        .from("recipe_translations")
+        .select("title, story")
+        .eq("recipe_id", recipeId)
+        .eq("language_code", langParam)
+        .maybeSingle(),
+      supabase
+        .from("recipe_step_translations")
+        .select("step_id, description")
+        .in("step_id", steps.map((s: any) => s.id))
+        .eq("language_code", langParam),
+      ingredientIds.length > 0
+        ? supabase
+            .from("recipe_ingredient_translations")
+            .select("recipe_ingredient_id, unit")
+            .in("recipe_ingredient_id", ingredientIds)
+            .eq("language_code", langParam)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
+
+    if (recipeTransResult.data) {
+      resolvedTitle = recipeTransResult.data.title;
+      resolvedStory = (recipeTransResult.data as any).story ?? resolvedStory;
+    }
+
+    for (const row of stepTransResult.data ?? []) {
+      stepTranslationMap[(row as any).step_id] = (row as any).description;
+    }
+
+    for (const row of ingTransResult.data ?? []) {
+      ingredientUnitMap[(row as any).recipe_ingredient_id] = (row as any).unit;
+    }
+  }
+
   res.status(200).json(
     successResponse({
       id: data.id,
@@ -106,8 +155,8 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       dishVarietyId: (data.dish_variety as any)?.id ?? null,
       dishVarietyName: (data.dish_variety as any)?.name ?? null,
       genreName: (data.dish_variety as any)?.dish_genre?.name ?? null,
-      title: data.title,
-      story: (data as any).story ?? null,
+      title: resolvedTitle,
+      story: resolvedStory,
       videoUrl: (data as any).video_url ?? null,
       servingSize: (data as any).serving_size ?? null,
       type: data.type,
@@ -119,7 +168,7 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
         ingredientId: ri.ingredient?.id ?? null,
         ingredientName: ri.ingredient?.name ?? null,
         quantity: ri.quantity,
-        unit: ri.unit,
+        unit: ingredientUnitMap[ri.id] ?? ri.unit,
         allergens: (ri.ingredient?.ingredient_allergens ?? [])
           .map((ia: any) => ia.allergen?.name)
           .filter(Boolean),
@@ -127,7 +176,7 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       steps: steps.map((s: any) => ({
         id: s.id,
         stepOrder: s.step_order,
-        description: s.description,
+        description: stepTranslationMap[s.id] ?? s.description,
       })),
       tools: (data.recipe_tools ?? []).map((t: any) => ({
         id: t.id,
@@ -140,6 +189,69 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       })),
       createdAt: data.created_at,
       updatedAt: data.updated_at,
+    })
+  );
+});
+
+// ─── GET /recipes ────────────────────────────────────────────────────────────
+
+const listRecipesQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+/**
+ * List published recipes with pagination.
+ * Public — no auth required.
+ */
+router.get("/", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listRecipesQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid query parameters.";
+    res.status(400).json(errorResponse("VALIDATION_ERROR", message));
+    return;
+  }
+
+  const { page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const { data, error, count } = await supabase
+    .from("recipes")
+    .select(
+      `id, title, type, average_rating, rating_count, created_at, updated_at,
+       creator:profiles!recipes_creator_id_fkey(id, username),
+       dish_variety:dish_varieties(id, name, dish_genre:dish_genres(id, name))`,
+      { count: "exact" }
+    )
+    .eq("is_published", true)
+    .order("average_rating", { ascending: false })
+    .range(from, to);
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  const recipes = (data ?? []).map((r: any) => ({
+    id: r.id,
+    title: r.title,
+    type: r.type,
+    averageRating: r.average_rating ?? null,
+    ratingCount: r.rating_count ?? 0,
+    creatorId: r.creator?.id ?? null,
+    creatorUsername: r.creator?.username ?? null,
+    dishVarietyId: r.dish_variety?.id ?? null,
+    dishVarietyName: r.dish_variety?.name ?? null,
+    genreName: r.dish_variety?.dish_genre?.name ?? null,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  }));
+
+  res.status(200).json(
+    successResponse({
+      recipes,
+      pagination: { page, limit, total: count ?? 0 },
     })
   );
 });
@@ -398,7 +510,7 @@ router.patch(
  */
 router.post("/:id/publish", requireAuth, async (req, res): Promise<void> => {
   const user = (req as AuthenticatedRequest).user;
-  const recipeId = req.params["id"];
+  const recipeId = (req.params["id"] ?? "") as string;
   const userClient = createUserClient(user.accessToken);
 
   // Fetch recipe ownership, current publish status, ingredients count, and steps count
@@ -469,6 +581,11 @@ router.post("/:id/publish", requireAuth, async (req, res): Promise<void> => {
     res.status(500).json(errorResponse("PUBLISH_FAILED", "Failed to publish recipe."));
     return;
   }
+
+  // Trigger translation non-blocking — publish succeeds even if this fails
+  translateRecipe(recipeId).catch((err) =>
+    console.error("[publish] Translation trigger error:", err)
+  );
 
   res.status(200).json(
     successResponse({

--- a/backend/src/services/translationService.ts
+++ b/backend/src/services/translationService.ts
@@ -1,0 +1,198 @@
+import { Translator, type TextResult } from "deepl-node";
+import { supabase } from "../config/supabase.js";
+
+// ─── Unit Translation Maps ────────────────────────────────────────────────────
+
+const EN_TO_TR: Record<string, string> = {
+  cup: "bardak",
+  tbsp: "yemek kaşığı",
+  tsp: "çay kaşığı",
+  g: "g",
+  kg: "kg",
+  mg: "mg",
+  ml: "ml",
+  l: "litre",
+  oz: "oz",
+  lb: "lb",
+  pinch: "tutam",
+  piece: "adet",
+  slice: "dilim",
+  clove: "diş",
+  bunch: "demet",
+  handful: "avuç",
+  drop: "damla",
+  stick: "çubuk",
+  sheet: "yaprak",
+  can: "kutu",
+  jar: "kavanoz",
+  package: "paket",
+  bag: "torba",
+  bottle: "şişe",
+  sprig: "dal",
+  stalk: "sap",
+  head: "baş",
+  pod: "bakla",
+  cube: "küp",
+  strip: "şerit",
+  fillet: "fileto",
+  portion: "porsiyon",
+  serving: "servis",
+  dash: "az",
+  splash: "çok az",
+};
+
+// Build TR→EN by inverting EN_TO_TR (skip identity entries like g, kg, etc.)
+const TR_TO_EN: Record<string, string> = Object.fromEntries(
+  Object.entries(EN_TO_TR)
+    .filter(([en, tr]) => en !== tr)
+    .map(([en, tr]) => [tr, en])
+);
+
+/**
+ * Translate a unit string using the hardcoded mapping.
+ * Returns the mapped value, or the original if no mapping exists.
+ */
+function translateUnit(unit: string, targetLang: "EN" | "TR"): string {
+  const map = targetLang === "TR" ? EN_TO_TR : TR_TO_EN;
+  return map[unit.toLowerCase()] ?? unit;
+}
+
+// ─── Main Translation Function ────────────────────────────────────────────────
+
+/**
+ * Translates a published recipe's title, story, step descriptions, and
+ * ingredient units to the opposite supported language (EN ↔ TR).
+ *
+ * - title / story / step descriptions: via DeepL
+ * - ingredient units: via hardcoded mapping (no DeepL call)
+ *
+ * Intended to be called fire-and-forget after a recipe is published.
+ * Errors are logged but never thrown to the caller.
+ */
+export async function translateRecipe(recipeId: string): Promise<void> {
+  const apiKey = process.env["DEEPL_API_KEY"];
+  if (!apiKey) {
+    console.error("[translation] DEEPL_API_KEY is not set — skipping translation.");
+    return;
+  }
+
+  const translator = new Translator(apiKey);
+
+  // 1. Fetch recipe fields, steps, and ingredients in parallel
+  const [recipeResult, stepsResult, ingredientsResult] = await Promise.all([
+    supabase.from("recipes").select("title, story").eq("id", recipeId).single(),
+    supabase
+      .from("recipe_steps")
+      .select("id, description")
+      .eq("recipe_id", recipeId)
+      .order("step_order", { ascending: true }),
+    supabase
+      .from("recipe_ingredients")
+      .select("id, unit")
+      .eq("recipe_id", recipeId),
+  ]);
+
+  if (recipeResult.error || !recipeResult.data) {
+    console.error(`[translation] Could not fetch recipe ${recipeId}:`, recipeResult.error);
+    return;
+  }
+
+  const recipe = recipeResult.data;
+  const steps = stepsResult.data ?? [];
+  const ingredients = ingredientsResult.data ?? [];
+
+  // 2. Detect source language by translating title to EN-US
+  let detectedSource: string;
+  let enTitle: string;
+
+  try {
+    const result = (await translator.translateText(recipe.title, null, "en-US")) as TextResult;
+    detectedSource = result.detectedSourceLang; // e.g. 'en', 'tr'
+    enTitle = result.text;
+  } catch (err) {
+    console.error(`[translation] DeepL detection failed for recipe ${recipeId}:`, err);
+    return;
+  }
+
+  const sourceIsEnglish = detectedSource === "en";
+  const langCode: "EN" | "TR" = sourceIsEnglish ? "TR" : "EN";
+
+  // 3. Translate title, story, step descriptions via DeepL
+  let translatedTitle: string;
+  let translatedStory: string | null = null;
+  let translatedStepDescriptions: string[] = [];
+
+  const extraTexts: string[] = [];
+  if (recipe.story) extraTexts.push(recipe.story as string);
+  for (const step of steps) extraTexts.push(step.description);
+
+  try {
+    if (sourceIsEnglish) {
+      const allTexts = [recipe.title, ...extraTexts];
+      const results = (await translator.translateText(allTexts, null, "tr")) as TextResult[];
+      translatedTitle = results[0]!.text;
+      let idx = 1;
+      if (recipe.story) translatedStory = results[idx++]!.text;
+      translatedStepDescriptions = results.slice(idx).map((r) => r.text);
+    } else {
+      translatedTitle = enTitle;
+      if (extraTexts.length > 0) {
+        const results = (await translator.translateText(extraTexts, null, "en-US")) as TextResult[];
+        let idx = 0;
+        if (recipe.story) translatedStory = results[idx++]!.text;
+        translatedStepDescriptions = results.slice(idx).map((r) => r.text);
+      }
+    }
+  } catch (err) {
+    console.error(`[translation] DeepL translation failed for recipe ${recipeId}:`, err);
+    return;
+  }
+
+  // 4. Upsert recipe translation
+  const { error: recipeTransError } = await supabase
+    .from("recipe_translations")
+    .upsert(
+      { recipe_id: recipeId, language_code: langCode, title: translatedTitle, story: translatedStory },
+      { onConflict: "recipe_id,language_code" }
+    );
+
+  if (recipeTransError) {
+    console.error(`[translation] Failed to store recipe translation (${langCode}):`, recipeTransError);
+  }
+
+  // 5. Upsert step translations
+  if (steps.length > 0) {
+    const stepRows = steps.map((step, i) => ({
+      step_id: step.id,
+      language_code: langCode,
+      description: translatedStepDescriptions[i] ?? step.description,
+    }));
+
+    const { error: stepsTransError } = await supabase
+      .from("recipe_step_translations")
+      .upsert(stepRows, { onConflict: "step_id,language_code" });
+
+    if (stepsTransError) {
+      console.error(`[translation] Failed to store step translations (${langCode}):`, stepsTransError);
+    }
+  }
+
+  // 6. Upsert ingredient unit translations via hardcoded mapping
+  if (ingredients.length > 0) {
+    const ingredientRows = ingredients.map((ing) => ({
+      recipe_ingredient_id: ing.id,
+      language_code: langCode,
+      unit: translateUnit(ing.unit, langCode),
+    }));
+
+    const { error: ingTransError } = await supabase
+      .from("recipe_ingredient_translations")
+      .upsert(ingredientRows, { onConflict: "recipe_ingredient_id,language_code" });
+
+    if (ingTransError) {
+      console.error(`[translation] Failed to store ingredient translations (${langCode}):`, ingTransError);
+    }
+  }
+
+  console.log(`[translation] Recipe ${recipeId} translated to ${langCode}.`);
+}


### PR DESCRIPTION
## What does this PR do?
Implements automated recipe translation triggered when a recipe is published.

- Added `POST /recipes/:id/publish` endpoint — sets `is_published = true` and triggers translation
- Added `translationService.ts` — translates title, story, and step descriptions using DeepL API (TR↔EN)
- Added hardcode unit mapping (TR↔EN) for ingredient units, stored in `recipe_ingredient_translations`
- Updated `GET /recipes/:id` — accepts `?lang=en` / `?lang=tr` and returns translated fields if available
- Added DB migration for `recipe_translations`, `recipe_step_translations`, `recipe_ingredient_translations` tables

## How to test
1. Create a recipe with Turkish or English content
2. Publish it via `POST /recipes/:id/publish`
3. Fetch with `GET /recipes/:id?lang=en` or `?lang=tr` — translated fields should be returned

## Related issue
Closes #193