### PR TITLE
Backend/feat(recipes): add serving size normalization endpoint 

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -136,6 +136,10 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - `POST /recipes/:id/media` — Attach media to recipe (creator only)
 - `GET /recipes/:id/media` — List recipe media
 - `DELETE /recipes/:id/media/:mediaId` — Remove media (creator only)
+- `GET /recipes/:id/scale` — Scale ingredient quantities to a desired serving size (#163)
+  - Query params: `servings` (required, integer 1–1000)
+  - Returns `{ recipeId, baseServings, requestedServings, ingredients[] }` with proportionally scaled quantities
+  - Returns 400 if `servings` param is invalid or recipe has no base serving size set
 
 ### Dish Genres (`/dish-genres`)
 - `GET /dish-genres` — All genres with nested varieties

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   collectCoverage: false,
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
+    "^deepl-node$": "<rootDir>/src/__mocks__/deepl-node.ts",
   },
   transform: {
     "^.+\\.tsx?$": [

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -66,6 +66,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1485,6 +1486,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2197,6 +2199,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3749,6 +3752,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4987,6 +4991,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -6011,6 +6016,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6104,6 +6110,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/__mocks__/deepl-node.ts
+++ b/backend/src/__mocks__/deepl-node.ts
@@ -1,0 +1,5 @@
+export class Translator {
+  translateText = jest.fn().mockResolvedValue({ text: "" });
+}
+
+export type TextResult = { text: string };

--- a/backend/src/__tests__/scale.test.ts
+++ b/backend/src/__tests__/scale.test.ts
@@ -1,0 +1,278 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: {
+      auth: { getUser: jest.fn() },
+      from: mockFrom,
+    },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+// ─── GET /recipes/:id/scale ───────────────────────────────────────────────────
+
+describe("GET /recipes/:id/scale", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockRecipeData = {
+    id: "recipe-uuid-1",
+    serving_size: 4,
+    recipe_ingredients: [
+      {
+        id: 1,
+        quantity: 500,
+        unit: "g",
+        ingredient: {
+          id: 2,
+          name: "Minced Meat",
+          ingredient_allergens: [],
+        },
+      },
+      {
+        id: 2,
+        quantity: 200,
+        unit: "ml",
+        ingredient: {
+          id: 3,
+          name: "Olive Oil",
+          ingredient_allergens: [],
+        },
+      },
+    ],
+  };
+
+  const setupMock = (data: any, error: any) => {
+    const mockSingle = jest.fn().mockResolvedValue({ data, error });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes") return { select: mockSelect };
+      return {};
+    });
+  };
+
+  // ─── Happy path ───────────────────────────────────────────────────────────
+
+  it("returns 200 with scaled quantities when doubling servings", async () => {
+    setupMock(mockRecipeData, null);
+
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=8");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.recipeId).toBe("recipe-uuid-1");
+    expect(res.body.data.baseServings).toBe(4);
+    expect(res.body.data.requestedServings).toBe(8);
+    expect(res.body.data.ingredients[0].quantity).toBe(1000);
+    expect(res.body.data.ingredients[1].quantity).toBe(400);
+  });
+
+  it("returns unchanged quantities when requested servings equal base servings", async () => {
+    setupMock(mockRecipeData, null);
+
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=4");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].quantity).toBe(500);
+    expect(res.body.data.ingredients[1].quantity).toBe(200);
+  });
+
+  it("returns halved quantities when halving servings", async () => {
+    setupMock(mockRecipeData, null);
+
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].quantity).toBe(250);
+    expect(res.body.data.ingredients[1].quantity).toBe(100);
+  });
+
+  it("returns quantity rounded to 2 decimal places", async () => {
+    setupMock(
+      {
+        ...mockRecipeData,
+        recipe_ingredients: [
+          {
+            id: 1,
+            quantity: 100,
+            unit: "g",
+            ingredient: { id: 2, name: "Flour", ingredient_allergens: [] },
+          },
+        ],
+      },
+      null
+    );
+
+    // 100 * 3 / 4 = 75 (exact)
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=3");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].quantity).toBe(75);
+  });
+
+  it("rounds non-integer scaled quantity to 2 decimal places", async () => {
+    setupMock(
+      {
+        ...mockRecipeData,
+        serving_size: 3,
+        recipe_ingredients: [
+          {
+            id: 1,
+            quantity: 100,
+            unit: "g",
+            ingredient: { id: 2, name: "Sugar", ingredient_allergens: [] },
+          },
+        ],
+      },
+      null
+    );
+
+    // 100 * 2 / 3 = 66.6666... → 66.67
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].quantity).toBe(66.67);
+  });
+
+  it("preserves ingredient metadata (id, ingredientId, ingredientName, unit, allergens)", async () => {
+    const dataWithAllergens = {
+      ...mockRecipeData,
+      recipe_ingredients: [
+        {
+          id: 5,
+          quantity: 200,
+          unit: "g",
+          ingredient: {
+            id: 7,
+            name: "Wheat",
+            ingredient_allergens: [{ allergen: { name: "gluten" } }],
+          },
+        },
+      ],
+    };
+    setupMock(dataWithAllergens, null);
+
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=8");
+
+    expect(res.status).toBe(200);
+    const ing = res.body.data.ingredients[0];
+    expect(ing.id).toBe(5);
+    expect(ing.ingredientId).toBe(7);
+    expect(ing.ingredientName).toBe("Wheat");
+    expect(ing.unit).toBe("g");
+    expect(ing.allergens).toEqual(["gluten"]);
+    expect(ing.quantity).toBe(400);
+  });
+
+  it("returns empty ingredients array when recipe has no ingredients", async () => {
+    setupMock({ ...mockRecipeData, recipe_ingredients: [] }, null);
+
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=8");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients).toHaveLength(0);
+  });
+
+  it("handles null ingredient (freetext ingredient with no linked ingredient row)", async () => {
+    setupMock(
+      {
+        ...mockRecipeData,
+        recipe_ingredients: [
+          {
+            id: 9,
+            quantity: 100,
+            unit: "g",
+            ingredient: null,
+          },
+        ],
+      },
+      null
+    );
+
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=8");
+
+    expect(res.status).toBe(200);
+    const ing = res.body.data.ingredients[0];
+    expect(ing.ingredientId).toBeNull();
+    expect(ing.ingredientName).toBeNull();
+    expect(ing.allergens).toEqual([]);
+    expect(ing.quantity).toBe(200);
+  });
+
+  // ─── Validation errors ────────────────────────────────────────────────────
+
+  it("returns 400 when servings param is missing", async () => {
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when servings is 0", async () => {
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=0");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when servings is negative", async () => {
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=-2");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when servings is a float", async () => {
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=2.5");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when servings is a non-numeric string", async () => {
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=abc");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when servings exceeds 1000", async () => {
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=1001");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 NO_SERVING_SIZE when recipe has no base serving size", async () => {
+    setupMock({ ...mockRecipeData, serving_size: null }, null);
+
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=4");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("NO_SERVING_SIZE");
+  });
+
+  // ─── Not found / DB errors ────────────────────────────────────────────────
+
+  it("returns 404 when recipe does not exist", async () => {
+    setupMock(null, { code: "PGRST116", message: "Not found" });
+
+    const res = await request(app).get("/recipes/nonexistent-uuid/scale?servings=4");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 500 on database error", async () => {
+    setupMock(null, { code: "500", message: "DB timeout" });
+
+    const res = await request(app).get("/recipes/recipe-uuid-1/scale?servings=4");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -67,6 +67,75 @@ const recipeSchema = z.object({
 
 const updateRecipeSchema = recipeSchema.partial();
 
+// ─── GET /recipes/:id/scale ──────────────────────────────────────────────────
+
+/**
+ * Scale recipe ingredient quantities to a desired serving size.
+ * Query params:
+ *   servings — desired number of servings (integer, 1–1000, required)
+ * Returns scaled ingredient quantities proportional to the recipe's base serving size.
+ * Formula: scaledQuantity = round((baseQuantity * desiredServings / baseServings) * 100) / 100
+ */
+router.get("/:id/scale", async (req: Request, res: Response): Promise<void> => {
+  const recipeId = (req.params["id"] ?? "") as string;
+
+  const servingsRaw = req.query["servings"];
+  const servings = Number(servingsRaw);
+
+  if (!servingsRaw || !Number.isInteger(servings) || servings < 1 || servings > 1000) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", "Query param 'servings' must be an integer between 1 and 1000."));
+    return;
+  }
+
+  const { data, error } = await supabase
+    .from("recipes")
+    .select(
+      `id, serving_size,
+       recipe_ingredients(id, quantity, unit, ingredient:ingredients(id, name, ingredient_allergens(allergen:allergens(name))))`
+    )
+    .eq("id", recipeId)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      res.status(404).json(errorResponse("NOT_FOUND", "Recipe not found."));
+      return;
+    }
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  const baseServings: number = (data as any).serving_size;
+
+  if (!baseServings || baseServings <= 0) {
+    res.status(400).json(errorResponse("NO_SERVING_SIZE", "Recipe does not have a base serving size set."));
+    return;
+  }
+
+  const scaledIngredients = ((data as any).recipe_ingredients ?? []).map((ri: any) => {
+    const scaled = Math.round((ri.quantity * servings / baseServings) * 100) / 100;
+    return {
+      id: ri.id,
+      ingredientId: ri.ingredient?.id ?? null,
+      ingredientName: ri.ingredient?.name ?? null,
+      quantity: scaled,
+      unit: ri.unit,
+      allergens: (ri.ingredient?.ingredient_allergens ?? [])
+        .map((ia: any) => ia.allergen?.name)
+        .filter(Boolean),
+    };
+  });
+
+  res.status(200).json(
+    successResponse({
+      recipeId: data.id,
+      baseServings,
+      requestedServings: servings,
+      ingredients: scaledIngredients,
+    })
+  );
+});
+
 // ─── GET /recipes/:id ────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
This pull request introduces a new API endpoint for scaling recipe ingredient quantities based on a desired serving size, along with comprehensive tests and supporting documentation updates. It also includes minor testing and configuration improvements.

**New Recipe Scaling Endpoint and Tests**

* Adds a new `GET /recipes/:id/scale` endpoint to the recipes API, allowing clients to request ingredient quantities scaled to a specified number of servings. The endpoint validates input, handles errors, and returns ingredient metadata with quantities rounded to two decimal places.

* Adds a full test suite for the scaling endpoint, covering happy paths, rounding, metadata preservation, validation errors, and database errors.

Closes #163
Closes #287 