### PR TITLE
Backend/fix: remove legacy region filter and /meta/regions endpoint

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -109,7 +109,7 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - **ingredient_substitutions** — `id`, `ingredient_id` (FK ingredients), `substitute_id` (FK ingredients), `source_amount` NUMERIC(10,3), `source_unit` TEXT, `sub_amount` NUMERIC(10,3), `sub_unit` TEXT, `confidence` NUMERIC(3,2), `description` TEXT — unique on (ingredient_id, substitute_id), no self-substitution
 - **dietary_tags** — `id`, `name` (unique), `category` (dietary|allergen)
 - **dish_genres** — `id`, `name`, `description`
-- **dish_varieties** — `id`, `name`, `description`, `genre_id` (FK dish_genres), `region`
+- **dish_varieties** — `id`, `name`, `description`, `genre_id` (FK dish_genres)
 
 ### Database Triggers
 
@@ -119,7 +119,6 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 
 ### Health & Meta
 - `GET /health` — Health check
-- `GET /meta/regions` — Supported regions list (Turkey, Greece, Italy, Mexico, India, Japan)
 
 ### Auth (`/auth`)
 - `POST /auth/register` — Register (email, password, username, role)
@@ -167,7 +166,7 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 
 ### Discovery (`/discovery`)
 - `GET /discovery/recipes` — Filtered recipe discovery
-  - Query params: `region`, `genreId`, `varietyId`, `excludeAllergens` (comma-separated IDs), `tagIds` (comma-separated dietary tag IDs — only recipes with ALL specified tags), `search` (case-insensitive partial match on recipe title), `country`, `city`, `district` (exact match on recipe location fields), `page`, `limit`
+  - Query params: `genreId`, `varietyId`, `excludeAllergens` (comma-separated IDs), `tagIds` (comma-separated dietary tag IDs — only recipes with ALL specified tags), `search` (case-insensitive partial match on recipe title), `country`, `city`, `district` (exact match on recipe location fields), `page`, `limit`
   - Response recipe objects include `country`, `city`, `district` fields (nullable)
 - `GET /discovery/recipes/by-ingredients` — Recipes fully makeable with provided ingredients
   - Query params: `ingredientIds` (comma-separated IDs, required), `page`, `limit`

--- a/backend/src/__tests__/discovery.test.ts
+++ b/backend/src/__tests__/discovery.test.ts
@@ -197,7 +197,7 @@ describe("GET /dish-varieties/:id", () => {
       dish_genre: { id: 1, name: "Kebap" },
     };
     const mockRecipes = [
-      { id: 10, title: "Classic Adana", type: "community", average_rating: 4.5, rating_count: 12, region: "Turkey", created_at: "2024-01-01", updated_at: "2024-01-01" },
+      { id: 10, title: "Classic Adana", type: "community", average_rating: 4.5, rating_count: 12, created_at: "2024-01-01", updated_at: "2024-01-01" },
     ];
 
     (supabase.from as jest.Mock).mockImplementation((table) => {
@@ -381,7 +381,7 @@ describe("GET /discovery/recipes", () => {
 
   const mockRecipes = [
     {
-      id: 1, title: "Adana Kebap", type: "community", region: "Turkey",
+      id: 1, title: "Adana Kebap", type: "community",
       average_rating: 4.8, rating_count: 20, created_at: "2024-01-01", updated_at: "2024-01-01",
       dish_variety: { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } },
       profile: { id: "p1", username: "cook1" },
@@ -399,17 +399,6 @@ describe("GET /discovery/recipes", () => {
     expect(res.body.success).toBe(true);
     expect(res.body.data.recipes).toHaveLength(1);
     expect(res.body.data.pagination).toMatchObject({ page: 1, limit: 20, total: 1 });
-  });
-
-  it("filters by region", async () => {
-    (supabase.from as jest.Mock).mockReturnValue(
-      chainable({ data: mockRecipes, error: null, count: 1 })
-    );
-
-    const res = await request(app).get("/discovery/recipes?region=Turkey");
-
-    expect(res.status).toBe(200);
-    expect(res.body.data.recipes[0].region).toBe("Turkey");
   });
 
   it("excludes recipes with specified allergens", async () => {
@@ -552,17 +541,6 @@ describe("GET /discovery/recipes", () => {
     expect(res.status).toBe(200);
     expect(res.body.data.recipes).toHaveLength(1);
     expect(res.body.data.recipes[0].title).toBe("Adana Kebap");
-  });
-
-  it("combines search with region filter", async () => {
-    (supabase.from as jest.Mock).mockReturnValue(
-      chainable({ data: mockRecipes, error: null, count: 1 })
-    );
-
-    const res = await request(app).get("/discovery/recipes?search=adana&region=Turkey");
-
-    expect(res.status).toBe(200);
-    expect(res.body.data.recipes).toHaveLength(1);
   });
 
   it("filters by country", async () => {

--- a/backend/src/__tests__/health.test.ts
+++ b/backend/src/__tests__/health.test.ts
@@ -9,11 +9,4 @@ describe("Health Check API", () => {
     expect(response.body).toHaveProperty("timestamp");
   });
 
-  it("should return regions from /meta/regions", async () => {
-    const response = await request(app).get("/meta/regions");
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(Array.isArray(response.body.data)).toBe(true);
-    expect(response.body.data).toContain("Turkey");
-  });
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,15 +28,6 @@ app.get("/health", (_req, res) => {
   res.status(200).json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
-// ─── Meta ─────────────────────────────────────────────────────────────────────
-app.get("/meta/regions", (_req, res) => {
-  res.status(200).json({
-    success: true,
-    data: ["Turkey", "Greece", "Italy", "Mexico", "India", "Japan"],
-    error: null,
-  });
-});
-
 // ─── API Routes ───────────────────────────────────────────────────────────────
 app.use("/auth", authRouter);
 app.use("/recipes", recipesRouter);

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -8,7 +8,6 @@ const router = Router();
 // ─── Zod Schema ───────────────────────────────────────────────────────────────
 
 const discoveryQuerySchema = z.object({
-  region: z.string().optional(),
   // Comma-separated allergen IDs to exclude (e.g. "1,2,3")
   excludeAllergens: z.string().optional(),
   // Comma-separated dietary tag IDs to require (e.g. "1,3" for Halal + Vegan)
@@ -27,7 +26,6 @@ const discoveryQuerySchema = z.object({
 
 // ─── GET /discovery/recipes ───────────────────────────────────────────────────
 // Returns published recipes with composable filters:
-//   ?region=Turkey
 //   ?excludeAllergens=1,2,3   (allergen IDs)
 //   ?genreId=1
 //   ?varietyId=1
@@ -42,7 +40,7 @@ router.get("/recipes", async (req, res) => {
         .join("; ");
       return res.status(400).json(errorResponse("VALIDATION_ERROR", message));
     }
-    const { region, excludeAllergens, tagIds, genreId, varietyId, search, country, city, district, page, limit } = parsed.data;
+    const { excludeAllergens, tagIds, genreId, varietyId, search, country, city, district, page, limit } = parsed.data;
 
     // ── Step 0: Resolve tag filter ───────────────────────────────────────────
     let tagFilteredRecipeIds: string[] | null = null;
@@ -177,7 +175,7 @@ router.get("/recipes", async (req, res) => {
          country, city, district,
          created_at, updated_at,
          dish_variety:dish_varieties!recipes_dish_variety_id_fkey(
-           id, name, region,
+           id, name,
            dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)
          ),
          profile:profiles!recipes_creator_id_fkey(id, username),
@@ -185,10 +183,6 @@ router.get("/recipes", async (req, res) => {
         { count: "exact" }
       )
       .eq("is_published", true);
-
-    if (region) {
-      query = query.eq("dish_varieties.region", region);
-    }
 
     if (search) {
       query = query.ilike("title", `%${search}%`);
@@ -338,9 +332,10 @@ router.get("/recipes/by-ingredients", async (req, res) => {
       .from("recipes")
       .select(
         `id, title, type, average_rating, rating_count,
+         country, city, district,
          created_at, updated_at,
          dish_variety:dish_varieties!recipes_dish_variety_id_fkey(
-           id, name, region,
+           id, name,
            dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)
          ),
          profile:profiles!recipes_creator_id_fkey(id, username),

--- a/backend/src/routes/dish-varieties.ts
+++ b/backend/src/routes/dish-varieties.ts
@@ -76,7 +76,7 @@ router.get("/:id", async (req, res) => {
 
   const { data: recipes, error: recipesError } = await supabase
     .from("recipes")
-    .select("id, title, type, average_rating, rating_count, created_at, updated_at")
+    .select("id, title, type, average_rating, rating_count, country, city, district, created_at, updated_at")
     .eq("dish_variety_id", id)
     .eq("is_published", true)
     .order("average_rating", { ascending: false });
@@ -119,7 +119,7 @@ router.get("/:id/recipes", async (req, res) => {
   const { data: recipes, error: recipesError } = await supabase
     .from("recipes")
     .select(
-      `id, title, type, average_rating, rating_count, created_at, updated_at,
+      `id, title, type, average_rating, rating_count, country, city, district, created_at, updated_at,
        creator:profiles!recipes_creator_id_fkey(id, username)`
     )
     .eq("dish_variety_id", id)


### PR DESCRIPTION
This pull request removes support for filtering and displaying recipes by "region" in the backend API and updates related documentation, code, and tests accordingly. The "region" field is also removed from the `dish_varieties` table, and the `/meta/regions` endpoint is deleted. Recipe location is now handled via `country`, `city`, and `district` fields.

**API and Data Model Changes:**

* Removed the `region` field from the `dish_varieties` table and from all related queries and API responses. The table and queries now use only `id`, `name`, `description`, and `genre_id` for `dish_varieties`. 

**API Filtering and Query Changes:**

* Removed support for filtering recipes by `region` in the `/discovery/recipes` endpoint, both in the API implementation and in the validation schema. Filtering by `country`, `city`, and `district` remains supported.


**Test Updates:**

* Removed or updated tests that referenced the `region` field or tested region-based filtering, ensuring all tests now use `country`, `city`, and `district` for location-based queries. 

**Recipe Location Handling:**

* Ensured that recipe objects in API responses consistently include `country`, `city`, and `district` fields (nullable), and updated queries for both dish variety and ingredient-based recipe discovery to include these fields. 

Closes #305