### PR TITLE
Add creatorId filter to GET /recipes for user-specific views

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -129,6 +129,9 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 
 ### Recipes (`/recipes`)
 - `GET /recipes/:id` — Recipe detail (public if published, creator-only if draft)
+- `GET /recipes` — List published recipes with pagination
+  - Query params: `creatorId` (optional UUID — filter by creator's profile ID to view a specific user's published recipes), `page`, `limit`
+  - Response recipe objects include `coverImageUrl` (first image from `recipe_media`, or `null`)
 - `POST /recipes` — Create recipe (cook/expert only, accepts `tagIds`, optional `country`, `city`, `district`)
 - `PATCH /recipes/:id` — Update draft (creator only, cook/expert, accepts `tagIds`, optional `country`, `city`, `district`)
 - `POST /recipes/:id/publish` — Publish draft (validates completeness)

--- a/backend/src/__tests__/recipes.test.ts
+++ b/backend/src/__tests__/recipes.test.ts
@@ -275,6 +275,119 @@ describe("GET /recipes/mine", () => {
   });
 });
 
+// ─── GET /recipes (list) ─────────────────────────────────────────────────────
+
+describe("GET /recipes", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const setupListMock = (data: any, error: any = null, count: number | null = null) => {
+    const chain: any = {};
+    chain.select = jest.fn().mockReturnValue(chain);
+    chain.eq = jest.fn().mockReturnValue(chain);
+    chain.order = jest.fn().mockReturnValue(chain);
+    chain.range = jest.fn().mockResolvedValue({ data, error, count });
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes") return chain;
+      return {};
+    });
+    return chain;
+  };
+
+  const mockRecipeList = [
+    {
+      id: "r1", title: "Adana Kebap", type: "community",
+      average_rating: 4.5, rating_count: 10,
+      created_at: "2024-01-01", updated_at: "2024-01-02",
+      creator: { id: "profile-1", username: "furkan" },
+      dish_variety: { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } },
+      recipe_media: [{ id: 1, url: "https://example.com/img1.jpg", type: "image" }],
+    },
+    {
+      id: "r2", title: "Mercimek Çorbası", type: "cultural",
+      average_rating: 4.0, rating_count: 5,
+      created_at: "2024-02-01", updated_at: "2024-02-02",
+      creator: { id: "profile-2", username: "ayse" },
+      dish_variety: { id: 2, name: "Mercimek", dish_genre: { id: 2, name: "Çorba" } },
+      recipe_media: [],
+    },
+  ];
+
+  it("returns published recipes with 200", async () => {
+    setupListMock(mockRecipeList, null, 2);
+    const res = await request(app).get("/recipes");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.recipes).toHaveLength(2);
+    expect(res.body.data.pagination).toMatchObject({ page: 1, limit: 20, total: 2 });
+  });
+
+  it("returns only recipes from a specific creator when creatorId is provided", async () => {
+    const chain = setupListMock([mockRecipeList[0]], null, 1);
+    const res = await request(app).get("/recipes?creatorId=a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d");
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(res.body.data.recipes[0].creatorId).toBe("profile-1");
+    // Verify eq was called with creator_id filter
+    expect(chain.eq).toHaveBeenCalledWith("creator_id", "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d");
+  });
+
+  it("returns empty array when creatorId has no published recipes", async () => {
+    setupListMock([], null, 0);
+    const res = await request(app).get("/recipes?creatorId=b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e");
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(0);
+    expect(res.body.data.pagination.total).toBe(0);
+  });
+
+  it("returns 400 for invalid creatorId format", async () => {
+    const res = await request(app).get("/recipes?creatorId=not-a-uuid");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("includes coverImageUrl from recipe_media", async () => {
+    setupListMock(mockRecipeList, null, 2);
+    const res = await request(app).get("/recipes");
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes[0].coverImageUrl).toBe("https://example.com/img1.jpg");
+    expect(res.body.data.recipes[1].coverImageUrl).toBeNull();
+  });
+
+  it("supports pagination query params", async () => {
+    const chain = setupListMock([], null, 0);
+    const res = await request(app).get("/recipes?page=2&limit=5");
+    expect(res.status).toBe(200);
+    // range should be called with (5, 9) for page=2, limit=5
+    expect(chain.range).toHaveBeenCalledWith(5, 9);
+  });
+
+  it("returns correct response shape", async () => {
+    setupListMock([mockRecipeList[0]], null, 1);
+    const res = await request(app).get("/recipes");
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes[0]).toMatchObject({
+      id: "r1",
+      title: "Adana Kebap",
+      type: "community",
+      averageRating: 4.5,
+      ratingCount: 10,
+      creatorId: "profile-1",
+      creatorUsername: "furkan",
+      dishVarietyId: 1,
+      dishVarietyName: "Adana Kebap",
+      genreName: "Kebap",
+      coverImageUrl: "https://example.com/img1.jpg",
+    });
+  });
+
+  it("returns 500 on database error", async () => {
+    setupListMock(null, { message: "DB timeout" });
+    const res = await request(app).get("/recipes");
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("Recipe Endpoints (Creation & Publishing)", () => {

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -336,12 +336,14 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
 // ─── GET /recipes ────────────────────────────────────────────────────────────
 
 const listRecipesQuerySchema = z.object({
+  creatorId: z.string().uuid().optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
 });
 
 /**
  * List published recipes with pagination.
+ * Optionally filter by creatorId to view a specific user's published recipes.
  * Public — no auth required.
  */
 router.get("/", async (req: Request, res: Response): Promise<void> => {
@@ -352,19 +354,26 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
     return;
   }
 
-  const { page, limit } = parsed.data;
+  const { creatorId, page, limit } = parsed.data;
   const from = (page - 1) * limit;
   const to = from + limit - 1;
 
-  const { data, error, count } = await supabase
+  let query = supabase
     .from("recipes")
     .select(
       `id, title, type, average_rating, rating_count, created_at, updated_at,
        creator:profiles!recipes_creator_id_fkey(id, username),
-       dish_variety:dish_varieties(id, name, dish_genre:dish_genres(id, name))`,
+       dish_variety:dish_varieties(id, name, dish_genre:dish_genres(id, name)),
+       recipe_media(id, url, type)`,
       { count: "exact" }
     )
-    .eq("is_published", true)
+    .eq("is_published", true);
+
+  if (creatorId) {
+    query = query.eq("creator_id", creatorId);
+  }
+
+  const { data, error, count } = await query
     .order("average_rating", { ascending: false })
     .range(from, to);
 
@@ -373,20 +382,24 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
     return;
   }
 
-  const recipes = (data ?? []).map((r: any) => ({
-    id: r.id,
-    title: r.title,
-    type: r.type,
-    averageRating: r.average_rating ?? null,
-    ratingCount: r.rating_count ?? 0,
-    creatorId: r.creator?.id ?? null,
-    creatorUsername: r.creator?.username ?? null,
-    dishVarietyId: r.dish_variety?.id ?? null,
-    dishVarietyName: r.dish_variety?.name ?? null,
-    genreName: r.dish_variety?.dish_genre?.name ?? null,
-    createdAt: r.created_at,
-    updatedAt: r.updated_at,
-  }));
+  const recipes = (data ?? []).map((r: any) => {
+    const firstImage = (r.recipe_media ?? []).find((m: any) => m.type === "image");
+    return {
+      id: r.id,
+      title: r.title,
+      type: r.type,
+      averageRating: r.average_rating ?? null,
+      ratingCount: r.rating_count ?? 0,
+      creatorId: r.creator?.id ?? null,
+      creatorUsername: r.creator?.username ?? null,
+      dishVarietyId: r.dish_variety?.id ?? null,
+      dishVarietyName: r.dish_variety?.name ?? null,
+      genreName: r.dish_variety?.dish_genre?.name ?? null,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+      coverImageUrl: firstImage?.url ?? null,
+    };
+  });
 
   res.status(200).json(
     successResponse({


### PR DESCRIPTION
This pull request adds a new public API endpoint for listing published recipes, with support for pagination, filtering by creator, and including a cover image URL. It also introduces comprehensive tests for this endpoint and updates the API documentation to reflect these changes.

**Testing:**

* Implemented thorough tests for the new `GET /recipes` endpoint, covering success cases, filtering, pagination, validation errors, response shape, and error handling.