### PR TITLE
[Frontend/Task] Split Vite env for API base URL (dev proxy vs production) and prod build script

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.env.development
+.env.production
+.DS_Store

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prod": "tsc -b && vite build && vite preview",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/frontend/src/lib/http-client.ts
+++ b/frontend/src/lib/http-client.ts
@@ -3,7 +3,8 @@ import { session } from '@/auth/session'
 import { refreshSession } from '@/lib/refresh-session'
 
 /**
- * Tek HTTP istemcisi. Geliştirmede `VITE_API_BASE_URL=/api` + Vite proxy ile backend’e yönlendirilir.
+ * Tek HTTP istemcisi. `npm run dev`: `.env.development` → `/api` + Vite proxy (localhost:3000).
+ * `npm run build` / `npm run prod`: `.env.production` → tam backend URL.
  * Bearer token, login/register/refresh hariç isteklere eklenir.
  * 401: refresh token ile yenile, isteği bir kez tekrarla; refresh başarısızsa çıkış + `/login`.
  */

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client", "vitest/globals"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -29,5 +29,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,6 @@
-/// <reference types="vitest/config" />
 import path from 'node:path'
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -14,7 +13,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true,
-        rewrite: (p) => p.replace(/^\/api/, ''),
+        rewrite: (p: string) => p.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
## What does this PR do?

- Splits API base URL by Vite mode: **development** uses `VITE_API_BASE_URL=/api` with the existing Vite proxy to `localhost:3000`; **production** builds read `VITE_API_BASE_URL` from `.env.production` (deployed backend).
- Adds **`npm run prod`**: `tsc -b && vite build && vite preview` for a full typecheck, production bundle, and local preview.
- Updates **`http-client`** comments to describe dev vs production behavior.
- Adjusts **TypeScript / Vitest** setup so `tsc -b` succeeds: test files excluded from `tsconfig.app.json`; `vite.config.ts` uses `defineConfig` from `vitest/config` (proxy `rewrite` param typed).
- **Gitignore**: `.env.development` and `.env.production` stay local (not committed). Team members create them from shared values (see issue / team channel).

## How to test

1. Copy or create `frontend/.env.development` with `VITE_API_BASE_URL=/api`. Run `npm run dev` in `frontend/` — API calls should go through the proxy (local backend on port 3000 if running).
2. Copy or create `frontend/.env.production` with the deployed API base URL. Run `npm run build` or `npm run prod` — build should finish without TS errors; `vite preview` serves on `http://localhost:4173` by default.
3. Run `npm run test` / `npm run test:run` if you want to confirm tests still pass.

## Related issue

Closes #332