### PR TITLE
fix(mobile): replace placeholder images with real DB images for recip…

### DIFF
--- a/mobile/src/api/home.ts
+++ b/mobile/src/api/home.ts
@@ -16,6 +16,7 @@ export interface RecipeListItem {
   genreName: string | null;
   createdAt: string;
   updatedAt: string;
+  imageUrl: string | null;
 }
 
 export interface RecipeListResponse {
@@ -32,7 +33,23 @@ export async function fetchCommunityPicks(
   limit = 10
 ): Promise<RecipeListResponse> {
   try {
-    return await fetchApi<RecipeListResponse>(`/recipes?page=${page}&limit=${limit}`);
+    const raw = await fetchApi<{ recipes: any[]; pagination: any }>(`/recipes?page=${page}&limit=${limit}`);
+    const recipes: RecipeListItem[] = (raw.recipes ?? []).map((r: any) => ({
+      id: r.id,
+      title: r.title,
+      type: r.type,
+      averageRating: r.averageRating ?? null,
+      ratingCount: r.ratingCount ?? 0,
+      creatorId: r.creatorId ?? null,
+      creatorUsername: r.creatorUsername ?? null,
+      dishVarietyId: r.dishVarietyId ?? null,
+      dishVarietyName: r.dishVarietyName ?? null,
+      genreName: r.genreName ?? null,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+      imageUrl: r.coverImageUrl ?? null,
+    }));
+    return { recipes, pagination: raw.pagination };
   } catch (error) {
     console.error('fetchCommunityPicks error:', error);
     return {

--- a/mobile/src/components/home/CommunityPickCard.tsx
+++ b/mobile/src/components/home/CommunityPickCard.tsx
@@ -12,10 +12,14 @@ interface CommunityPickCardProps {
 export function CommunityPickCard({ recipe, onPress }: CommunityPickCardProps) {
   return (
     <TouchableOpacity onPress={onPress} style={styles.container} activeOpacity={0.7}>
-      <Image
-        source={{ uri: `https://picsum.photos/seed/${recipe.id}/400/300` }}
-        style={styles.image}
-      />
+      {recipe.imageUrl ? (
+        <Image
+          source={{ uri: recipe.imageUrl }}
+          style={styles.image}
+        />
+      ) : (
+        <View style={styles.image} />
+      )}
       <View style={styles.info}>
         <Text style={styles.title} numberOfLines={2}>
           {recipe.title}

--- a/mobile/src/components/home/GenreCard.tsx
+++ b/mobile/src/components/home/GenreCard.tsx
@@ -1,22 +1,6 @@
 import React from 'react';
-import { ImageBackground, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
-
-const GENRE_IMAGES: Record<string, string> = {
-  soups: 'https://picsum.photos/seed/genre-soups/300/400',
-  mezzes: 'https://picsum.photos/seed/genre-mezzes/300/400',
-  pastry: 'https://picsum.photos/seed/genre-pastry/300/400',
-  kebabs: 'https://picsum.photos/seed/genre-kebabs/300/400',
-  salads: 'https://picsum.photos/seed/genre-salads/300/400',
-  desserts: 'https://picsum.photos/seed/genre-desserts/300/400',
-  stews: 'https://picsum.photos/seed/genre-stews/300/400',
-  pilafs: 'https://picsum.photos/seed/genre-pilafs/300/400',
-};
-
-function getGenreImage(name: string): string {
-  const key = name.toLowerCase();
-  return GENRE_IMAGES[key] ?? `https://picsum.photos/seed/genre-${key}/300/400`;
-}
 
 interface GenreCardProps {
   id: number;
@@ -27,16 +11,12 @@ interface GenreCardProps {
 export function GenreCard({ name, onPress }: GenreCardProps) {
   return (
     <TouchableOpacity onPress={onPress} activeOpacity={0.8} style={styles.container}>
-      <ImageBackground
-        source={{ uri: getGenreImage(name) }}
-        style={styles.image}
-        imageStyle={styles.imageInner}
-      >
+      <View style={styles.image}>
         <View style={styles.overlay} />
         <View style={styles.labelContainer}>
           <Text style={styles.label}>{name}</Text>
         </View>
-      </ImageBackground>
+      </View>
     </TouchableOpacity>
   );
 }
@@ -53,15 +33,12 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  imageInner: {
-    borderRadius: 24,
-    opacity: 0.6,
+    backgroundColor: colors.surfaceContainer,
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: colors.surfaceContainer,
-    opacity: 0.3,
+    backgroundColor: colors.primary,
+    opacity: 0.15,
   },
   labelContainer: {
     position: 'absolute',

--- a/mobile/src/components/search/DishVarietyCard.tsx
+++ b/mobile/src/components/search/DishVarietyCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import type { DishVarietyResult } from '../../api/search';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
@@ -12,10 +12,7 @@ interface DishVarietyCardProps {
 export function DishVarietyCard({ variety, onPress }: DishVarietyCardProps) {
   return (
     <TouchableOpacity onPress={onPress} style={styles.container} activeOpacity={0.7}>
-      <Image
-        source={{ uri: `https://picsum.photos/seed/variety-${variety.id}/200/200` }}
-        style={styles.image}
-      />
+      <View style={styles.image} />
       <View style={styles.info}>
         <View style={styles.titleRow}>
           <Text style={styles.name} numberOfLines={1}>

--- a/mobile/src/components/search/GenreBentoGrid.tsx
+++ b/mobile/src/components/search/GenreBentoGrid.tsx
@@ -1,22 +1,7 @@
 import React from 'react';
-import { ImageBackground, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { DishGenre } from '../../api/dish-genres';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
-
-const GENRE_IMAGES: Record<string, string> = {
-  soups: 'https://picsum.photos/seed/genre-soups/400/300',
-  desserts: 'https://picsum.photos/seed/genre-desserts/400/300',
-  pastries: 'https://picsum.photos/seed/genre-pastries/400/300',
-  salads: 'https://picsum.photos/seed/genre-salads/400/300',
-  stews: 'https://picsum.photos/seed/genre-stews/400/300',
-  mezzes: 'https://picsum.photos/seed/genre-mezzes/400/300',
-  kebabs: 'https://picsum.photos/seed/genre-kebabs/400/300',
-};
-
-function getGenreImage(name: string): string {
-  const key = name.toLowerCase();
-  return GENRE_IMAGES[key] ?? `https://picsum.photos/seed/genre-${key}/400/300`;
-}
 
 interface GenreBentoGridProps {
   genres: DishGenre[];
@@ -38,16 +23,12 @@ function GenreTile({ genre, onPress, tall = false, active = false }: GenreTilePr
       activeOpacity={0.8}
       style={[styles.tile, tall && styles.tileTall, active && styles.tileActive]}
     >
-      <ImageBackground
-        source={{ uri: getGenreImage(genre.name) }}
-        style={styles.tileImage}
-        imageStyle={styles.tileImageInner}
-      >
+      <View style={styles.tileImage}>
         <View style={[styles.tileOverlay, active && styles.tileOverlayActive]} />
         <View style={styles.tileLabel}>
           <Text style={styles.tileName}>{genre.name}</Text>
         </View>
-      </ImageBackground>
+      </View>
     </TouchableOpacity>
   );
 }
@@ -88,9 +69,7 @@ const styles = StyleSheet.create({
   tileImage: {
     flex: 1,
     justifyContent: 'flex-end',
-  },
-  tileImageInner: {
-    borderRadius: 20,
+    backgroundColor: colors.surfaceContainer,
   },
   tileActive: {
     borderWidth: 3,
@@ -98,11 +77,12 @@ const styles = StyleSheet.create({
   },
   tileOverlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.35)',
+    backgroundColor: colors.primary,
+    opacity: 0.6,
     borderRadius: 20,
   },
   tileOverlayActive: {
-    backgroundColor: 'rgba(0,0,0,0.55)',
+    opacity: 0.8,
   },
   tileLabel: {
     padding: spacing.md,

--- a/mobile/src/components/search/RecipeCard.tsx
+++ b/mobile/src/components/search/RecipeCard.tsx
@@ -13,17 +13,18 @@ interface RecipeCardProps {
 export function RecipeCard({ recipe, onPress }: RecipeCardProps) {
   const { t } = useTranslation('common');
   const isCultural = recipe.recipeType === 'cultural';
-  const imageSource = recipe.imageUrl
-    ? { uri: recipe.imageUrl }
-    : { uri: `https://picsum.photos/seed/r${recipe.id}/400/240` };
 
   return (
     <TouchableOpacity onPress={onPress} style={styles.container} activeOpacity={0.7}>
       <View style={styles.imageWrapper}>
-        <Image
-          source={imageSource}
-          style={styles.image}
-        />
+        {recipe.imageUrl ? (
+          <Image
+            source={{ uri: recipe.imageUrl }}
+            style={styles.image}
+          />
+        ) : (
+          <View style={styles.image} />
+        )}
         {/* Recipe type badge — top-right, like the example image */}
         <View style={[styles.badge, isCultural ? styles.badgeCultural : styles.badgeCommunity]}>
           <Text style={styles.badgeText}>


### PR DESCRIPTION
## What does this PR do?

Removes all hardcoded `picsum.photos` placeholder URLs from mobile components.  
Recipe cards (CommunityPickCard, RecipeCard) now display real images stored in the DB, falling back to a solid background when no image is available.  
Genre and dish variety cards — which have no image field in the DB — now use styled solid color backgrounds instead of random placeholder images.

## How to test

- Open the **Home** screen — community pick cards should show recipe cover images uploaded to the DB, or a plain background if none exist.  
- Open the **Search** screen — recipe cards should show real cover images; genre tiles and dish variety cards should show solid colored backgrounds (no random or broken images).

## Related issue

Closes **#354**