### PR TITLE
Add comments API with rating functionality

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -61,6 +61,7 @@ backend/
 │   │   ├── substitutions.ts     # Ingredient substitution suggestions
 │   │   ├── tools.ts             # Tool search/autocomplete
 │   │   ├── units.ts             # Unit search/autocomplete
+│   │   ├── comments.ts          # Recipe comments (create, list, delete)
 │   │   └── parse.ts             # Free-text recipe parser endpoint
 │   ├── types/
 │   │   └── index.ts             # TypeScript interfaces (roles, auth, response)
@@ -78,6 +79,7 @@ backend/
 │       ├── substitutions.test.ts
 │       ├── tools.test.ts
 │       ├── units.test.ts
+│       ├── comments.test.ts
 │       └── health.test.ts
 ├── Dockerfile
 ├── jest.config.js
@@ -99,6 +101,7 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - **recipe_media** — `id`, `recipe_id` (FK), `url`, `type` (image|video), `created_at`
 - **ratings** — `id`, `recipe_id` (FK), `user_id` (FK profiles), `score` (1-5), `created_at`, `updated_at` — unique constraint on (recipe_id, user_id)
 - **recipe_dietary_tags** — `recipe_id` (FK recipes), `tag_id` (FK dietary_tags) — composite PK
+- **comments** — `id` (serial PK), `recipe_id` (FK recipes ON DELETE CASCADE), `user_id` (FK profiles ON DELETE CASCADE), `text` (1–2000 chars, CHECK), `created_at`, `updated_at` (nullable). Indexed on `recipe_id`, `user_id`, and `(recipe_id, created_at DESC)`. The API exposes the column as `body`; the route maps `body` ↔ `text` at the DB boundary.
 
 ### Reference Tables
 
@@ -204,6 +207,27 @@ Database is managed via Supabase (no migration files in repo). Key tables:
   - Query params: `search` (optional — filters by partial name match when provided)
   - Returns distinct unit values from `recipe_ingredients`; without `search`, returns all known units; supports autocomplete use case
 
+### Comments (`/recipes/:id/comments`, `/comments/:id`)
+Comments are coupled to ratings (Amazon-style): a non-creator must have a rating on the recipe to comment, but rating is allowed without commenting.
+
+- `POST /recipes/:id/comments` — Create a comment on a recipe (auth required, #419)
+  - Body: `{ body: string, score?: number }` — `body` is 1–2000 chars (trimmed); `score` is an optional integer 1–5
+  - If `score` is provided, upserts the user's rating on the recipe in the same call
+  - If `score` is omitted, requires an existing rating from the user; otherwise returns 400 `RATING_REQUIRED`
+  - Recipe creators may comment on their own recipe without a rating; passing a `score` as the creator returns 403 (self-rating forbidden, mirroring `POST /recipes/:id/ratings`)
+  - Returns 404 if the recipe does not exist
+  - Response: `{ comment: {...}, rating: {...} | null }`
+- `GET /recipes/:id/comments` — List comments on a recipe with pagination (public)
+  - Query params: `page` (default 1), `limit` (default 20, max 100)
+  - Ordered by `created_at` descending (newest first)
+  - Each comment includes the author's `username` (joined from `profiles`)
+- `PATCH /comments/:id` — Edit own comment (auth required, author only)
+  - Body: `{ body: string }` (1–2000 chars, trimmed)
+  - Returns 403 if the caller is not the author, 404 if the comment does not exist
+- `DELETE /comments/:id` — Delete own comment (auth required, author only)
+  - Returns 403 if the user is not the comment author
+  - Returns 404 if the comment does not exist
+
 ### Parse (`/parse`)
 - `POST /parse/recipe-text` — Parse free-text recipe into structured components (cook/expert only)
   - Body: `{ text: string }` (10–5000 chars)
@@ -248,6 +272,7 @@ Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/r
 - `FORBIDDEN` (403) — Wrong role or not owner
 - `NOT_FOUND` (404) — Resource not found
 - `CONFLICT` (409) — Duplicate username/email, already published
+- `RATING_REQUIRED` (400) — Comment attempted without a rating on the recipe
 - `INCOMPLETE_RECIPE` (400) — Missing fields for publish
 - `PARSE_FAILED` (500) — AI parsing of recipe text failed
 - `STANDARDIZATION_FAILED` (500) — AI unit standardization failed

--- a/backend/src/__tests__/comments.test.ts
+++ b/backend/src/__tests__/comments.test.ts
@@ -1,0 +1,590 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+
+  return {
+    supabase: {
+      auth: { getUser: jest.fn() },
+      from: mockFrom,
+    },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+const setupAuth = (role = "cook", profileId = "profile-123", username = "tester") => {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "user-123", email: "test@example.com" } },
+    error: null,
+  });
+
+  (supabase.from as jest.Mock).mockImplementation((table) => {
+    if (table === "profiles") {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: profileId, username, role },
+        error: null,
+      });
+      const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+      return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+    }
+    return { select: jest.fn(), insert: jest.fn(), delete: jest.fn(), update: jest.fn(), upsert: jest.fn() };
+  });
+};
+
+const setupAuthAndTables = (
+  role: string,
+  profileId: string,
+  tableMock: (table: string) => any,
+  username = "tester"
+) => {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "user-123", email: "test@example.com" } },
+    error: null,
+  });
+
+  (supabase.from as jest.Mock).mockImplementation((table) => {
+    if (table === "profiles") {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: profileId, username, role },
+        error: null,
+      });
+      const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+      return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+    }
+    return tableMock(table);
+  });
+};
+
+const chainable = (resolved: { data: any; error: any; count?: number | null }) => {
+  const mock: any = {};
+  const methods = ["select", "eq", "single", "insert", "delete", "update", "upsert", "order", "range"];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  return mock;
+};
+
+const okComment = {
+  id: "comment-1",
+  recipe_id: "recipe-1",
+  user_id: "profile-123",
+  text: "Great recipe!",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const okRating = {
+  id: "rating-1",
+  score: 4,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+// ─── POST /recipes/:id/comments ──────────────────────────────────────────────
+
+describe("POST /recipes/:id/comments", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .send({ body: "Looks delicious!" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is empty", async () => {
+    setupAuth("cook");
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when body is missing", async () => {
+    setupAuth("cook");
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when body exceeds 2000 characters", async () => {
+    setupAuth("cook");
+    const longBody = "a".repeat(2001);
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: longBody });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when score is out of range", async () => {
+    setupAuth("cook");
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Hi", score: 6 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 404 when recipe does not exist", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/missing/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Hi" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 400 RATING_REQUIRED when no score and no existing rating", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "ratings")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Looks great" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("RATING_REQUIRED");
+  });
+
+  it("returns 201 when score is provided (upserts rating + creates comment)", async () => {
+    const ratingsMock = chainable({ data: okRating, error: null });
+    const commentsMock = chainable({ data: okComment, error: null });
+
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "ratings") return ratingsMock;
+      if (table === "comments") return commentsMock;
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Great recipe!", score: 4 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.comment).toMatchObject({
+      id: "comment-1",
+      recipeId: "recipe-1",
+      userId: "profile-123",
+      username: "tester",
+      body: "Great recipe!",
+    });
+    expect(res.body.data.rating).toMatchObject({ id: "rating-1", score: 4 });
+    expect(ratingsMock.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipe_id: "recipe-1",
+        user_id: "profile-123",
+        score: 4,
+      }),
+      expect.objectContaining({ onConflict: "recipe_id,user_id" })
+    );
+  });
+
+  it("returns 201 when no score but existing rating found", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "ratings") return chainable({ data: okRating, error: null });
+      if (table === "comments") return chainable({ data: okComment, error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Tried it again, still tasty." });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.comment.id).toBe("comment-1");
+    expect(res.body.data.rating).toMatchObject({ id: "rating-1", score: 4 });
+  });
+
+  it("returns 403 when creator includes a score (self-rating forbidden)", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "profile-123" }, error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Author note", score: 5 });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 201 when creator comments on own recipe without a score (no rating required)", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "profile-123" }, error: null });
+      if (table === "comments") return chainable({ data: okComment, error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Author follow-up" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.comment.id).toBe("comment-1");
+    expect(res.body.data.rating).toBeNull();
+  });
+
+  it("returns 500 on db error during comment insert", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "ratings") return chainable({ data: okRating, error: null });
+      if (table === "comments") return chainable({ data: null, error: { message: "DB timeout" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Hello" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("returns 500 on db error during rating upsert", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "ratings") return chainable({ data: null, error: { message: "DB timeout" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Hello", score: 5 });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /recipes/:id/comments ───────────────────────────────────────────────
+
+describe("GET /recipes/:id/comments", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const setupListMock = (data: any, error: any = null, count: number | null = null) => {
+    const chain: any = {};
+    chain.select = jest.fn().mockReturnValue(chain);
+    chain.eq = jest.fn().mockReturnValue(chain);
+    chain.order = jest.fn().mockReturnValue(chain);
+    chain.range = jest.fn().mockResolvedValue({ data, error, count });
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "comments") return chain;
+      return {};
+    });
+    return chain;
+  };
+
+  const sampleComments = [
+    {
+      id: "c2",
+      recipe_id: "recipe-1",
+      user_id: "profile-2",
+      text: "Made this yesterday — turned out great.",
+      created_at: "2024-02-02T00:00:00Z",
+      updated_at: "2024-02-02T00:00:00Z",
+      author: { id: "profile-2", username: "ayse" },
+    },
+    {
+      id: "c1",
+      recipe_id: "recipe-1",
+      user_id: "profile-1",
+      text: "Looks tasty!",
+      created_at: "2024-02-01T00:00:00Z",
+      updated_at: "2024-02-01T00:00:00Z",
+      author: { id: "profile-1", username: "furkan" },
+    },
+  ];
+
+  it("returns 200 with paginated comments", async () => {
+    setupListMock(sampleComments, null, 2);
+    const res = await request(app).get("/recipes/recipe-1/comments");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.comments).toHaveLength(2);
+    expect(res.body.data.pagination).toMatchObject({ page: 1, limit: 20, total: 2 });
+  });
+
+  it("returns the response shape with username from joined profile", async () => {
+    setupListMock([sampleComments[0]], null, 1);
+    const res = await request(app).get("/recipes/recipe-1/comments");
+    expect(res.status).toBe(200);
+    expect(res.body.data.comments[0]).toMatchObject({
+      id: "c2",
+      recipeId: "recipe-1",
+      userId: "profile-2",
+      username: "ayse",
+      body: "Made this yesterday — turned out great.",
+    });
+  });
+
+  it("supports pagination query params", async () => {
+    const chain = setupListMock([], null, 0);
+    const res = await request(app).get("/recipes/recipe-1/comments?page=2&limit=5");
+    expect(res.status).toBe(200);
+    expect(chain.range).toHaveBeenCalledWith(5, 9);
+  });
+
+  it("returns empty array when recipe has no comments", async () => {
+    setupListMock([], null, 0);
+    const res = await request(app).get("/recipes/recipe-1/comments");
+    expect(res.status).toBe(200);
+    expect(res.body.data.comments).toHaveLength(0);
+    expect(res.body.data.pagination.total).toBe(0);
+  });
+
+  it("returns 400 for invalid page param", async () => {
+    const res = await request(app).get("/recipes/recipe-1/comments?page=0");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 500 on database error", async () => {
+    setupListMock(null, { message: "DB timeout" });
+    const res = await request(app).get("/recipes/recipe-1/comments");
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── PATCH /comments/:id ─────────────────────────────────────────────────────
+
+describe("PATCH /comments/:id", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app).patch("/comments/comment-1").send({ body: "edit" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is empty", async () => {
+    setupAuth("cook");
+    const res = await request(app)
+      .patch("/comments/comment-1")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 404 when comment does not exist", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "comments")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .patch("/comments/missing")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "edit" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 403 when user is not the author", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "comments")
+        return chainable({
+          data: { id: "comment-1", user_id: "different-profile" },
+          error: null,
+        });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .patch("/comments/comment-1")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "edit" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 200 with the updated comment when author edits", async () => {
+    let callCount = 0;
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "comments") {
+        callCount++;
+        if (callCount === 1)
+          return chainable({
+            data: { id: "comment-1", user_id: "profile-123" },
+            error: null,
+          });
+        return chainable({
+          data: {
+            id: "comment-1",
+            recipe_id: "recipe-1",
+            user_id: "profile-123",
+            text: "updated body",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-02T00:00:00Z",
+          },
+          error: null,
+        });
+      }
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .patch("/comments/comment-1")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "updated body" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: "comment-1",
+      recipeId: "recipe-1",
+      userId: "profile-123",
+      username: "tester",
+      body: "updated body",
+    });
+    expect(res.body.data.updatedAt).not.toEqual(res.body.data.createdAt);
+  });
+});
+
+// ─── DELETE /comments/:id ────────────────────────────────────────────────────
+
+describe("DELETE /comments/:id", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app).delete("/comments/comment-1");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when comment does not exist", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "comments")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .delete("/comments/missing")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 403 when user is not the author", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "comments")
+        return chainable({
+          data: { id: "comment-1", user_id: "different-profile" },
+          error: null,
+        });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .delete("/comments/comment-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 204 when author deletes their own comment", async () => {
+    let callCount = 0;
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "comments") {
+        callCount++;
+        if (callCount === 1)
+          return chainable({
+            data: { id: "comment-1", user_id: "profile-123" },
+            error: null,
+          });
+        return chainable({ data: null, error: null });
+      }
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .delete("/comments/comment-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 500 on db error during fetch", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "comments")
+        return chainable({ data: null, error: { message: "DB timeout" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .delete("/comments/comment-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("returns 500 on db error during delete", async () => {
+    let callCount = 0;
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "comments") {
+        callCount++;
+        if (callCount === 1)
+          return chainable({
+            data: { id: "comment-1", user_id: "profile-123" },
+            error: null,
+          });
+        return chainable({ data: null, error: { message: "DB timeout" } });
+      }
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .delete("/comments/comment-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import ingredientsRouter from "./routes/ingredients.js";
 import toolsRouter from "./routes/tools.js";
 import unitsRouter from "./routes/units.js";
 import substitutionsRouter from "./routes/substitutions.js";
+import commentsRouter from "./routes/comments.js";
 
 const app = express();
 const PORT = process.env["PORT"] ?? 3000;
@@ -41,6 +42,7 @@ app.use("/ingredients", ingredientsRouter);
 app.use("/tools", toolsRouter);
 app.use("/units", unitsRouter);
 app.use("/ingredients", substitutionsRouter);
+app.use("/", commentsRouter);
 
 // ─── 404 Handler ─────────────────────────────────────────────────────────────
 app.use((_req, res) => {

--- a/backend/src/routes/comments.ts
+++ b/backend/src/routes/comments.ts
@@ -1,0 +1,351 @@
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest } from "../types/index.js";
+import { errorResponse, successResponse } from "../utils/response.js";
+
+const router = Router();
+
+// ─── Zod Schemas ──────────────────────────────────────────────────────────────
+
+const commentBodySchema = z
+  .string()
+  .trim()
+  .min(1, { message: "Comment body must not be empty." })
+  .max(2000, { message: "Comment body must be at most 2000 characters." });
+
+const createCommentSchema = z.object({
+  body: commentBodySchema,
+  score: z
+    .number({ message: "Score must be a number." })
+    .int({ message: "Score must be an integer." })
+    .min(1, { message: "Score must be at least 1." })
+    .max(5, { message: "Score must be at most 5." })
+    .optional(),
+});
+
+const updateCommentSchema = z.object({
+  body: commentBodySchema,
+});
+
+const listCommentsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+// ─── POST /recipes/:id/comments ───────────────────────────────────────────────
+
+/**
+ * Create a comment on a recipe. Amazon-style coupling with ratings:
+ *   - The user must have a rating on the recipe to comment.
+ *   - Optionally accept a `score` in the same request to upsert the rating.
+ *   - Recipe creators may comment on their own recipe without a rating
+ *     (since self-rating is forbidden); a `score` from the creator returns 403.
+ */
+router.post(
+  "/recipes/:id/comments",
+  requireAuth,
+  validate(createCommentSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const recipeId = (req.params["id"] ?? "") as string;
+    const { body, score } = req.body as z.infer<typeof createCommentSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    // 1. Verify recipe exists and check creator
+    const { data: recipe, error: fetchError } = await supabase
+      .from("recipes")
+      .select("id, creator_id")
+      .eq("id", recipeId)
+      .single();
+
+    if (fetchError || !recipe) {
+      if (fetchError?.code === "PGRST116") {
+        res.status(404).json(errorResponse("NOT_FOUND", "Recipe not found."));
+        return;
+      }
+      res.status(500).json(errorResponse("DB_ERROR", fetchError?.message ?? "Failed to fetch recipe."));
+      return;
+    }
+
+    const isCreator = (recipe as any).creator_id === user.profileId;
+
+    // 2. Self-rating guard — creators cannot rate their own recipe
+    if (isCreator && score !== undefined) {
+      res
+        .status(403)
+        .json(errorResponse("FORBIDDEN", "You cannot rate your own recipe."));
+      return;
+    }
+
+    // 3. Ensure a rating exists for non-creators (either provided in this call or already on file)
+    let rating: any = null;
+
+    if (!isCreator) {
+      if (score !== undefined) {
+        const { data: upserted, error: upsertError } = await userClient
+          .from("ratings")
+          .upsert(
+            { recipe_id: recipeId, user_id: user.profileId, score },
+            { onConflict: "recipe_id,user_id" }
+          )
+          .select("id, score, created_at, updated_at")
+          .single();
+
+        if (upsertError || !upserted) {
+          res
+            .status(500)
+            .json(errorResponse("DB_ERROR", upsertError?.message ?? "Failed to save rating."));
+          return;
+        }
+
+        rating = upserted;
+      } else {
+        const { data: existing, error: ratingFetchError } = await supabase
+          .from("ratings")
+          .select("id, score, created_at, updated_at")
+          .eq("recipe_id", recipeId)
+          .eq("user_id", user.profileId)
+          .single();
+
+        if (ratingFetchError && ratingFetchError.code !== "PGRST116") {
+          res.status(500).json(errorResponse("DB_ERROR", ratingFetchError.message));
+          return;
+        }
+
+        if (!existing) {
+          res
+            .status(400)
+            .json(
+              errorResponse(
+                "RATING_REQUIRED",
+                "You must rate this recipe before commenting. Include a 'score' (1–5) in the request, or rate first."
+              )
+            );
+          return;
+        }
+
+        rating = existing;
+      }
+    }
+
+    // 4. Insert the comment
+    const { data: inserted, error: insertError } = await userClient
+      .from("comments")
+      .insert({
+        recipe_id: recipeId,
+        user_id: user.profileId,
+        text: body,
+      })
+      .select("id, recipe_id, user_id, text, created_at, updated_at")
+      .single();
+
+    if (insertError || !inserted) {
+      res
+        .status(500)
+        .json(errorResponse("DB_ERROR", insertError?.message ?? "Failed to create comment."));
+      return;
+    }
+
+    res.status(201).json(
+      successResponse({
+        comment: {
+          id: (inserted as any).id,
+          recipeId: (inserted as any).recipe_id,
+          userId: (inserted as any).user_id,
+          username: user.username,
+          body: (inserted as any).text,
+          createdAt: (inserted as any).created_at,
+          updatedAt: (inserted as any).updated_at,
+        },
+        rating: rating
+          ? {
+              id: rating.id,
+              score: rating.score,
+              createdAt: rating.created_at,
+              updatedAt: rating.updated_at,
+            }
+          : null,
+      })
+    );
+  }
+);
+
+// ─── GET /recipes/:id/comments ────────────────────────────────────────────────
+
+/**
+ * List comments on a recipe with pagination.
+ * Public — no auth required.
+ * Ordered by created_at descending (newest first).
+ */
+router.get("/recipes/:id/comments", async (req: Request, res: Response): Promise<void> => {
+  const recipeId = (req.params["id"] ?? "") as string;
+
+  const parsed = listCommentsQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid query parameters.";
+    res.status(400).json(errorResponse("VALIDATION_ERROR", message));
+    return;
+  }
+
+  const { page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const { data, error, count } = await supabase
+    .from("comments")
+    .select(
+      `id, recipe_id, user_id, text, created_at, updated_at,
+       author:profiles!comments_user_id_fkey(id, username)`,
+      { count: "exact" }
+    )
+    .eq("recipe_id", recipeId)
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  const comments = (data ?? []).map((c: any) => ({
+    id: c.id,
+    recipeId: c.recipe_id,
+    userId: c.user_id,
+    username: c.author?.username ?? null,
+    body: c.text,
+    createdAt: c.created_at,
+    updatedAt: c.updated_at,
+  }));
+
+  res.status(200).json(
+    successResponse({
+      comments,
+      pagination: { page, limit, total: count ?? 0 },
+    })
+  );
+});
+
+// ─── PATCH /comments/:id ─────────────────────────────────────────────────────
+
+/**
+ * Edit a comment.
+ * Auth required: Yes. Only the comment author may edit their own comment.
+ */
+router.patch(
+  "/comments/:id",
+  requireAuth,
+  validate(updateCommentSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const commentId = (req.params["id"] ?? "") as string;
+    const { body } = req.body as z.infer<typeof updateCommentSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    // 1. Fetch comment to verify ownership
+    const { data: comment, error: fetchError } = await userClient
+      .from("comments")
+      .select("id, user_id")
+      .eq("id", commentId)
+      .single();
+
+    if (fetchError || !comment) {
+      if (fetchError?.code === "PGRST116") {
+        res.status(404).json(errorResponse("NOT_FOUND", "Comment not found."));
+        return;
+      }
+      res.status(500).json(errorResponse("DB_ERROR", fetchError?.message ?? "Failed to fetch comment."));
+      return;
+    }
+
+    if ((comment as any).user_id !== user.profileId) {
+      res
+        .status(403)
+        .json(errorResponse("FORBIDDEN", "You can only edit your own comments."));
+      return;
+    }
+
+    // 2. Update
+    const { data: updated, error: updateError } = await userClient
+      .from("comments")
+      .update({ text: body, updated_at: new Date().toISOString() })
+      .eq("id", commentId)
+      .select("id, recipe_id, user_id, text, created_at, updated_at")
+      .single();
+
+    if (updateError || !updated) {
+      res
+        .status(500)
+        .json(errorResponse("DB_ERROR", updateError?.message ?? "Failed to update comment."));
+      return;
+    }
+
+    res.status(200).json(
+      successResponse({
+        id: (updated as any).id,
+        recipeId: (updated as any).recipe_id,
+        userId: (updated as any).user_id,
+        username: user.username,
+        body: (updated as any).text,
+        createdAt: (updated as any).created_at,
+        updatedAt: (updated as any).updated_at,
+      })
+    );
+  }
+);
+
+// ─── DELETE /comments/:id ─────────────────────────────────────────────────────
+
+/**
+ * Delete a comment.
+ * Auth required: Yes. Only the comment author may delete their own comment.
+ */
+router.delete(
+  "/comments/:id",
+  requireAuth,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const commentId = (req.params["id"] ?? "") as string;
+    const userClient = createUserClient(user.accessToken);
+
+    // 1. Fetch comment to verify ownership
+    const { data: comment, error: fetchError } = await userClient
+      .from("comments")
+      .select("id, user_id")
+      .eq("id", commentId)
+      .single();
+
+    if (fetchError || !comment) {
+      if (fetchError?.code === "PGRST116") {
+        res.status(404).json(errorResponse("NOT_FOUND", "Comment not found."));
+        return;
+      }
+      res.status(500).json(errorResponse("DB_ERROR", fetchError?.message ?? "Failed to fetch comment."));
+      return;
+    }
+
+    if ((comment as any).user_id !== user.profileId) {
+      res
+        .status(403)
+        .json(errorResponse("FORBIDDEN", "You can only delete your own comments."));
+      return;
+    }
+
+    // 2. Delete it
+    const { error: deleteError } = await userClient
+      .from("comments")
+      .delete()
+      .eq("id", commentId);
+
+    if (deleteError) {
+      res.status(500).json(errorResponse("DB_ERROR", deleteError.message));
+      return;
+    }
+
+    res.status(204).send();
+  }
+);
+
+export default router;


### PR DESCRIPTION
This pull request introduces a full-featured comments system for recipes in the backend. It adds a new `comments` table to the documentation, implements endpoints for creating, listing, editing, and deleting comments (with Amazon-style coupling to ratings), and integrates the new routes into the Express app. The changes also include validation, error handling, and updates to API documentation and tests.

**Comments API Implementation:**
- Added a new `comments.ts` route handler implementing the following endpoints:  
  - `POST /recipes/:id/comments`: Create a comment (requires rating unless the user is the recipe creator; allows upserting a rating in the same call).  
  - `GET /recipes/:id/comments`: List comments with pagination, including author usernames.  
  - `PATCH /comments/:id`: Edit own comment (author only).  
  - `DELETE /comments/:id`: Delete own comment (author only).  
  Includes input validation, error handling, and proper permission checks.
