### PR TITLE
Resolve country aliases and diacritics in origin filter

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -172,16 +172,16 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 
 ### Discovery (`/discovery`)
 - `GET /discovery/recipes` — Filtered recipe discovery
-  - Query params: `genreId`, `varietyId`, `excludeAllergens` (comma-separated IDs), `tagIds` (comma-separated dietary tag IDs — only recipes with ALL specified tags), `search` (case-insensitive partial match on recipe title), `country`, `city`, `district` (exact match on recipe location fields), `page`, `limit`
+  - Query params: `genreId`, `varietyId`, `excludeAllergens` (comma-separated IDs), `tagIds` (comma-separated dietary tag IDs — only recipes with ALL specified tags), `search` (case-insensitive partial match on recipe title), `country`, `city`, `district` (case-insensitive, whitespace-/diacritic-tolerant; country also resolves common aliases — `"tr"`/`"Türkiye"`/`"TUR"` all match recipes stored as `"Turkey"`. See Location Normalization below), `page`, `limit`
   - Response recipe objects include `country`, `city`, `district` fields (nullable)
 - `GET /discovery/recipes/by-ingredients` — Recipes fully makeable with provided ingredients
   - Query params: `ingredientIds` (comma-separated IDs, required), `page`, `limit`
   - Only returns recipes whose every ingredient is in the provided list; partial matches excluded
 - `GET /discovery/locations` — Distinct location values with at least one published recipe (#323)
   - No params → distinct countries
-  - `?country=Turkey` → distinct cities in Turkey
-  - `?country=Turkey&city=Istanbul` → distinct districts in Istanbul
-  - Returns `{ results: string[] }` sorted alphabetically
+  - `?country=Turkey` → distinct cities in Turkey (parent `country` matched case-insensitively + via known aliases — `"tr"`/`"Türkiye"`/`"TUR"` all resolve to the same set)
+  - `?country=Turkey&city=Istanbul` → distinct districts in Istanbul (parent `country`/`city` matched case-insensitively; country also alias-aware)
+  - Returns `{ results: string[] }` deduplicated by canonical key (alias-aware: `"Turkey"`, `"Türkiye"`, `"TR"` collapse into one entry — canonical display name wins), sorted alphabetically
   - Returns 400 if `city` is provided without `country`; null/empty fields excluded
 
 ### Media (`/media`)
@@ -293,6 +293,53 @@ Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/r
 - Chainable mock pattern simulates PostgREST query builder
 - Supertest for HTTP-level assertions
 - Tests run sequentially (`--runInBand`)
+
+### Location Normalization (issue #398)
+
+Recipe origin labels (`country`, `city`, `district`) are free-text fields that
+are easy to mis-type. The origin filter must tolerate three kinds of mismatch
+between filter input and stored value:
+
+1. **Casing / whitespace** — `"Turkey"` vs `" turkey "`.
+2. **Diacritics / Turkish dotted-i** — `"Türkiye"` vs `"Turkiye"`,
+   `"İstanbul"` vs `"Istanbul"`.
+3. **Aliases** — `"Turkey"` vs `"tr"` vs `"TUR"` vs `"Türkiye"`.
+
+The helpers live in `src/utils/locations.ts`:
+
+- `normalizeLocation()` — trims, collapses internal whitespace, returns
+  `null` for empty input. Preserves casing and diacritics.
+- `canonicalizeLocationForWrite()` — `normalizeLocation` + alias resolution
+  to the canonical display name (e.g. `"tr"` / `"Türkiye"` → `"Turkey"`).
+  Inputs that don't match any alias pass through unchanged.
+- `getLocationVariants()` — returns every known surface form equivalent to
+  the input (e.g. `"tr"` → `["Turkey", "tr", "tur", "turkiye",
+  "republic of turkey", ...]`). Inputs without aliases return as a
+  single-element list.
+- `escapeLikePattern()` — escapes `%`, `_`, `\` for safe ILIKE patterns.
+- `dedupeLocationLabels()` — collapses values by canonical key (alias-aware,
+  diacritic-insensitive); when an alias group is hit the canonical display
+  name wins, otherwise first-seen casing wins. Sorted alphabetically.
+
+How they're wired:
+
+- **On write** (`POST /recipes`, `PATCH /recipes/:id`): country, city, and
+  district run through `canonicalizeLocationForWrite()`, so a user who types
+  `"tr"` ends up with `"Turkey"` stored. Future rows are clean by
+  construction.
+- **On read** (`GET /discovery/recipes`, `GET /discovery/locations`): each
+  location filter expands to `getLocationVariants()` and the query becomes
+  `column.ilike.<v1> OR column.ilike.<v2> OR …` (via Supabase `.or()`).
+  Single-variant inputs (e.g. cities not in the alias table) fall back to a
+  plain `.ilike()` so the SQL stays simple. This handles legacy rows that
+  predate the canonicalize-on-write change.
+- **Locations dedup**: `GET /discovery/locations` runs results through
+  `dedupeLocationLabels()`, so a DB holding `"Turkey"`, `"Türkiye"`, and
+  `"TR"` collapses into a single `"Turkey"` entry in the response.
+
+The alias table currently covers Turkey, United States, United Kingdom,
+Germany, Italy, France, Spain, Japan, Greece, and Azerbaijan. Add countries
+to `LOCATION_ALIASES` in `src/utils/locations.ts` as new mismatches surface.
 
 ### Naming Conventions
 - **Files:** kebab-case (`dish-varieties.ts`)

--- a/backend/src/__tests__/discovery.test.ts
+++ b/backend/src/__tests__/discovery.test.ts
@@ -18,7 +18,7 @@ jest.mock("../config/supabase.js", () => {
 
 const chainable = (resolved: { data: any; error: any; count?: number | null }) => {
   const mock: any = {};
-  const methods = ["select", "eq", "neq", "in", "not", "order", "range", "filter", "single", "limit", "ilike"];
+  const methods = ["select", "eq", "neq", "in", "not", "or", "order", "range", "filter", "single", "limit", "ilike"];
   methods.forEach((m) => {
     mock[m] = jest.fn().mockReturnValue(mock);
   });
@@ -649,6 +649,187 @@ describe("GET /discovery/recipes", () => {
     expect(recipe).toHaveProperty("city");
     expect(recipe).toHaveProperty("district");
   });
+
+  // ─── Region label normalization (issue #398) ───────────────────────────────
+  // The origin filter must tolerate incidental differences in casing and
+  // whitespace, otherwise valid recipes are dropped from filtered results.
+
+  it("matches country case-insensitively (filter 'turkey' finds 'Turkey')", async () => {
+    const mockWithLocation = [{ ...mockRecipes[0], country: "Turkey", city: null, district: null }];
+    const chain = chainable({ data: mockWithLocation, error: null, count: 1 });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?country=turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    // "turkey" is in the alias table, so the filter expands to an OR over
+    // every known variant (Turkey/Türkiye/tr/...) instead of a single ilike.
+    expect(chain.or).toHaveBeenCalledTimes(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.Turkey");
+    expect(orArg).toContain("country.ilike.tr");
+    expect(orArg).toContain("country.ilike.turkiye");
+    expect(chain.eq).not.toHaveBeenCalledWith("country", expect.anything());
+  });
+
+  it("matches city case-insensitively (filter 'ADANA' finds 'Adana')", async () => {
+    const mockWithLocation = [{ ...mockRecipes[0], country: "Turkey", city: "Adana", district: null }];
+    const chain = chainable({ data: mockWithLocation, error: null, count: 1 });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?city=ADANA");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(chain.ilike).toHaveBeenCalledWith("city", "ADANA");
+  });
+
+  it("matches district case-insensitively (filter 'seyhan' finds 'Seyhan')", async () => {
+    const mockWithLocation = [{ ...mockRecipes[0], country: "Turkey", city: "Adana", district: "Seyhan" }];
+    const chain = chainable({ data: mockWithLocation, error: null, count: 1 });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?district=seyhan");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(chain.ilike).toHaveBeenCalledWith("district", "seyhan");
+  });
+
+  it("trims and collapses whitespace on country filter input", async () => {
+    const mockWithLocation = [{ ...mockRecipes[0], country: "Turkey", city: null, district: null }];
+    const chain = chainable({ data: mockWithLocation, error: null, count: 1 });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?country=%20%20Turkey%20%20");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    // Whitespace-padded "Turkey" is trimmed before alias lookup; the result
+    // is an OR over Turkey variants (no leading/trailing spaces in any).
+    expect(chain.or).toHaveBeenCalledTimes(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.Turkey");
+    expect(orArg).not.toContain("  Turkey  ");
+  });
+
+  it("escapes ILIKE wildcards in country filter input", async () => {
+    const chain = chainable({ data: [], error: null, count: 0 });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?country=100%25_organic");
+
+    expect(res.status).toBe(200);
+    expect(chain.ilike).toHaveBeenCalledWith("country", "100\\%\\_organic");
+  });
+
+  // ─── Alias + diacritic resolution (issue #398) ────────────────────────────
+  // The origin filter must not silently drop recipes when the user types a
+  // country in a different surface form than what is stored in the DB.
+  // E.g. recipe stored as "Turkey", filter sent as "tr" / "TUR" / "Türkiye".
+
+  it("matches stored 'Turkey' when filter is 'tr' (ISO-2 alias)", async () => {
+    const chain = chainable({
+      data: [{ ...mockRecipes[0], country: "Turkey", city: null, district: null }],
+      error: null,
+      count: 1,
+    });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?country=tr");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(chain.or).toHaveBeenCalledTimes(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.Turkey");
+    expect(orArg).toContain("country.ilike.tr");
+    expect(orArg).toContain("country.ilike.turkiye");
+  });
+
+  it("matches stored 'Turkey' when filter is 'Türkiye' (folds diacritics)", async () => {
+    const chain = chainable({
+      data: [{ ...mockRecipes[0], country: "Turkey", city: null, district: null }],
+      error: null,
+      count: 1,
+    });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get(
+      "/discovery/recipes?country=" + encodeURIComponent("Türkiye")
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(chain.or).toHaveBeenCalledTimes(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.Turkey");
+  });
+
+  it("matches stored 'Türkiye' when filter is 'Turkey' (legacy DB rows)", async () => {
+    // Existing rows may still hold "Türkiye" — the OR over variants should
+    // include the variant form too.
+    const chain = chainable({
+      data: [{ ...mockRecipes[0], country: "Türkiye", city: null, district: null }],
+      error: null,
+      count: 1,
+    });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?country=Turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.turkiye");
+  });
+
+  it("matches stored 'Türkiye' when filter is uppercase 'TÜRKIYE'", async () => {
+    const chain = chainable({
+      data: [{ ...mockRecipes[0], country: "Türkiye", city: null, district: null }],
+      error: null,
+      count: 1,
+    });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get(
+      "/discovery/recipes?country=" + encodeURIComponent("TÜRKIYE")
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(chain.or).toHaveBeenCalledTimes(1);
+  });
+
+  it("expands 'usa' to United States variants (not turkey-only)", async () => {
+    const chain = chainable({
+      data: [{ ...mockRecipes[0], country: "United States", city: null, district: null }],
+      error: null,
+      count: 1,
+    });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?country=usa");
+
+    expect(res.status).toBe(200);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.United States");
+    expect(orArg).toContain("country.ilike.us");
+    expect(orArg).not.toContain("Turkey");
+  });
+
+  it("falls back to a single ilike for non-alias countries (e.g. Narnia)", async () => {
+    const chain = chainable({ data: [], error: null, count: 0 });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/recipes?country=Narnia");
+
+    expect(res.status).toBe(200);
+    // Not in alias table → simple ilike, no .or() expansion.
+    expect(chain.ilike).toHaveBeenCalledWith("country", "Narnia");
+    expect(chain.or).not.toHaveBeenCalled();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -941,5 +1122,135 @@ describe("GET /discovery/locations", () => {
     expect(res.status).toBe(500);
     expect(res.body.success).toBe(false);
     expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  // ─── Region label normalization (issue #398) ───────────────────────────────
+
+  it("deduplicates countries case-insensitively", async () => {
+    const mockRows = [
+      { country: "Turkey", city: null, district: null },
+      { country: "TURKEY", city: null, district: null },
+      { country: "turkey", city: null, district: null },
+      { country: "Italy", city: null, district: null },
+    ];
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockRows, error: null })
+    );
+
+    const res = await request(app).get("/discovery/locations");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toEqual(["Italy", "Turkey"]);
+  });
+
+  it("matches parent country case-insensitively when listing cities", async () => {
+    const mockRows = [
+      { country: "Turkey", city: "Istanbul", district: null },
+      { country: "Turkey", city: "Adana", district: null },
+    ];
+    const chain = chainable({ data: mockRows, error: null });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/locations?country=turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toEqual(["Adana", "Istanbul"]);
+    // Turkey is in the alias table, so the filter is an OR over variants.
+    expect(chain.or).toHaveBeenCalledTimes(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.Turkey");
+    expect(orArg).toContain("country.ilike.turkiye");
+  });
+
+  it("matches parent country and city case-insensitively when listing districts", async () => {
+    const mockRows = [
+      { country: "Turkey", city: "Istanbul", district: "Kadıköy" },
+      { country: "Turkey", city: "Istanbul", district: "Şişli" },
+    ];
+    const chain = chainable({ data: mockRows, error: null });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/locations?country=TURKEY&city=istanbul");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toEqual(["Kadıköy", "Şişli"]);
+    // Country goes through the alias-OR; city is not in the alias table so
+    // it falls through to a single ilike.
+    expect(chain.or).toHaveBeenCalledTimes(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.Turkey");
+    expect(chain.ilike).toHaveBeenCalledWith("city", "istanbul");
+  });
+
+  it("trims and collapses whitespace in country filter input", async () => {
+    const mockRows = [
+      { country: "Turkey", city: "Istanbul", district: null },
+    ];
+    const chain = chainable({ data: mockRows, error: null });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/locations?country=%20%20Turkey%20%20");
+
+    expect(res.status).toBe(200);
+    expect(chain.or).toHaveBeenCalledTimes(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.Turkey");
+    expect(orArg).not.toContain("  Turkey  ");
+  });
+
+  // ─── Alias-aware dedup (issue #398) ───────────────────────────────────────
+  // Legacy data may hold the same place under several surface forms. The
+  // distinct list returned to clients should collapse them into one entry.
+
+  it("collapses 'Turkey' / 'Türkiye' / 'TR' into a single canonical entry", async () => {
+    const mockRows = [
+      { country: "Turkey", city: null, district: null },
+      { country: "Türkiye", city: null, district: null },
+      { country: "TR", city: null, district: null },
+      { country: "TUR", city: null, district: null },
+      { country: "Italy", city: null, district: null },
+    ];
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockRows, error: null })
+    );
+
+    const res = await request(app).get("/discovery/locations");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toEqual(["Italy", "Turkey"]);
+  });
+
+  it("returns the canonical display name even when the DB row is an alias form", async () => {
+    const mockRows = [
+      { country: "TR", city: null, district: null },
+      { country: "tr", city: null, district: null },
+    ];
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockRows, error: null })
+    );
+
+    const res = await request(app).get("/discovery/locations");
+
+    expect(res.status).toBe(200);
+    // Even though the DB only has "TR"/"tr", the API surfaces "Turkey".
+    expect(res.body.data.results).toEqual(["Turkey"]);
+  });
+
+  it("filtering by 'tr' returns cities from rows stored as 'Turkey'", async () => {
+    const mockRows = [
+      { country: "Turkey", city: "Istanbul", district: null },
+      { country: "Türkiye", city: "Adana", district: null },
+    ];
+    const chain = chainable({ data: mockRows, error: null });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/discovery/locations?country=tr");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toEqual(["Adana", "Istanbul"]);
+    expect(chain.or).toHaveBeenCalledTimes(1);
+    const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
+    expect(orArg).toContain("country.ilike.Turkey");
+    expect(orArg).toContain("country.ilike.turkiye");
   });
 });

--- a/backend/src/__tests__/recipes.test.ts
+++ b/backend/src/__tests__/recipes.test.ts
@@ -572,6 +572,158 @@ describe("Recipe Endpoints (Creation & Publishing)", () => {
       expect(response.body.data.city).toBe("Adana");
     });
 
+    it("should collapse internal whitespace in location fields and persist the normalized value", async () => {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: "recipe-collapse-1", created_at: "2023-01-01" },
+      });
+      const mockSelect = jest.fn().mockReturnValue({ single: mockSingle });
+      const mockInsert = jest.fn().mockReturnValue({ select: mockSelect });
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes") return { insert: mockInsert };
+        return { insert: jest.fn().mockResolvedValue({ error: null }) };
+      });
+
+      const response = await request(app)
+        .post("/recipes")
+        .set("Authorization", "Bearer valid_token")
+        .send({ ...validCommunityPayload, country: "United   States", city: " New  York " });
+
+      expect(response.status).toBe(201);
+      expect(response.body.data.country).toBe("United States");
+      expect(response.body.data.city).toBe("New York");
+      // Verify the DB-bound payload uses the normalized form, not the raw input.
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          country: "United States",
+          city: "New York",
+        })
+      );
+    });
+
+    it("should store null when a location field is whitespace-only", async () => {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: "recipe-empty-loc-1", created_at: "2023-01-01" },
+      });
+      const mockSelect = jest.fn().mockReturnValue({ single: mockSingle });
+      const mockInsert = jest.fn().mockReturnValue({ select: mockSelect });
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes") return { insert: mockInsert };
+        return { insert: jest.fn().mockResolvedValue({ error: null }) };
+      });
+
+      const response = await request(app)
+        .post("/recipes")
+        .set("Authorization", "Bearer valid_token")
+        .send({ ...validCommunityPayload, country: "Turkey", city: "   " });
+
+      expect(response.status).toBe(201);
+      expect(response.body.data.country).toBe("Turkey");
+      expect(response.body.data.city).toBeNull();
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ city: null })
+      );
+    });
+
+    // ─── Alias canonicalization on write (issue #398) ────────────────────
+    // POST normalizes country to its canonical display name, so future rows
+    // store one consistent form regardless of how the user typed it.
+
+    it("should canonicalize ISO-2 alias on write (country='tr' → 'Turkey')", async () => {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: "recipe-tr-1", created_at: "2023-01-01" },
+      });
+      const mockSelect = jest.fn().mockReturnValue({ single: mockSingle });
+      const mockInsert = jest.fn().mockReturnValue({ select: mockSelect });
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes") return { insert: mockInsert };
+        return { insert: jest.fn().mockResolvedValue({ error: null }) };
+      });
+
+      const response = await request(app)
+        .post("/recipes")
+        .set("Authorization", "Bearer valid_token")
+        .send({ ...validCommunityPayload, country: "tr" });
+
+      expect(response.status).toBe(201);
+      expect(response.body.data.country).toBe("Turkey");
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ country: "Turkey" })
+      );
+    });
+
+    it("should canonicalize Turkish-name alias on write (country='Türkiye' → 'Turkey')", async () => {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: "recipe-tk-1", created_at: "2023-01-01" },
+      });
+      const mockSelect = jest.fn().mockReturnValue({ single: mockSingle });
+      const mockInsert = jest.fn().mockReturnValue({ select: mockSelect });
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes") return { insert: mockInsert };
+        return { insert: jest.fn().mockResolvedValue({ error: null }) };
+      });
+
+      const response = await request(app)
+        .post("/recipes")
+        .set("Authorization", "Bearer valid_token")
+        .send({ ...validCommunityPayload, country: "Türkiye" });
+
+      expect(response.status).toBe(201);
+      expect(response.body.data.country).toBe("Turkey");
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ country: "Turkey" })
+      );
+    });
+
+    it("should canonicalize uppercase alias on write (country='TUR' → 'Turkey')", async () => {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: "recipe-tur-1", created_at: "2023-01-01" },
+      });
+      const mockSelect = jest.fn().mockReturnValue({ single: mockSingle });
+      const mockInsert = jest.fn().mockReturnValue({ select: mockSelect });
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes") return { insert: mockInsert };
+        return { insert: jest.fn().mockResolvedValue({ error: null }) };
+      });
+
+      const response = await request(app)
+        .post("/recipes")
+        .set("Authorization", "Bearer valid_token")
+        .send({ ...validCommunityPayload, country: "TUR" });
+
+      expect(response.status).toBe(201);
+      expect(response.body.data.country).toBe("Turkey");
+    });
+
+    it("should preserve unknown country names verbatim on write", async () => {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: "recipe-narnia-1", created_at: "2023-01-01" },
+      });
+      const mockSelect = jest.fn().mockReturnValue({ single: mockSingle });
+      const mockInsert = jest.fn().mockReturnValue({ select: mockSelect });
+
+      setupMocks("cook", "profile-123", (table) => {
+        if (table === "recipes") return { insert: mockInsert };
+        return { insert: jest.fn().mockResolvedValue({ error: null }) };
+      });
+
+      const response = await request(app)
+        .post("/recipes")
+        .set("Authorization", "Bearer valid_token")
+        .send({ ...validCommunityPayload, country: "Narnia" });
+
+      expect(response.status).toBe(201);
+      // Not in alias table → stored as typed (after whitespace trim).
+      expect(response.body.data.country).toBe("Narnia");
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ country: "Narnia" })
+      );
+    });
+
     it("should return 201 with only country provided", async () => {
       const mockSingle = jest.fn().mockResolvedValue({
         data: { id: "recipe-partial-1", created_at: "2023-01-01" },

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -2,6 +2,31 @@ import { Router } from "express";
 import { z } from "zod";
 import { supabase } from "../config/supabase.js";
 import { successResponse, errorResponse } from "../utils/response.js";
+import {
+  escapeLikePattern,
+  dedupeLocationLabels,
+  getLocationVariants,
+} from "../utils/locations.js";
+
+// Apply a case-insensitive location filter that also expands known aliases
+// (so a filter for "tr"/"Türkiye" still matches recipes stored as "Turkey").
+// When the input has only one known variant, falls back to a single .ilike()
+// call so the SQL stays simple. Returns the modified query.
+function applyLocationFilter(
+  query: any,
+  column: "country" | "city" | "district",
+  rawValue: string
+): any {
+  const variants = getLocationVariants(rawValue);
+  if (variants.length === 0) return query;
+  if (variants.length === 1) {
+    return query.ilike(column, escapeLikePattern(variants[0]!));
+  }
+  const orFilter = variants
+    .map((v) => `${column}.ilike.${escapeLikePattern(v)}`)
+    .join(",");
+  return query.or(orFilter);
+}
 
 const router = Router();
 
@@ -188,17 +213,12 @@ router.get("/recipes", async (req, res) => {
       query = query.ilike("title", `%${search}%`);
     }
 
-    if (country) {
-      query = query.eq("country", country);
-    }
-
-    if (city) {
-      query = query.eq("city", city);
-    }
-
-    if (district) {
-      query = query.eq("district", district);
-    }
+    // Origin filters tolerate casing/whitespace differences and known
+    // aliases (e.g. "tr"/"Türkiye" → "Turkey") via applyLocationFilter
+    // (issue #398).
+    if (country) query = applyLocationFilter(query, "country", country);
+    if (city) query = applyLocationFilter(query, "city", city);
+    if (district) query = applyLocationFilter(query, "district", district);
 
     if (varietyId !== undefined) {
       query = query.eq("dish_variety_id", varietyId);
@@ -403,15 +423,21 @@ router.get("/locations", async (req, res) => {
     );
   }
 
+  // Match parent scope case-insensitively and across known aliases so
+  // "Turkey" / "turkey" / "Türkiye" / "tr" all resolve the same set of
+  // children (issue #398).
   let field: string;
   let query = supabase.from("recipes").select("country, city, district").eq("is_published", true);
 
   if (country && city) {
     field = "district";
-    query = query.eq("country", country).eq("city", city).not("district", "is", null);
+    query = applyLocationFilter(query, "country", country);
+    query = applyLocationFilter(query, "city", city);
+    query = query.not("district", "is", null);
   } else if (country) {
     field = "city";
-    query = query.eq("country", country).not("city", "is", null);
+    query = applyLocationFilter(query, "country", country);
+    query = query.not("city", "is", null);
   } else {
     field = "country";
     query = query.not("country", "is", null);
@@ -423,13 +449,7 @@ router.get("/locations", async (req, res) => {
     return res.status(500).json(errorResponse("DB_ERROR", error.message));
   }
 
-  const results = [
-    ...new Set(
-      (data ?? [])
-        .map((r: any) => r[field])
-        .filter((v: any) => typeof v === "string" && v.trim() !== "")
-    ),
-  ].sort();
+  const results = dedupeLocationLabels((data ?? []).map((r: any) => r[field]));
 
   return res.status(200).json(successResponse({ results }));
 });

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -5,6 +5,7 @@ import { requireAuth, requireRole } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import type { AuthenticatedRequest } from "../types/index.js";
 import { errorResponse, successResponse } from "../utils/response.js";
+import { canonicalizeLocationForWrite } from "../utils/locations.js";
 import { translateRecipe } from "../services/translationService.js";
 
 const router = Router();
@@ -434,6 +435,10 @@ router.post(
       return;
     }
 
+    const normalizedCountry = canonicalizeLocationForWrite(body.country);
+    const normalizedCity = canonicalizeLocationForWrite(body.city);
+    const normalizedDistrict = canonicalizeLocationForWrite(body.district);
+
     // 1. Insert Core Recipe
     const { data: recipe, error: recipeError } = await userClient
       .from("recipes")
@@ -446,9 +451,9 @@ router.post(
         serving_size: body.servingSize ?? null,
         type: body.type,
         is_published: body.isPublished,
-        country: body.country ?? null,
-        city: body.city ?? null,
-        district: body.district ?? null,
+        country: normalizedCountry,
+        city: normalizedCity,
+        district: normalizedDistrict,
       })
       .select("id, created_at")
       .single();
@@ -535,9 +540,9 @@ router.post(
         servingSize: body.servingSize ?? null,
         type: body.type,
         isPublished: body.isPublished,
-        country: body.country ?? null,
-        city: body.city ?? null,
-        district: body.district ?? null,
+        country: normalizedCountry,
+        city: normalizedCity,
+        district: normalizedDistrict,
         ingredients: body.ingredients,
         steps: body.steps,
         tools: body.tools,
@@ -603,9 +608,9 @@ router.patch(
     if (body.servingSize !== undefined) updateData.serving_size = body.servingSize;
     if (body.type !== undefined) updateData.type = body.type;
     if (body.dishVarietyId !== undefined) updateData.dish_variety_id = body.dishVarietyId;
-    if (body.country !== undefined) updateData.country = body.country;
-    if (body.city !== undefined) updateData.city = body.city;
-    if (body.district !== undefined) updateData.district = body.district;
+    if (body.country !== undefined) updateData.country = canonicalizeLocationForWrite(body.country);
+    if (body.city !== undefined) updateData.city = canonicalizeLocationForWrite(body.city);
+    if (body.district !== undefined) updateData.district = canonicalizeLocationForWrite(body.district);
 
     if (Object.keys(updateData).length > 0) {
       const { error: updateError } = await userClient

--- a/backend/src/utils/locations.ts
+++ b/backend/src/utils/locations.ts
@@ -1,0 +1,189 @@
+/**
+ * Helpers for handling recipe location labels (country, city, district).
+ *
+ * Recipes are tagged with free-text region labels supplied by users. Two kinds
+ * of mismatches break the origin filter (issue #398):
+ *
+ *   1. Casing / whitespace — "Turkey" vs " turkey ".
+ *   2. Aliases / translations / diacritics — "Turkey" vs "tr" vs "Türkiye"
+ *      vs "TUR".
+ *
+ * The first is solved with normalizeLocation + ilike. The second needs an
+ * alias table (so "tr" and "Türkiye" both resolve to "Turkey") plus a
+ * folding function that ignores diacritics and Turkish dotted-i so the
+ * lookup is robust to user typing.
+ *
+ * Reads expand the input into every known surface form and OR them together;
+ * writes resolve the input to the canonical display name, so future rows
+ * are clean regardless of which form the user typed.
+ */
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function normalizeLocation(
+  input: string | null | undefined
+): string | null {
+  if (input == null) return null;
+  const collapsed = input.replace(/\s+/g, " ").trim();
+  return collapsed.length === 0 ? null : collapsed;
+}
+
+export function escapeLikePattern(input: string): string {
+  return input.replace(/[\\%_]/g, (m) => `\\${m}`);
+}
+
+/**
+ * Resolve a location label to its canonical display name when the input
+ * matches a known alias (e.g. "tr"/"Türkiye"/"TUR" → "Turkey"). Inputs
+ * that don't match any alias are returned trimmed/whitespace-collapsed.
+ * Returns null for empty/whitespace-only input.
+ *
+ * Used on the write path (POST/PATCH /recipes) so future rows store a
+ * single canonical form regardless of how the user typed it.
+ */
+export function canonicalizeLocationForWrite(
+  input: string | null | undefined
+): string | null {
+  const trimmed = normalizeLocation(input);
+  if (trimmed == null) return null;
+  return getCanonicalDisplay(foldLocation(trimmed)) ?? trimmed;
+}
+
+/**
+ * Return every surface form known to be equivalent to the input, suitable
+ * for an OR-of-ilikes query. For inputs not in the alias table, returns
+ * the trimmed input alone.
+ *
+ * Used on the read path so a filter for "tr" still matches legacy rows
+ * stored as "Turkey", "Türkiye", or "TR".
+ */
+export function getLocationVariants(input: string): string[] {
+  const trimmed = normalizeLocation(input);
+  if (trimmed == null) return [];
+  const folded = foldLocation(trimmed);
+  const canonical = getCanonicalDisplay(folded);
+  if (!canonical) return [trimmed];
+
+  const variants = new Set<string>([canonical]);
+  for (const [aliasKey, displayName] of Object.entries(LOCATION_ALIASES)) {
+    if (displayName === canonical) variants.add(aliasKey);
+  }
+  return [...variants];
+}
+
+/**
+ * Deduplicate a list of location labels, treating values that share a
+ * canonical key (after folding + alias resolution) as the same entry.
+ * The canonical display name wins when present; otherwise the first-seen
+ * raw form is kept. Result is sorted alphabetically.
+ */
+export function dedupeLocationLabels(values: unknown[]): string[] {
+  const seen = new Map<string, string>();
+  for (const v of values) {
+    if (typeof v !== "string") continue;
+    const trimmed = v.trim();
+    if (!trimmed) continue;
+    const folded = foldLocation(trimmed);
+    const canonical = getCanonicalDisplay(folded);
+    const key = canonical ? foldLocation(canonical) : folded;
+    if (!seen.has(key)) seen.set(key, canonical ?? trimmed);
+  }
+  return [...seen.values()].sort((a, b) => a.localeCompare(b));
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────────
+
+/**
+ * Fold a label into a comparison key: handle Turkish dotted-i (İ/ı), strip
+ * combining diacritical marks via NFD, lowercase, and collapse whitespace.
+ * "Türkiye", "TÜRKİYE", " turkiye " all fold to "turkiye".
+ */
+function foldLocation(input: string): string {
+  return input
+    .replace(/İ/g, "I")
+    .replace(/ı/g, "i")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function getCanonicalDisplay(folded: string): string | null {
+  return LOCATION_ALIASES[folded] ?? null;
+}
+
+/**
+ * Folded alias → canonical display name. Add a country here when users in
+ * the wild type it multiple ways (translations, ISO-2/ISO-3, common
+ * abbreviations). The canonical form is whatever we want to show in the
+ * UI / store on write.
+ */
+const LOCATION_ALIASES: Record<string, string> = {
+  // Turkey
+  "turkey": "Turkey",
+  "turkiye": "Turkey",
+  "tr": "Turkey",
+  "tur": "Turkey",
+  "republic of turkey": "Turkey",
+  "republic of turkiye": "Turkey",
+
+  // United States
+  "united states": "United States",
+  "united states of america": "United States",
+  "us": "United States",
+  "usa": "United States",
+  "america": "United States",
+
+  // United Kingdom
+  "united kingdom": "United Kingdom",
+  "uk": "United Kingdom",
+  "gb": "United Kingdom",
+  "gbr": "United Kingdom",
+  "great britain": "United Kingdom",
+  "britain": "United Kingdom",
+
+  // Germany
+  "germany": "Germany",
+  "deutschland": "Germany",
+  "de": "Germany",
+  "deu": "Germany",
+  "ger": "Germany",
+
+  // Italy
+  "italy": "Italy",
+  "italia": "Italy",
+  "it": "Italy",
+  "ita": "Italy",
+
+  // France
+  "france": "France",
+  "fr": "France",
+  "fra": "France",
+
+  // Spain
+  "spain": "Spain",
+  "espana": "Spain",
+  "es": "Spain",
+  "esp": "Spain",
+
+  // Japan
+  "japan": "Japan",
+  "nihon": "Japan",
+  "nippon": "Japan",
+  "jp": "Japan",
+  "jpn": "Japan",
+
+  // Greece
+  "greece": "Greece",
+  "ellada": "Greece",
+  "hellas": "Greece",
+  "gr": "Greece",
+  "grc": "Greece",
+
+  // Azerbaijan
+  "azerbaijan": "Azerbaijan",
+  "azerbaycan": "Azerbaijan",
+  "az": "Azerbaijan",
+  "aze": "Azerbaijan",
+};


### PR DESCRIPTION
This pull request implements robust normalization, alias resolution, and deduplication for recipe origin labels (`country`, `city`, `district`) in the discovery endpoints, addressing mismatches due to casing, whitespace, diacritics, and common aliases. It updates both the documentation and the test suite to reflect and verify these improvements, ensuring that filtering and listing by location is reliable and user-friendly—even when data or input varies in format.