### PR TITLE
Backend/feat: add user favorites API endpoints and tests

### DIFF
--- a/backend/src/__tests__/users.test.ts
+++ b/backend/src/__tests__/users.test.ts
@@ -1,0 +1,370 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: {
+      auth: { getUser: jest.fn() },
+      from: mockFrom,
+    },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const setupAuth = () => {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "auth-user-1", email: "test@example.com" } },
+    error: null,
+  });
+};
+
+const authProfileMock = () => {
+  const mockSingle = jest.fn().mockResolvedValue({
+    data: { id: "profile-1", username: "testuser", role: "cook" },
+    error: null,
+  });
+  const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+  return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+};
+
+const recipeMaybeSingleMock = (data: any) => {
+  const mockMaybeSingle = jest.fn().mockResolvedValue({ data, error: null });
+  const mockEq2 = jest.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+  const mockEq1 = jest.fn().mockReturnValue({ eq: mockEq2 });
+  return { select: jest.fn().mockReturnValue({ eq: mockEq1 }) };
+};
+
+// ─── POST /users/me/favorites/:recipeId ───────────────────────────────────────
+
+describe("POST /users/me/favorites/:recipeId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app).post("/users/me/favorites/recipe-1");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when recipe not found or unpublished", async () => {
+    setupAuth();
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") return authProfileMock();
+      if (table === "recipes") return recipeMaybeSingleMock(null);
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/users/me/favorites/nonexistent")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 201 when successfully favorited", async () => {
+    setupAuth();
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") return authProfileMock();
+      if (table === "recipes") return recipeMaybeSingleMock({ id: "recipe-1" });
+      if (table === "user_favorites") {
+        return { insert: jest.fn().mockResolvedValue({ error: null }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/users/me/favorites/recipe-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.favorited).toBe(true);
+  });
+
+  it("returns 409 when recipe is already in favorites", async () => {
+    setupAuth();
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") return authProfileMock();
+      if (table === "recipes") return recipeMaybeSingleMock({ id: "recipe-1" });
+      if (table === "user_favorites") {
+        return { insert: jest.fn().mockResolvedValue({ error: { code: "23505", message: "duplicate key" } }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/users/me/favorites/recipe-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("CONFLICT");
+  });
+});
+
+// ─── DELETE /users/me/favorites/:recipeId ─────────────────────────────────────
+
+describe("DELETE /users/me/favorites/:recipeId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app).delete("/users/me/favorites/recipe-1");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 204 when successfully removed", async () => {
+    setupAuth();
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") return authProfileMock();
+      if (table === "user_favorites") {
+        const mockMaybeSingle = jest.fn().mockResolvedValue({ data: { id: "fav-1" }, error: null });
+        const mockSelect = jest.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+        const mockEq2 = jest.fn().mockReturnValue({ select: mockSelect });
+        const mockEq1 = jest.fn().mockReturnValue({ eq: mockEq2 });
+        return { delete: jest.fn().mockReturnValue({ eq: mockEq1 }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .delete("/users/me/favorites/recipe-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 404 when favorite does not exist", async () => {
+    setupAuth();
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") return authProfileMock();
+      if (table === "user_favorites") {
+        const mockMaybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+        const mockSelect = jest.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+        const mockEq2 = jest.fn().mockReturnValue({ select: mockSelect });
+        const mockEq1 = jest.fn().mockReturnValue({ eq: mockEq2 });
+        return { delete: jest.fn().mockReturnValue({ eq: mockEq1 }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .delete("/users/me/favorites/recipe-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+});
+
+// ─── GET /users/me/favorites ──────────────────────────────────────────────────
+
+describe("GET /users/me/favorites", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockFavRow = {
+    recipe: {
+      id: "recipe-1",
+      title: "Adana Kebap",
+      type: "community",
+      average_rating: 4.5,
+      rating_count: 10,
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+      creator: { id: "profile-2", username: "cook1" },
+      dish_variety: { id: 1, name: "Kebap", dish_genre: { id: 1, name: "Grills" } },
+      recipe_media: [{ id: 1, url: "https://example.com/img.jpg", type: "image" }],
+    },
+  };
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app).get("/users/me/favorites");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 200 with paginated list of favorited recipes", async () => {
+    setupAuth();
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") return authProfileMock();
+      if (table === "user_favorites") {
+        const mockRange = jest.fn().mockResolvedValue({ data: [mockFavRow], error: null, count: 1 });
+        const mockOrder = jest.fn().mockReturnValue({ range: mockRange });
+        const mockEq = jest.fn().mockReturnValue({ order: mockOrder });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/users/me/favorites")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(res.body.data.recipes[0].title).toBe("Adana Kebap");
+    expect(res.body.data.recipes[0].coverImageUrl).toBe("https://example.com/img.jpg");
+    expect(res.body.data.pagination.total).toBe(1);
+  });
+
+  it("returns 200 with empty list when no favorites", async () => {
+    setupAuth();
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") return authProfileMock();
+      if (table === "user_favorites") {
+        const mockRange = jest.fn().mockResolvedValue({ data: [], error: null, count: 0 });
+        const mockOrder = jest.fn().mockReturnValue({ range: mockRange });
+        const mockEq = jest.fn().mockReturnValue({ order: mockOrder });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/users/me/favorites")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(0);
+    expect(res.body.data.pagination.total).toBe(0);
+  });
+
+  it("returns correct pagination metadata", async () => {
+    setupAuth();
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") return authProfileMock();
+      if (table === "user_favorites") {
+        const mockRange = jest.fn().mockResolvedValue({ data: [mockFavRow], error: null, count: 25 });
+        const mockOrder = jest.fn().mockReturnValue({ range: mockRange });
+        const mockEq = jest.fn().mockReturnValue({ order: mockOrder });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/users/me/favorites?page=2&limit=10")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pagination.page).toBe(2);
+    expect(res.body.data.pagination.limit).toBe(10);
+    expect(res.body.data.pagination.total).toBe(25);
+  });
+});
+
+// ─── GET /recipes/:id — isFavorited ──────────────────────────────────────────
+
+describe("GET /recipes/:id isFavorited", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockRecipe = {
+    id: "recipe-1",
+    title: "Adana Kebap",
+    story: null,
+    video_url: null,
+    serving_size: null,
+    type: "community",
+    is_published: true,
+    average_rating: 4.5,
+    rating_count: 10,
+    country: null, city: null, district: null,
+    created_at: "2024-01-01",
+    updated_at: "2024-01-01",
+    creator: { id: "profile-2", username: "cook1" },
+    dish_variety: { id: 1, name: "Kebap", dish_genre: { id: 1, name: "Grills" } },
+    recipe_ingredients: [],
+    recipe_steps: [],
+    recipe_tools: [],
+    recipe_media: [],
+    recipe_dietary_tags: [],
+  };
+
+  it("returns isFavorited: false when no Authorization header", async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ data: mockRecipe, error: null });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "recipes") return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      return {};
+    });
+
+    const res = await request(app).get("/recipes/recipe-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.isFavorited).toBe(false);
+  });
+
+  it("returns isFavorited: true when user has favorited the recipe", async () => {
+    (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+      data: { user: { id: "auth-user-1" } },
+      error: null,
+    });
+
+    let profileCallCount = 0;
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "recipes") {
+        const mockSingle = jest.fn().mockResolvedValue({ data: mockRecipe, error: null });
+        const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      }
+      if (table === "profiles") {
+        profileCallCount++;
+        const mockMaybeSingle = jest.fn().mockResolvedValue({ data: { id: "profile-1" }, error: null });
+        const mockEq = jest.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      }
+      if (table === "user_favorites") {
+        const mockMaybeSingle = jest.fn().mockResolvedValue({ data: { id: "fav-1" }, error: null });
+        const mockEq2 = jest.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+        const mockEq1 = jest.fn().mockReturnValue({ eq: mockEq2 });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq1 }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/recipes/recipe-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.isFavorited).toBe(true);
+  });
+
+  it("returns isFavorited: false when user has not favorited the recipe", async () => {
+    (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+      data: { user: { id: "auth-user-1" } },
+      error: null,
+    });
+
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "recipes") {
+        const mockSingle = jest.fn().mockResolvedValue({ data: mockRecipe, error: null });
+        const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      }
+      if (table === "profiles") {
+        const mockMaybeSingle = jest.fn().mockResolvedValue({ data: { id: "profile-1" }, error: null });
+        const mockEq = jest.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+      }
+      if (table === "user_favorites") {
+        const mockMaybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+        const mockEq2 = jest.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+        const mockEq1 = jest.fn().mockReturnValue({ eq: mockEq2 });
+        return { select: jest.fn().mockReturnValue({ eq: mockEq1 }) };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/recipes/recipe-1")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.isFavorited).toBe(false);
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import toolsRouter from "./routes/tools.js";
 import unitsRouter from "./routes/units.js";
 import substitutionsRouter from "./routes/substitutions.js";
 import commentsRouter from "./routes/comments.js";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const PORT = process.env["PORT"] ?? 3000;
@@ -43,6 +44,7 @@ app.use("/tools", toolsRouter);
 app.use("/units", unitsRouter);
 app.use("/ingredients", substitutionsRouter);
 app.use("/", commentsRouter);
+app.use("/users", usersRouter);
 
 // ─── 404 Handler ─────────────────────────────────────────────────────────────
 app.use((_req, res) => {

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -279,6 +279,30 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
     }
   }
 
+  // Optionally resolve isFavorited for authenticated callers
+  let isFavorited = false;
+  const authHeader = req.headers["authorization"];
+  if (authHeader?.startsWith("Bearer ")) {
+    const token = authHeader.slice(7);
+    const { data: userData } = await supabase.auth.getUser(token);
+    if (userData?.user) {
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("id")
+        .eq("user_id", userData.user.id)
+        .maybeSingle();
+      if (profile) {
+        const { data: fav } = await supabase
+          .from("user_favorites")
+          .select("id")
+          .eq("user_id", (profile as any).id)
+          .eq("recipe_id", recipeId)
+          .maybeSingle();
+        isFavorited = !!fav;
+      }
+    }
+  }
+
   res.status(200).json(
     successResponse({
       id: data.id,
@@ -298,6 +322,7 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       district: (data as any).district ?? null,
       averageRating: (data as any).average_rating ?? null,
       ratingCount: (data as any).rating_count ?? 0,
+      isFavorited,
       ingredients: (data.recipe_ingredients ?? []).map((ri: any) => ({
         id: ri.id,
         ingredientId: ri.ingredient?.id ?? null,

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,0 +1,142 @@
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { supabase } from "../config/supabase.js";
+import { requireAuth } from "../middleware/auth.js";
+import type { AuthenticatedRequest } from "../types/index.js";
+import { errorResponse, successResponse } from "../utils/response.js";
+
+const router = Router();
+
+// ─── Zod Schemas ──────────────────────────────────────────────────────────────
+
+const listFavoritesQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+// ─── POST /users/me/favorites/:recipeId ───────────────────────────────────────
+
+router.post("/me/favorites/:recipeId", requireAuth, async (req: Request, res: Response): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+  const recipeId = req.params["recipeId"] as string;
+
+  const { data: recipe } = await supabase
+    .from("recipes")
+    .select("id")
+    .eq("id", recipeId)
+    .eq("is_published", true)
+    .maybeSingle();
+
+  if (!recipe) {
+    res.status(404).json(errorResponse("NOT_FOUND", "Recipe not found."));
+    return;
+  }
+
+  const { error } = await supabase
+    .from("user_favorites")
+    .insert({ user_id: user.profileId, recipe_id: recipeId });
+
+  if (error) {
+    if (error.code === "23505") {
+      res.status(409).json(errorResponse("CONFLICT", "Recipe is already in favorites."));
+      return;
+    }
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(201).json(successResponse({ recipeId, favorited: true }));
+});
+
+// ─── DELETE /users/me/favorites/:recipeId ─────────────────────────────────────
+
+router.delete("/me/favorites/:recipeId", requireAuth, async (req: Request, res: Response): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+  const recipeId = req.params["recipeId"] as string;
+
+  const { data, error } = await supabase
+    .from("user_favorites")
+    .delete()
+    .eq("user_id", user.profileId)
+    .eq("recipe_id", recipeId)
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  if (!data) {
+    res.status(404).json(errorResponse("NOT_FOUND", "Favorite not found."));
+    return;
+  }
+
+  res.status(204).send();
+});
+
+// ─── GET /users/me/favorites ──────────────────────────────────────────────────
+
+router.get("/me/favorites", requireAuth, async (req: Request, res: Response): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+
+  const parsed = listFavoritesQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid query parameters.";
+    res.status(400).json(errorResponse("VALIDATION_ERROR", message));
+    return;
+  }
+
+  const { page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const { data, error, count } = await supabase
+    .from("user_favorites")
+    .select(
+      `recipe:recipes(
+        id, title, type, average_rating, rating_count, created_at, updated_at,
+        creator:profiles!recipes_creator_id_fkey(id, username),
+        dish_variety:dish_varieties(id, name, dish_genre:dish_genres(id, name)),
+        recipe_media(id, url, type)
+      )`,
+      { count: "exact" }
+    )
+    .eq("user_id", user.profileId)
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  const recipes = (data ?? []).map((fav: any) => {
+    const r = fav.recipe;
+    const firstImage = (r?.recipe_media ?? []).find((m: any) => m.type === "image");
+    return {
+      id: r?.id ?? null,
+      title: r?.title ?? null,
+      type: r?.type ?? null,
+      averageRating: r?.average_rating ?? null,
+      ratingCount: r?.rating_count ?? 0,
+      creatorId: r?.creator?.id ?? null,
+      creatorUsername: r?.creator?.username ?? null,
+      dishVarietyId: r?.dish_variety?.id ?? null,
+      dishVarietyName: r?.dish_variety?.name ?? null,
+      genreName: r?.dish_variety?.dish_genre?.name ?? null,
+      createdAt: r?.created_at ?? null,
+      updatedAt: r?.updated_at ?? null,
+      coverImageUrl: firstImage?.url ?? null,
+    };
+  });
+
+  res.status(200).json(
+    successResponse({
+      recipes,
+      pagination: { page, limit, total: count ?? 0 },
+    })
+  );
+});
+
+export default router;


### PR DESCRIPTION
This pull request adds a complete implementation for user recipe favorites, including new API endpoints, their integration into the main app, and comprehensive tests. It allows authenticated users to favorite and unfavorite recipes, list their favorites with pagination, and see if a recipe is favorited in the recipe details response.

**New feature: User favorites system**

* Adds a new `users` router with endpoints for managing recipe favorites:
  - `POST /users/me/favorites/:recipeId`: Favorite a published recipe.
  - `DELETE /users/me/favorites/:recipeId`: Unfavorite a recipe.
  - [`GET /users/me/favorites`](diffhunk://#diff-b842c9733e2eef1c2259600bbf09044590e37d17244ddaf3de22ce6be74158c2R1-R142): List favorited recipes with pagination and metadata.
* Integrates the `users` router into the main Express app, registering the new endpoints under `/users`. [[1]](diffhunk://#diff-c20200a666b149a045e365999f581db8e04687cfc9569bdf4c9477cab954d324R18) [[2]](diffhunk://#diff-c20200a666b149a045e365999f581db8e04687cfc9569bdf4c9477cab954d324R47)

**Recipe API enhancements**

* Updates the recipe details endpoint (`GET /recipes/:id`) to include an `isFavorited` field, indicating if the authenticated user has favorited the recipe. [[1]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baR282-R305) [[2]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baR325)

**Testing**

* Adds comprehensive tests for all user favorite endpoints and the new `isFavorited` field in recipe details, covering success and error cases.
Closes #416 
Closes #442 