### PR TITLE
[Mobile/Fix] Fix case-insensitive search for Turkish characters

### DIFF
--- a/mobile/src/__tests__/string.test.ts
+++ b/mobile/src/__tests__/string.test.ts
@@ -1,0 +1,52 @@
+import { searchStartsWith, searchIncludes, searchEquals } from '../utils/string';
+
+describe('searchStartsWith', () => {
+  it('matches Turkish İ with plain "i" query', () => {
+    expect(searchStartsWith('İstanbul', 'ist')).toBe(true);
+  });
+
+  it('matches plain I with plain "i" query', () => {
+    expect(searchStartsWith('Istanbul', 'ist')).toBe(true);
+  });
+
+  it('is case-insensitive for ASCII', () => {
+    expect(searchStartsWith('Community', 'comm')).toBe(true);
+  });
+
+  it('matches Turkish ş, ğ, ü, ö, ç', () => {
+    expect(searchStartsWith('Şeker', 'şek')).toBe(true);
+    expect(searchStartsWith('Güveç', 'güv')).toBe(true);
+  });
+
+  it('returns false when no match', () => {
+    expect(searchStartsWith('Ankara', 'ist')).toBe(false);
+  });
+});
+
+describe('searchIncludes', () => {
+  it('finds İ-containing substring', () => {
+    expect(searchIncludes('Türk Mutfağı', 'mutfağ')).toBe(true);
+  });
+
+  it('finds plain-I substring in Turkish name', () => {
+    expect(searchIncludes('Istanbul Pidesi', 'istanbul')).toBe(true);
+  });
+
+  it('returns false when not found', () => {
+    expect(searchIncludes('Çorba', 'xyz')).toBe(false);
+  });
+});
+
+describe('searchEquals', () => {
+  it('treats İ and i as equal', () => {
+    expect(searchEquals('İzmir', 'izmir')).toBe(true);
+  });
+
+  it('treats plain I and i as equal', () => {
+    expect(searchEquals('ISTANBUL', 'istanbul')).toBe(true);
+  });
+
+  it('returns false for different strings', () => {
+    expect(searchEquals('Ankara', 'İzmir')).toBe(false);
+  });
+});

--- a/mobile/src/api/search.ts
+++ b/mobile/src/api/search.ts
@@ -1,5 +1,6 @@
 import { fetchApi } from './client';
 import type { DishGenre } from './dish-genres';
+import { searchIncludes } from '../utils/string';
 
 export type { DishGenre } from './dish-genres';
 
@@ -67,7 +68,7 @@ export async function fetchSearchGenres(query?: string): Promise<DishGenre[]> {
   try {
     const genres = await fetchApi<DishGenre[]>('/dish-genres');
     if (!query?.trim()) return genres;
-    return genres.filter((g) => g.name.toLowerCase().includes(query.toLowerCase()));
+    return genres.filter((g) => searchIncludes(g.name, query));
   } catch (error) {
     console.error('fetchSearchGenres error:', error);
     return [];

--- a/mobile/src/components/create-ingredients/CreateIngredientsToolsScreen.tsx
+++ b/mobile/src/components/create-ingredients/CreateIngredientsToolsScreen.tsx
@@ -23,6 +23,7 @@ import { ToolSearchSection } from "./ToolSearchSection";
 import { useTranslation } from "react-i18next";
 import { useRecipeForm } from "../../context/RecipeFormContext";
 import { validateIngredients } from "../../utils/recipeValidation";
+import { searchEquals } from "../../utils/string";
 import { searchIngredients } from "../../api/ingredients";
 import type { IngredientItem } from "../../api/ingredients";
 import { getTools } from "../../api/tools";
@@ -88,7 +89,7 @@ export function CreateIngredientsToolsScreen() {
           prev.map((ing) => {
             if (ing.name.trim() && ing.ingredientId === null) {
               const match = data.find(
-                (ai) => ai.name.toLowerCase() === ing.name.toLowerCase(),
+                (ai) => searchEquals(ai.name, ing.name),
               );
               if (match) return { ...ing, ingredientId: match.id };
               console.warn(

--- a/mobile/src/components/create-ingredients/IngredientRowEditor.tsx
+++ b/mobile/src/components/create-ingredients/IngredientRowEditor.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
 import { FormDropdown } from '../shared/FormDropdown';
 import type { IngredientItem } from '../../api/ingredients';
+import { searchStartsWith } from '../../utils/string';
 
 export interface IngredientFormItem {
   id: string;
@@ -41,10 +42,10 @@ export function IngredientRowEditor({
   const { t } = useTranslation('common');
   const [showSuggestions, setShowSuggestions] = useState(false);
 
-  const query = ingredient.name.trim().toLowerCase();
+  const query = ingredient.name.trim();
   const suggestions = query.length > 0
     ? allIngredients
-        .filter((i) => i.name.toLowerCase().startsWith(query))
+        .filter((i) => searchStartsWith(i.name, query))
         .slice(0, 5)
     : [];
 

--- a/mobile/src/components/create-ingredients/ToolSearchSection.tsx
+++ b/mobile/src/components/create-ingredients/ToolSearchSection.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import type { Tool } from '../../types/ingredient';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
 import type { ToolItem } from '../../api/tools';
+import { searchStartsWith } from '../../utils/string';
 
 // Number of tools to show in the quick-add chips row
 const QUICK_ADD_COUNT = 7;
@@ -33,11 +34,11 @@ export function ToolSearchSection({
   const [search, setSearch] = useState('');
   const [showResults, setShowResults] = useState(false);
 
-  const query = search.trim().toLowerCase();
+  const query = search.trim();
   const filtered = query.length > 0
     ? allTools
         .filter((t) =>
-          t.name.toLowerCase().startsWith(query) &&
+          searchStartsWith(t.name, query) &&
           !selectedTools.some((s) => s.id === t.name),
         )
         .slice(0, 5)

--- a/mobile/src/components/shared/FormDropdown.tsx
+++ b/mobile/src/components/shared/FormDropdown.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
+import { searchStartsWith } from '../../utils/string';
 
 interface DropdownOption {
   label: string;
@@ -44,7 +45,7 @@ export function FormDropdown({
   const selectedOption = options.find((o) => o.value === value);
 
   const filteredOptions = searchable && search.length > 0
-    ? options.filter((o) => o.label.toLowerCase().startsWith(search.toLowerCase()))
+    ? options.filter((o) => searchStartsWith(o.label, search))
     : options;
 
   const handleSelect = (option: DropdownOption) => {

--- a/mobile/src/screens/SearchScreen.tsx
+++ b/mobile/src/screens/SearchScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { searchIncludes } from '../utils/string';
 import {
   ActivityIndicator,
   ScrollView,
@@ -80,7 +81,7 @@ export function SearchScreen() {
   // Client-side filtered genres (by search text)
   const filteredGenres = useMemo(() => {
     if (!normalizedSearch) return allGenres;
-    return allGenres.filter((g) => g.name.toLowerCase().includes(normalizedSearch));
+    return allGenres.filter((g) => searchIncludes(g.name, normalizedSearch));
   }, [allGenres, normalizedSearch]);
 
   // Client-side filtered varieties (by selected genre + search text)
@@ -92,8 +93,8 @@ export function SearchScreen() {
     if (normalizedSearch) {
       result = result.filter(
         (v) =>
-          v.name.toLowerCase().includes(normalizedSearch) ||
-          v.genreName?.toLowerCase().includes(normalizedSearch)
+          searchIncludes(v.name, normalizedSearch) ||
+          (v.genreName != null && searchIncludes(v.genreName, normalizedSearch))
       );
     }
     return sortVarieties(result, sort);

--- a/mobile/src/utils/string.ts
+++ b/mobile/src/utils/string.ts
@@ -1,0 +1,19 @@
+// Normalizes a string for case-insensitive search across both Turkish and English.
+// Turkish locale rules: İ→i (dotted), I→ı (dotless). After applying tr-TR lowercase,
+// we also replace ı→i so that "Istanbul" (plain I) and "İstanbul" (dotted İ) both
+// normalize to "istanbul" and match the same query.
+function foldForSearch(s: string): string {
+  return s.toLocaleLowerCase('tr-TR').replace(/ı/g, 'i');
+}
+
+export function searchStartsWith(text: string, query: string): boolean {
+  return foldForSearch(text).startsWith(foldForSearch(query));
+}
+
+export function searchIncludes(text: string, query: string): boolean {
+  return foldForSearch(text).includes(foldForSearch(query));
+}
+
+export function searchEquals(a: string, b: string): boolean {
+  return foldForSearch(a) === foldForSearch(b);
+}


### PR DESCRIPTION
## What does this PR do?
Adds a `utils/string.ts` module with locale-aware search comparison helpers (`searchStartsWith`, `searchIncludes`, `searchEquals`) and replaces all client-side `.toLowerCase()` comparisons in search and filter logic with these helpers.

Investigation showed that Turkish character input and display were already working correctly in the app — the originally reported issue turned out to be APK-specific and unrelated to the codebase. However, during the investigation a separate search accuracy bug was identified: standard JS `.toLowerCase()` does not correctly handle Turkish `İ` (dotted uppercase I), causing queries like "ist" to miss results like "İstanbul". This PR fixes that.

The fix normalizes both sides with `tr-TR` locale and unifies `ı→i` so that both "İstanbul" and "Istanbul" match the same query without breaking English searches.

## How to test
1. Open the Search screen, type "ist" — both "İstanbul" and "Istanbul" entries should appear in results.
2. In recipe creation, type a Turkish ingredient name starting with "İ" or "ı" — autocomplete suggestions should match correctly.
3. Verify English searches are unaffected: typing "comm" should still match "Community".

## Related issue
Closes #404
