### PR TITLE
[Mobile/Fix] Fix parse modal flicker on Android

### DIFF
--- a/mobile/src/components/create-basic/RecipeParseModal.tsx
+++ b/mobile/src/components/create-basic/RecipeParseModal.tsx
@@ -155,7 +155,7 @@ export function RecipeParseModal({ visible, onClose, onApplied }: Props) {
 
         <KeyboardAvoidingView
           style={styles.keyboardContainer}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
           pointerEvents="box-none"
         >
           <View style={styles.sheet}>


### PR DESCRIPTION
## What does this PR do?
Fixes the flickering in the recipe parse ("Paste Text") modal on Android. The modal was jumping/flickering both on keyboard focus and while typing, because `KeyboardAvoidingView` with `behavior="height"` was conflicting with Android's native keyboard avoidance mechanism. Setting `behavior` to `undefined` on Android lets the OS handle keyboard adjustment natively without interference.

## How to test
1. Open the Create tab on an Android device/APK
2. Tap "Paste Text"
3. Tap the text input field
4. Verify the modal no longer flickers when the keyboard appears or while typing

## Related issue
Closes #395 