### PR TITLE
[Mobile/Feature] Display recipe tags as tappable chips on detail screen

### DIFF
--- a/mobile/src/__tests__/SearchScreen.test.tsx
+++ b/mobile/src/__tests__/SearchScreen.test.tsx
@@ -14,7 +14,7 @@ jest.mock('react-native-safe-area-context', () => ({
 }));
 
 const mockNavigate = jest.fn();
-const mockRouteParams: { initialQuery?: string } = {};
+const mockRouteParams: { initialQuery?: string; initialTagName?: string; initialAllergenName?: string } = {};
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
@@ -34,10 +34,12 @@ import {
   fetchSearchGenres,
   searchDishVarieties,
   fetchDiscoveryRecipes,
+  fetchDietaryTags,
 } from '../api/search';
 const mockFetchGenres = fetchSearchGenres as jest.MockedFunction<typeof fetchSearchGenres>;
 const mockSearchVarietiesFn = searchDishVarieties as jest.MockedFunction<typeof searchDishVarieties>;
 const mockFetchDiscovery = fetchDiscoveryRecipes as jest.MockedFunction<typeof fetchDiscoveryRecipes>;
+const mockFetchDietaryTags = fetchDietaryTags as jest.MockedFunction<typeof fetchDietaryTags>;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -81,9 +83,12 @@ describe('SearchScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouteParams.initialQuery = undefined;
+    mockRouteParams.initialTagName = undefined;
+    mockRouteParams.initialAllergenName = undefined;
     mockFetchGenres.mockResolvedValue(mockSearchGenres);
     mockSearchVarietiesFn.mockResolvedValue(mockSearchVarieties);
     mockFetchDiscovery.mockResolvedValue(mockRecipes);
+    mockFetchDietaryTags.mockResolvedValue([]);
   });
 
   // ─── Default state ─────────────────────────────────────────────────────────
@@ -130,6 +135,34 @@ describe('SearchScreen', () => {
       const result = render(<SearchScreen />);
       await act(async () => { await new Promise((r) => setTimeout(r, 400)); });
       expect(result.getByDisplayValue('Soups')).toBeTruthy();
+    });
+  });
+
+  // ─── initialTagName / initialAllergenName from route params ──────────────
+
+  describe('initialTagName from route params', () => {
+    it('fetches dietary tags on mount when initialTagName is set', async () => {
+      mockRouteParams.initialTagName = 'VEGAN';
+      mockFetchDietaryTags.mockResolvedValue([{ id: 7, name: 'Vegan', category: 'dietary' }]);
+      const result = render(<SearchScreen />);
+      await act(async () => { await new Promise((r) => setTimeout(r, 400)); });
+      expect(mockFetchDietaryTags).toHaveBeenCalled();
+      result.unmount();
+    });
+
+    it('passes matched dietaryTagId to fetchDiscoveryRecipes when initialTagName matches', async () => {
+      mockRouteParams.initialTagName = 'VEGAN';
+      mockFetchDietaryTags.mockResolvedValue([{ id: 7, name: 'Vegan', category: 'dietary' }]);
+      render(<SearchScreen />);
+      await act(async () => { await new Promise((r) => setTimeout(r, 400)); });
+      expect(mockFetchDiscovery).toHaveBeenCalledWith(
+        expect.objectContaining({ dietaryTagIds: [7] })
+      );
+    });
+
+    it('does not fetch dietary tags when no initial tag params are set', async () => {
+      await renderAndFlush();
+      expect(mockFetchDietaryTags).not.toHaveBeenCalled();
     });
   });
 

--- a/mobile/src/components/recipe-detail/RecipeDetailScreen.tsx
+++ b/mobile/src/components/recipe-detail/RecipeDetailScreen.tsx
@@ -97,6 +97,13 @@ export function RecipeDetailScreen({ recipeId }: RecipeDetailScreenProps) {
           tags={recipe.tags}
           allergens={recipe.allergens}
           onAuthorPress={() => Alert.alert('Profile', t('common.comingSoon'))}
+          onTagPress={(tag, type) => {
+            if (type === 'dietary') {
+              navigation.navigate('SearchTab', { screen: 'Search', params: { initialTagName: tag } });
+            } else {
+              navigation.navigate('SearchTab', { screen: 'Search', params: { initialAllergenName: tag } });
+            }
+          }}
         />
 
         {recipe.story ? <StoryCard story={recipe.story} /> : null}

--- a/mobile/src/components/recipe-detail/RecipeHeader.tsx
+++ b/mobile/src/components/recipe-detail/RecipeHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { User } from '../../types/user';
 import type { RecipeType } from '../../types/common';
@@ -19,6 +19,7 @@ interface RecipeHeaderProps {
   tags: string[];
   allergens: string[];
   onAuthorPress?: () => void;
+  onTagPress?: (tag: string, type: 'dietary' | 'allergen') => void;
 }
 
 const dietaryTagColors: Record<string, string> = {
@@ -47,6 +48,7 @@ export function RecipeHeader({
   tags,
   allergens,
   onAuthorPress,
+  onTagPress,
 }: RecipeHeaderProps) {
   const { t } = useTranslation('common');
   const [bookmarked, setBookmarked] = useState(false);
@@ -88,18 +90,30 @@ export function RecipeHeader({
       {(tags.length > 0 || allergens.length > 0) && (
         <View style={styles.tagRow}>
           {tags.map((tag) => (
-            <Badge
+            <Pressable
               key={tag}
-              label={formatTagLabel(tag)}
-              backgroundColor={dietaryTagColors[tag] ?? '#586330'}
-            />
+              onPress={() => onTagPress?.(tag, 'dietary')}
+              accessibilityRole="button"
+              accessibilityLabel={formatTagLabel(tag)}
+            >
+              <Badge
+                label={formatTagLabel(tag)}
+                backgroundColor={dietaryTagColors[tag] ?? '#586330'}
+              />
+            </Pressable>
           ))}
           {allergens.map((allergen) => (
-            <Badge
+            <Pressable
               key={allergen}
-              label={formatTagLabel(allergen)}
-              backgroundColor={allergenTagColor}
-            />
+              onPress={() => onTagPress?.(allergen, 'allergen')}
+              accessibilityRole="button"
+              accessibilityLabel={formatTagLabel(allergen)}
+            >
+              <Badge
+                label={formatTagLabel(allergen)}
+                backgroundColor={allergenTagColor}
+              />
+            </Pressable>
           ))}
         </View>
       )}

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -19,7 +19,7 @@ export type HomeStackParamList = {
 };
 
 export type SearchStackParamList = {
-  Search: { initialQuery?: string } | undefined;
+  Search: { initialQuery?: string; initialTagName?: string; initialAllergenName?: string } | undefined;
   DishVarietyDetail: { id: number };
   RecipeDetail: { recipeId: string };
 };

--- a/mobile/src/screens/SearchScreen.tsx
+++ b/mobile/src/screens/SearchScreen.tsx
@@ -16,6 +16,7 @@ import {
   searchDishVarieties,
   fetchSearchGenres,
   fetchDiscoveryRecipes,
+  fetchDietaryTags,
   type DishVarietyResult,
   type Recipe,
   type SortOption,
@@ -108,6 +109,46 @@ export function SearchScreen() {
         setAllVarieties(vars);
       })
       .finally(() => setInitialLoading(false));
+  }, []);
+
+  // ── Apply initial tag/allergen filter from navigation params (tag chip press) ─
+  useEffect(() => {
+    const tagName = route.params?.initialTagName;
+    const allergenName = route.params?.initialAllergenName;
+    if (!tagName && !allergenName) return;
+    fetchDietaryTags().then((allTags) => {
+      const normalize = (code: string) =>
+        code.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()).toLowerCase();
+      setFilters((prev) => {
+        let next = { ...prev };
+        if (tagName) {
+          const match = allTags.find(
+            (t) => t.category === 'dietary' && t.name.toLowerCase() === normalize(tagName)
+          );
+          if (match) {
+            next = {
+              ...next,
+              dietaryTagIds: [match.id],
+              dietaryTagNames: [match.name],
+            };
+          }
+        }
+        if (allergenName) {
+          const match = allTags.find(
+            (t) => t.category === 'allergen' && t.name.toLowerCase() === normalize(allergenName)
+          );
+          if (match) {
+            next = {
+              ...next,
+              excludeAllergenIds: [match.id],
+              excludeAllergenNames: [match.name],
+            };
+          }
+        }
+        return next;
+      });
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ── Debounce search input ─────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Renders all recipe tags (dietary labels) and allergens as tappable chip/badge components on the recipe detail screen. Tapping a chip navigates to the Search/Discovery screen with that tag pre-applied as a filter.

## How to test

1. Open any recipe that has tags or allergens (e.g. a VEGAN or GLUTEN_FREE recipe).
2. Verify the tag chips appear below the recipe type/region badges.
3. Tap a dietary tag chip → should navigate to the Search tab with that dietary filter active (recipes list filtered accordingly).
4. Tap an allergen chip → should navigate to the Search tab with that allergen excluded.
5. Open a recipe with no tags → verify the tag row is not rendered (empty state handled).

## Related issue

Closes #426