### PR TITLE
[Frontend/Task] Add favorites UI on web (#417)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -160,7 +160,10 @@
     "statDraft": "Drafts",
     "recentRecipes": "Recent Recipes",
     "seeAll": "See all {{count}} recipes",
-    "noRecipes": "No recipes yet. Start creating!"
+    "noRecipes": "No recipes yet. Start creating!",
+    "favorites": "Favorites",
+    "noFavorites": "No favorites yet. Explore recipes!",
+    "seeAllFavorites": "See all {{count}} favorites"
   },
   "home": {
     "featured": "Featured Recipe",

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -160,7 +160,10 @@
     "statDraft": "Taslak",
     "recentRecipes": "Son Tarifler",
     "seeAll": "Tüm {{count}} tarifi gör",
-    "noRecipes": "Henüz tarif yok. Oluşturmaya başla!"
+    "noRecipes": "Henüz tarif yok. Oluşturmaya başla!",
+    "favorites": "Favorilerim",
+    "noFavorites": "Henüz favori yok. Tarifleri keşfet!",
+    "seeAllFavorites": "Tüm {{count}} favoriyi gör"
   },
   "home": {
     "featured": "Öne Çıkan Tarif",

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAppSelector } from '@/store/hooks'
 import { recipeService, type MyRecipeSummary } from '@/services/recipe-service'
+import { favoriteService, type FavoriteRecipe } from '@/services/favorite-service'
 import './ProfilePage.css'
 
 function StarIcon() {
@@ -20,6 +21,9 @@ export function ProfilePage() {
 
   const [recipes, setRecipes] = useState<MyRecipeSummary[]>([])
   const [recipesLoading, setRecipesLoading] = useState(true)
+  const [favorites, setFavorites] = useState<FavoriteRecipe[]>([])
+  const [favoritesTotal, setFavoritesTotal] = useState(0)
+  const [favoritesLoading, setFavoritesLoading] = useState(true)
 
   useEffect(() => {
     let cancelled = false
@@ -27,6 +31,20 @@ export function ProfilePage() {
       .then((data) => { if (!cancelled) setRecipes(data) })
       .catch(() => { if (!cancelled) setRecipes([]) })
       .finally(() => { if (!cancelled) setRecipesLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    favoriteService.list(1, 5)
+      .then((data) => {
+        if (!cancelled) {
+          setFavorites(data.recipes)
+          setFavoritesTotal(data.pagination.total)
+        }
+      })
+      .catch(() => { if (!cancelled) setFavorites([]) })
+      .finally(() => { if (!cancelled) setFavoritesLoading(false) })
     return () => { cancelled = true }
   }, [])
 
@@ -134,6 +152,57 @@ export function ProfilePage() {
 
       {!recipesLoading && recipes.length === 0 && (
         <p className="profile-page__empty">{t('profileScreen.noRecipes')}</p>
+      )}
+
+      {/* ── Favorites ── */}
+      {!favoritesLoading && favorites.length > 0 && (
+        <section className="profile-page__section">
+          <h2 className="profile-page__section-title">{t('profileScreen.favorites')}</h2>
+          <div className="profile-page__recipe-list">
+            {favorites.map((recipe) => (
+              <button
+                key={recipe.id}
+                type="button"
+                className="profile-page__recipe-card"
+                onClick={() => navigate(`/recipes/${recipe.id}`)}
+              >
+                <div className="profile-page__recipe-thumb">
+                  {recipe.coverImageUrl
+                    ? <img src={recipe.coverImageUrl} alt={recipe.title} loading="lazy" />
+                    : <div className="profile-page__recipe-placeholder" />
+                  }
+                </div>
+                <div className="profile-page__recipe-body">
+                  <p className="profile-page__recipe-title">{recipe.title}</p>
+                  <div className="profile-page__recipe-meta">
+                    <span className={`profile-page__type profile-page__type--${recipe.type}`}>
+                      {t(recipe.type === 'cultural' ? 'library.typeCultural' : 'library.typeCommunity')}
+                    </span>
+                    {recipe.averageRating !== null && (
+                      <span className="profile-page__rating">
+                        <StarIcon />
+                        {recipe.averageRating.toFixed(1)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+          {favoritesTotal > 5 && (
+            <button
+              type="button"
+              className="profile-page__see-all"
+              onClick={() => navigate('/library?tab=favorites')}
+            >
+              {t('profileScreen.seeAllFavorites', { count: favoritesTotal })}
+            </button>
+          )}
+        </section>
+      )}
+
+      {!favoritesLoading && favorites.length === 0 && (
+        <p className="profile-page__empty">{t('profileScreen.noFavorites')}</p>
       )}
     </div>
   )

--- a/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
+++ b/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
@@ -5,6 +5,7 @@ import { isAxiosError } from 'axios'
 import { recipeService, type RecipeDetail, type RecipeIngredient, type ScaledRecipeIngredient } from '@/services/recipe-service'
 import { ingredientService, type IngredientSubstitution } from '@/services/ingredient-service'
 import { ratingService } from '@/services/rating-service'
+import { favoriteService } from '@/services/favorite-service'
 import { RecipeRating } from '@/components/RecipeRating/RecipeRating'
 import { ConfirmModal } from '@/components/ConfirmModal/ConfirmModal'
 import { useAppSelector } from '@/store/hooks'
@@ -158,6 +159,7 @@ export function RecipeDetailPage() {
     const b = recipe.servingSize && recipe.servingSize > 0 ? recipe.servingSize : 4
     setServings(b)
     setScaledIngredients(null)
+    setFavorited(recipe.isFavorited ?? false)
   }, [recipe])
 
   // When servings changes, call the scale API (skip if same as base or no base serving size)
@@ -241,6 +243,31 @@ export function RecipeDetailPage() {
     }
   }, [id, recipe, t])
 
+  async function handleFavoriteToggle() {
+    if (!isAuthenticated) {
+      navigate('/login')
+      return
+    }
+    if (!recipe) return
+
+    const prev = favorited
+    setFavorited(!prev)
+
+    try {
+      if (prev) {
+        await favoriteService.remove(recipe.id)
+      } else {
+        await favoriteService.add(recipe.id)
+      }
+    } catch (err) {
+      setFavorited(prev)
+      // 409: already favorited — keep filled
+      if (isAxiosError(err) && err.response?.status === 409) {
+        setFavorited(true)
+      }
+    }
+  }
+
   const handleShare = async () => {
     const url = typeof window !== 'undefined' ? window.location.href : ''
     try {
@@ -312,7 +339,7 @@ export function RecipeDetailPage() {
             <button
               type="button"
               className="recipe-detail__hero-btn"
-              onClick={() => setFavorited((v) => !v)}
+              onClick={() => void handleFavoriteToggle()}
               aria-pressed={favorited}
               aria-label={t('recipeDetail.favoriteAria')}
             >

--- a/frontend/src/services/favorite-service.ts
+++ b/frontend/src/services/favorite-service.ts
@@ -1,0 +1,24 @@
+import { httpClient } from '@/lib/http-client'
+
+interface ApiEnvelope<T> {
+  success: boolean
+  data: T
+  error: null
+}
+
+interface AddFavoriteRow {
+  recipeId: string
+  favorited: boolean
+}
+
+export const favoriteService = {
+  async add(recipeId: string): Promise<void> {
+    await httpClient.post<ApiEnvelope<AddFavoriteRow>>(
+      `/users/me/favorites/${recipeId}`
+    )
+  },
+
+  async remove(recipeId: string): Promise<void> {
+    await httpClient.delete(`/users/me/favorites/${recipeId}`)
+  },
+}

--- a/frontend/src/services/favorite-service.ts
+++ b/frontend/src/services/favorite-service.ts
@@ -11,6 +11,24 @@ interface AddFavoriteRow {
   favorited: boolean
 }
 
+export interface FavoriteRecipe {
+  id: string
+  title: string
+  type: 'cultural' | 'community'
+  averageRating: number | null
+  ratingCount: number
+  creatorUsername: string | null
+  dishVarietyName: string | null
+  genreName: string | null
+  coverImageUrl: string | null
+  createdAt: string
+}
+
+interface FavoritesData {
+  recipes: FavoriteRecipe[]
+  pagination: { page: number; limit: number; total: number }
+}
+
 export const favoriteService = {
   async add(recipeId: string): Promise<void> {
     await httpClient.post<ApiEnvelope<AddFavoriteRow>>(
@@ -20,5 +38,13 @@ export const favoriteService = {
 
   async remove(recipeId: string): Promise<void> {
     await httpClient.delete(`/users/me/favorites/${recipeId}`)
+  },
+
+  async list(page = 1, limit = 20): Promise<FavoritesData> {
+    const { data } = await httpClient.get<ApiEnvelope<FavoritesData>>(
+      '/users/me/favorites',
+      { params: { page, limit } }
+    )
+    return data.data
   },
 }

--- a/frontend/src/services/recipe-service.ts
+++ b/frontend/src/services/recipe-service.ts
@@ -61,6 +61,7 @@ export interface RecipeDetail {
   media: RecipeMedia[]
   createdAt: string
   updatedAt: string
+  isFavorited: boolean
 }
 
 export interface UpdateRecipePayload {
@@ -184,6 +185,7 @@ export const recipeService = {
       district: d.district ?? null,
       createdAt: d.createdAt ?? '',
       updatedAt: d.updatedAt ?? '',
+      isFavorited: d.isFavorited ?? false,
     }
   },
 


### PR DESCRIPTION
## What changed?
- Created `favorite-service.ts` with `add()`, `remove()`, `list()` functions
- Added `isFavorited: boolean` to `RecipeDetail` type and normalizer
- Wired heart button on recipe detail page to API (optimistic update + rollback on error)
- Unauthenticated users are redirected to `/login` on heart button click
- Added "Favorites" section to profile page (first 5, pagination-aware)
- Added EN/TR i18n keys

## How to test?
1. Log in → open a recipe → click heart → Network should show `POST /users/me/favorites/:id` (201)
2. Click again → `DELETE /users/me/favorites/:id` (204)
3. Refresh the page → heart state should be preserved (loaded from API)
4. Click heart while logged out → should redirect to `/login`
5. Go to profile page → favorited recipe should appear in "Favorites" section

## Related issue
Closes #417
