### PR TITLE
Add one-comment-per-user limit and score to comments response

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -101,7 +101,7 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - **recipe_media** — `id`, `recipe_id` (FK), `url`, `type` (image|video), `created_at`
 - **ratings** — `id`, `recipe_id` (FK), `user_id` (FK profiles), `score` (1-5), `created_at`, `updated_at` — unique constraint on (recipe_id, user_id)
 - **recipe_dietary_tags** — `recipe_id` (FK recipes), `tag_id` (FK dietary_tags) — composite PK
-- **comments** — `id` (serial PK), `recipe_id` (FK recipes ON DELETE CASCADE), `user_id` (FK profiles ON DELETE CASCADE), `text` (1–2000 chars, CHECK), `created_at`, `updated_at` (nullable). Indexed on `recipe_id`, `user_id`, and `(recipe_id, created_at DESC)`. The API exposes the column as `body`; the route maps `body` ↔ `text` at the DB boundary.
+- **comments** — `id` (serial PK), `recipe_id` (FK recipes ON DELETE CASCADE), `user_id` (FK profiles ON DELETE CASCADE), `text` (1–2000 chars, CHECK), `created_at`, `updated_at` (nullable). Indexed on `recipe_id`, `user_id`, and `(recipe_id, created_at DESC)`. **Unique constraint on `(recipe_id, user_id)`** — one comment per user per recipe; the API enforces this with a pre-insert existence check and also maps Postgres `unique_violation` (23505) on insert to 409 `COMMENT_ALREADY_EXISTS` to handle the race window. The API exposes the column as `body`; the route maps `body` ↔ `text` at the DB boundary.
 
 ### Reference Tables
 
@@ -208,19 +208,20 @@ Database is managed via Supabase (no migration files in repo). Key tables:
   - Returns distinct unit values from `recipe_ingredients`; without `search`, returns all known units; supports autocomplete use case
 
 ### Comments (`/recipes/:id/comments`, `/comments/:id`)
-Comments are coupled to ratings (Amazon-style): a non-creator must have a rating on the recipe to comment, but rating is allowed without commenting.
+Comments are coupled to ratings (Amazon-style): a non-creator must have a rating on the recipe to comment, but rating is allowed without commenting. Each user is limited to **one comment per recipe** — to revise, they edit their existing comment via `PATCH /comments/:id`.
 
 - `POST /recipes/:id/comments` — Create a comment on a recipe (auth required, #419)
   - Body: `{ body: string, score?: number }` — `body` is 1–2000 chars (trimmed); `score` is an optional integer 1–5
   - If `score` is provided, upserts the user's rating on the recipe in the same call
   - If `score` is omitted, requires an existing rating from the user; otherwise returns 400 `RATING_REQUIRED`
+  - Returns 409 `COMMENT_ALREADY_EXISTS` if the user already has a comment on the recipe (the existence check runs before rating side-effects, so a rejected request never mutates the rating)
   - Recipe creators may comment on their own recipe without a rating; passing a `score` as the creator returns 403 (self-rating forbidden, mirroring `POST /recipes/:id/ratings`)
   - Returns 404 if the recipe does not exist
   - Response: `{ comment: {...}, rating: {...} | null }`
 - `GET /recipes/:id/comments` — List comments on a recipe with pagination (public)
   - Query params: `page` (default 1), `limit` (default 20, max 100)
   - Ordered by `created_at` descending (newest first)
-  - Each comment includes the author's `username` (joined from `profiles`)
+  - Each comment includes the author's `username` (joined from `profiles`) and the author's `score` for this recipe (joined from `ratings`, `null` if no rating row — e.g. for the recipe creator)
 - `PATCH /comments/:id` — Edit own comment (auth required, author only)
   - Body: `{ body: string }` (1–2000 chars, trimmed)
   - Returns 403 if the caller is not the author, 404 if the comment does not exist
@@ -273,6 +274,7 @@ Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/r
 - `NOT_FOUND` (404) — Resource not found
 - `CONFLICT` (409) — Duplicate username/email, already published
 - `RATING_REQUIRED` (400) — Comment attempted without a rating on the recipe
+- `COMMENT_ALREADY_EXISTS` (409) — User attempted to post a second comment on the same recipe (must edit instead)
 - `INCOMPLETE_RECIPE` (400) — Missing fields for publish
 - `PARSE_FAILED` (500) — AI parsing of recipe text failed
 - `STANDARDIZATION_FAILED` (500) — AI unit standardization failed

--- a/backend/src/__tests__/comments.test.ts
+++ b/backend/src/__tests__/comments.test.ts
@@ -155,9 +155,15 @@ describe("POST /recipes/:id/comments", () => {
   });
 
   it("returns 400 RATING_REQUIRED when no score and no existing rating", async () => {
+    let commentsCallCount = 0;
     setupAuthAndTables("cook", "profile-123", (table) => {
       if (table === "recipes")
         return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "comments") {
+        commentsCallCount++;
+        // First call is the existence check; no prior comment from this user.
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      }
       if (table === "ratings")
         return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
       return chainable({ data: null, error: null });
@@ -170,17 +176,26 @@ describe("POST /recipes/:id/comments", () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe("RATING_REQUIRED");
+    expect(commentsCallCount).toBeGreaterThanOrEqual(1);
   });
 
   it("returns 201 when score is provided (upserts rating + creates comment)", async () => {
     const ratingsMock = chainable({ data: okRating, error: null });
-    const commentsMock = chainable({ data: okComment, error: null });
+    let commentsCallCount = 0;
+    const insertMock = chainable({ data: okComment, error: null });
 
     setupAuthAndTables("cook", "profile-123", (table) => {
       if (table === "recipes")
         return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
       if (table === "ratings") return ratingsMock;
-      if (table === "comments") return commentsMock;
+      if (table === "comments") {
+        commentsCallCount++;
+        if (commentsCallCount === 1) {
+          // existence check — no prior comment
+          return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+        }
+        return insertMock;
+      }
       return chainable({ data: null, error: null });
     });
 
@@ -210,11 +225,18 @@ describe("POST /recipes/:id/comments", () => {
   });
 
   it("returns 201 when no score but existing rating found", async () => {
+    let commentsCallCount = 0;
     setupAuthAndTables("cook", "profile-123", (table) => {
       if (table === "recipes")
         return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
       if (table === "ratings") return chainable({ data: okRating, error: null });
-      if (table === "comments") return chainable({ data: okComment, error: null });
+      if (table === "comments") {
+        commentsCallCount++;
+        if (commentsCallCount === 1) {
+          return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+        }
+        return chainable({ data: okComment, error: null });
+      }
       return chainable({ data: null, error: null });
     });
 
@@ -245,10 +267,17 @@ describe("POST /recipes/:id/comments", () => {
   });
 
   it("returns 201 when creator comments on own recipe without a score (no rating required)", async () => {
+    let commentsCallCount = 0;
     setupAuthAndTables("cook", "profile-123", (table) => {
       if (table === "recipes")
         return chainable({ data: { id: "recipe-1", creator_id: "profile-123" }, error: null });
-      if (table === "comments") return chainable({ data: okComment, error: null });
+      if (table === "comments") {
+        commentsCallCount++;
+        if (commentsCallCount === 1) {
+          return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+        }
+        return chainable({ data: okComment, error: null });
+      }
       return chainable({ data: null, error: null });
     });
 
@@ -262,12 +291,89 @@ describe("POST /recipes/:id/comments", () => {
     expect(res.body.data.rating).toBeNull();
   });
 
-  it("returns 500 on db error during comment insert", async () => {
+  it("returns 409 COMMENT_ALREADY_EXISTS when the user has already commented", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "comments")
+        return chainable({ data: { id: "existing-comment" }, error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Trying to comment a second time" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("COMMENT_ALREADY_EXISTS");
+  });
+
+  it("returns 409 COMMENT_ALREADY_EXISTS even when a score is provided", async () => {
+    const ratingsMock = chainable({ data: okRating, error: null });
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "comments")
+        return chainable({ data: { id: "existing-comment" }, error: null });
+      if (table === "ratings") return ratingsMock;
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Trying again with a score", score: 5 });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("COMMENT_ALREADY_EXISTS");
+    // Rating must not be touched when the comment is rejected up front.
+    expect(ratingsMock.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the INSERT hits the DB unique constraint (race with concurrent insert)", async () => {
+    let commentsCallCount = 0;
     setupAuthAndTables("cook", "profile-123", (table) => {
       if (table === "recipes")
         return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
       if (table === "ratings") return chainable({ data: okRating, error: null });
-      if (table === "comments") return chainable({ data: null, error: { message: "DB timeout" } });
+      if (table === "comments") {
+        commentsCallCount++;
+        if (commentsCallCount === 1) {
+          // Existence check — no prior comment yet (concurrent request hasn't committed).
+          return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+        }
+        // INSERT loses the race; Postgres surfaces unique_violation.
+        return chainable({
+          data: null,
+          error: { code: "23505", message: 'duplicate key value violates unique constraint "comments_recipe_user_unique"' },
+        });
+      }
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/comments")
+      .set("Authorization", "Bearer valid_token")
+      .send({ body: "Racing in" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("COMMENT_ALREADY_EXISTS");
+  });
+
+  it("returns 500 on db error during comment insert", async () => {
+    let commentsCallCount = 0;
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "ratings") return chainable({ data: okRating, error: null });
+      if (table === "comments") {
+        commentsCallCount++;
+        if (commentsCallCount === 1) {
+          return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+        }
+        return chainable({ data: null, error: { message: "DB timeout" } });
+      }
       return chainable({ data: null, error: null });
     });
 
@@ -284,6 +390,8 @@ describe("POST /recipes/:id/comments", () => {
     setupAuthAndTables("cook", "profile-123", (table) => {
       if (table === "recipes")
         return chainable({ data: { id: "recipe-1", creator_id: "creator-999" }, error: null });
+      if (table === "comments")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
       if (table === "ratings") return chainable({ data: null, error: { message: "DB timeout" } });
       return chainable({ data: null, error: null });
     });
@@ -303,17 +411,30 @@ describe("POST /recipes/:id/comments", () => {
 describe("GET /recipes/:id/comments", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  const setupListMock = (data: any, error: any = null, count: number | null = null) => {
-    const chain: any = {};
-    chain.select = jest.fn().mockReturnValue(chain);
-    chain.eq = jest.fn().mockReturnValue(chain);
-    chain.order = jest.fn().mockReturnValue(chain);
-    chain.range = jest.fn().mockResolvedValue({ data, error, count });
+  const setupListMock = (
+    data: any,
+    error: any = null,
+    count: number | null = null,
+    ratings: { user_id: string; score: number }[] = [],
+    ratingsError: any = null
+  ) => {
+    const commentsChain: any = {};
+    commentsChain.select = jest.fn().mockReturnValue(commentsChain);
+    commentsChain.eq = jest.fn().mockReturnValue(commentsChain);
+    commentsChain.order = jest.fn().mockReturnValue(commentsChain);
+    commentsChain.range = jest.fn().mockResolvedValue({ data, error, count });
+
+    const ratingsChain: any = {};
+    ratingsChain.select = jest.fn().mockReturnValue(ratingsChain);
+    ratingsChain.eq = jest.fn().mockReturnValue(ratingsChain);
+    ratingsChain.in = jest.fn().mockResolvedValue({ data: ratings, error: ratingsError });
+
     (supabase.from as jest.Mock).mockImplementation((table) => {
-      if (table === "comments") return chain;
+      if (table === "comments") return commentsChain;
+      if (table === "ratings") return ratingsChain;
       return {};
     });
-    return chain;
+    return { commentsChain, ratingsChain };
   };
 
   const sampleComments = [
@@ -338,7 +459,10 @@ describe("GET /recipes/:id/comments", () => {
   ];
 
   it("returns 200 with paginated comments", async () => {
-    setupListMock(sampleComments, null, 2);
+    setupListMock(sampleComments, null, 2, [
+      { user_id: "profile-2", score: 5 },
+      { user_id: "profile-1", score: 4 },
+    ]);
     const res = await request(app).get("/recipes/recipe-1/comments");
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -346,8 +470,8 @@ describe("GET /recipes/:id/comments", () => {
     expect(res.body.data.pagination).toMatchObject({ page: 1, limit: 20, total: 2 });
   });
 
-  it("returns the response shape with username from joined profile", async () => {
-    setupListMock([sampleComments[0]], null, 1);
+  it("returns the response shape with username and score from joined data", async () => {
+    setupListMock([sampleComments[0]], null, 1, [{ user_id: "profile-2", score: 5 }]);
     const res = await request(app).get("/recipes/recipe-1/comments");
     expect(res.status).toBe(200);
     expect(res.body.data.comments[0]).toMatchObject({
@@ -356,22 +480,50 @@ describe("GET /recipes/:id/comments", () => {
       userId: "profile-2",
       username: "ayse",
       body: "Made this yesterday — turned out great.",
+      score: 5,
     });
   });
 
-  it("supports pagination query params", async () => {
-    const chain = setupListMock([], null, 0);
-    const res = await request(app).get("/recipes/recipe-1/comments?page=2&limit=5");
+  it("returns null score for commenters who have no rating (e.g. recipe creator)", async () => {
+    // Two comments, but only one user has a rating row.
+    setupListMock(sampleComments, null, 2, [{ user_id: "profile-1", score: 3 }]);
+    const res = await request(app).get("/recipes/recipe-1/comments");
     expect(res.status).toBe(200);
-    expect(chain.range).toHaveBeenCalledWith(5, 9);
+    const byId: Record<string, any> = Object.fromEntries(
+      res.body.data.comments.map((c: any) => [c.id, c])
+    );
+    expect(byId["c2"].score).toBeNull();
+    expect(byId["c1"].score).toBe(3);
   });
 
-  it("returns empty array when recipe has no comments", async () => {
-    setupListMock([], null, 0);
+  it("queries ratings only by the user_ids in the comment list and the recipe id", async () => {
+    const { ratingsChain } = setupListMock(sampleComments, null, 2, [
+      { user_id: "profile-1", score: 4 },
+      { user_id: "profile-2", score: 5 },
+    ]);
+    await request(app).get("/recipes/recipe-1/comments");
+    expect(ratingsChain.eq).toHaveBeenCalledWith("recipe_id", "recipe-1");
+    expect(ratingsChain.in).toHaveBeenCalledWith(
+      "user_id",
+      expect.arrayContaining(["profile-1", "profile-2"])
+    );
+  });
+
+  it("supports pagination query params", async () => {
+    const { commentsChain } = setupListMock([], null, 0);
+    const res = await request(app).get("/recipes/recipe-1/comments?page=2&limit=5");
+    expect(res.status).toBe(200);
+    expect(commentsChain.range).toHaveBeenCalledWith(5, 9);
+  });
+
+  it("returns empty array when recipe has no comments and skips ratings lookup", async () => {
+    const { ratingsChain } = setupListMock([], null, 0);
     const res = await request(app).get("/recipes/recipe-1/comments");
     expect(res.status).toBe(200);
     expect(res.body.data.comments).toHaveLength(0);
     expect(res.body.data.pagination.total).toBe(0);
+    // No commenters → no need to fetch ratings.
+    expect(ratingsChain.in).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid page param", async () => {
@@ -382,6 +534,13 @@ describe("GET /recipes/:id/comments", () => {
 
   it("returns 500 on database error", async () => {
     setupListMock(null, { message: "DB timeout" });
+    const res = await request(app).get("/recipes/recipe-1/comments");
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("returns 500 when the ratings lookup fails", async () => {
+    setupListMock(sampleComments, null, 2, [], { message: "ratings DB timeout" });
     const res = await request(app).get("/recipes/recipe-1/comments");
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe("DB_ERROR");

--- a/backend/src/routes/comments.ts
+++ b/backend/src/routes/comments.ts
@@ -80,7 +80,32 @@ router.post(
       return;
     }
 
-    // 3. Ensure a rating exists for non-creators (either provided in this call or already on file)
+    // 3. Enforce one comment per user per recipe — the user must edit instead of stacking
+    const { data: existingComment, error: existingCommentError } = await supabase
+      .from("comments")
+      .select("id")
+      .eq("recipe_id", recipeId)
+      .eq("user_id", user.profileId)
+      .single();
+
+    if (existingCommentError && existingCommentError.code !== "PGRST116") {
+      res.status(500).json(errorResponse("DB_ERROR", existingCommentError.message));
+      return;
+    }
+
+    if (existingComment) {
+      res
+        .status(409)
+        .json(
+          errorResponse(
+            "COMMENT_ALREADY_EXISTS",
+            "You have already commented on this recipe. Edit your existing comment instead."
+          )
+        );
+      return;
+    }
+
+    // 4. Ensure a rating exists for non-creators (either provided in this call or already on file)
     let rating: any = null;
 
     if (!isCreator) {
@@ -131,7 +156,7 @@ router.post(
       }
     }
 
-    // 4. Insert the comment
+    // 5. Insert the comment
     const { data: inserted, error: insertError } = await userClient
       .from("comments")
       .insert({
@@ -143,6 +168,19 @@ router.post(
       .single();
 
     if (insertError || !inserted) {
+      // Postgres unique_violation — the existence check above lost a race with a concurrent insert,
+      // or another path created a comment for this user. Map to the same 409 the existence check returns.
+      if (insertError?.code === "23505") {
+        res
+          .status(409)
+          .json(
+            errorResponse(
+              "COMMENT_ALREADY_EXISTS",
+              "You have already commented on this recipe. Edit your existing comment instead."
+            )
+          );
+        return;
+      }
       res
         .status(500)
         .json(errorResponse("DB_ERROR", insertError?.message ?? "Failed to create comment."));
@@ -210,12 +248,35 @@ router.get("/recipes/:id/comments", async (req: Request, res: Response): Promise
     return;
   }
 
+  // Fetch each commenter's rating on this recipe so the response includes the score alongside the body.
+  // Recipe creators are allowed to comment without a rating, so their score may legitimately be null.
+  const userIds = Array.from(new Set((data ?? []).map((c: any) => c.user_id)));
+  const ratingByUser: Record<string, number> = {};
+
+  if (userIds.length > 0) {
+    const { data: ratingsData, error: ratingsError } = await supabase
+      .from("ratings")
+      .select("user_id, score")
+      .eq("recipe_id", recipeId)
+      .in("user_id", userIds);
+
+    if (ratingsError) {
+      res.status(500).json(errorResponse("DB_ERROR", ratingsError.message));
+      return;
+    }
+
+    for (const r of ratingsData ?? []) {
+      ratingByUser[(r as any).user_id] = (r as any).score;
+    }
+  }
+
   const comments = (data ?? []).map((c: any) => ({
     id: c.id,
     recipeId: c.recipe_id,
     userId: c.user_id,
     username: c.author?.username ?? null,
     body: c.text,
+    score: ratingByUser[c.user_id] ?? null,
     createdAt: c.created_at,
     updatedAt: c.updated_at,
   }));


### PR DESCRIPTION
This pull request introduces and enforces a "one comment per user per recipe" rule in the comments API, ensuring that users must edit their existing comment instead of posting multiple comments on the same recipe. It adds both API-level and database-level protections, updates error handling, and expands test coverage to verify the new behavior. Additionally, the comments listing endpoint now includes each commenter's rating score for the recipe, if available.