### PR TITLE
feat(db): add en/tr language fields to data models (#412)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -64,9 +64,10 @@ backend/
 │   │   ├── comments.ts          # Recipe comments (create, list, delete)
 │   │   └── parse.ts             # Free-text recipe parser endpoint
 │   ├── types/
-│   │   └── index.ts             # TypeScript interfaces (roles, auth, response)
+│   │   └── index.ts             # TypeScript interfaces (roles, auth, response, SupportedLanguage)
 │   ├── utils/
-│   │   └── response.ts          # successResponse / errorResponse helpers
+│   │   ├── response.ts          # successResponse / errorResponse helpers
+│   │   └── i18n.ts              # parseLangParam, resolveLang — ?lang= query param helpers
 │   └── __tests__/               # Jest test suite
 │       ├── auth.test.ts
 │       ├── middleware.test.ts
@@ -105,13 +106,22 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 
 ### Reference Tables
 
-- **ingredients** — `id`, `name`
+- **ingredients** — `id`, `name`, `name_en`, `name_tr` (`name` mirrors `name_en` for backward compat; see migration 002)
 - **allergens** — `id`, `name`
 - **ingredient_allergens** — `ingredient_id` (FK), `allergen_id` (FK)
 - **ingredient_substitutions** — `id`, `ingredient_id` (FK ingredients), `substitute_id` (FK ingredients), `source_amount` NUMERIC(10,3), `source_unit` TEXT, `sub_amount` NUMERIC(10,3), `sub_unit` TEXT, `confidence` NUMERIC(3,2), `description` TEXT — unique on (ingredient_id, substitute_id), no self-substitution
-- **dietary_tags** — `id`, `name` (unique), `category` (dietary|allergen)
-- **dish_genres** — `id`, `name`, `description`
-- **dish_varieties** — `id`, `name`, `description`, `genre_id` (FK dish_genres)
+- **dietary_tags** — `id`, `name`, `name_en`, `name_tr`, `category` (dietary|allergen)
+- **dish_genres** — `id`, `name`, `name_en`, `name_tr`, `description`, `description_en`, `description_tr`
+- **dish_varieties** — `id`, `name`, `name_en`, `name_tr`, `description`, `description_en`, `description_tr`, `genre_id` (FK dish_genres)
+
+### Language Fields Convention (#412)
+
+All translatable reference fields follow the `<field>_en` / `<field>_tr` naming pattern.  
+Migration `002_en_tr_language_fields.sql` adds these columns and seeds `_en` from the existing value.
+
+- Without `?lang=`: endpoints return all fields including `_en` and `_tr`.
+- With `?lang=en` or `?lang=tr`: endpoints return a single resolved `name`/`description` (preferred language, falling back to the other if null).
+- Invalid `?lang=` values return 400 `VALIDATION_ERROR`.
 
 ### Database Triggers
 
@@ -151,14 +161,25 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 
 ### Dish Genres (`/dish-genres`)
 - `GET /dish-genres` — All genres with nested varieties
+  - Query params: `lang` (optional — "en" or "tr"; returns resolved `name`/`description` instead of `_en`/`_tr` pair)
+  - Without `lang`: each genre includes `name_en`, `name_tr`, `description_en`, `description_tr`; each nested variety includes `name_en`, `name_tr`
 
 ### Dish Varieties (`/dish-varieties`)
-- `GET /dish-varieties` — List varieties (optional: genreId, search filters)
+- `GET /dish-varieties` — List varieties (optional: genreId, search, lang filters)
+  - Query params: `genreId`, `search`, `lang` (optional — "en" or "tr")
+  - Without `lang`: response includes `name_en`, `name_tr`, `description_en`, `description_tr`
 - `GET /dish-varieties/:id` — Single variety with published recipes
+  - Query params: `lang` (optional — "en" or "tr")
 - `GET /dish-varieties/:id/recipes` — Variety recipes split into expertRecipe + communityRecipes
 
 ### Ingredients (`/ingredients`)
-- `GET /ingredients` — List all ingredients with allergens (optional: `?search=<string>`)
+- `GET /ingredients` — List all ingredients (optional: `?search=<string>`, `?lang=<en|tr>`)
+  - Without `lang`: response includes `name`, `name_en`, `name_tr`
+  - With `lang`: response includes only resolved `name` (preferred language, fallback to other)
+- `POST /ingredients` — Create a new ingredient (cook/expert only)
+  - Body: `{ name_en?: string, name_tr?: string }` — at least one field required
+  - Returns 409 if an ingredient with the same primary name already exists
+  - Stores `name_en` and `name_tr`; `name` column mirrors `name_en ?? name_tr` for backward compat
 - `GET /ingredients/:id/substitutions` — Get substitute suggestions for an ingredient (#274)
   - Query params: `amount` (optional, positive number), `unit` (optional, string — e.g. `gr`)
   - Without params: returns all substitutions with base amounts
@@ -169,6 +190,8 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 
 ### Dietary Tags (`/dietary-tags`)
 - `GET /dietary-tags` — List all supported dietary and allergen tags
+  - Query params: `lang` (optional — "en" or "tr")
+  - Without `lang`: response includes `name`, `name_en`, `name_tr`, `category`
 
 ### Discovery (`/discovery`)
 - `GET /discovery/recipes` — Filtered recipe discovery

--- a/backend/migrations/002_en_tr_language_fields.sql
+++ b/backend/migrations/002_en_tr_language_fields.sql
@@ -1,0 +1,41 @@
+-- Migration: Add EN/TR language fields to translatable reference tables
+-- Issue #412 — Update data models and migration for en/tr language fields
+
+-- ─── ingredients ─────────────────────────────────────────────────────────────
+ALTER TABLE ingredients
+  ADD COLUMN IF NOT EXISTS name_en text,
+  ADD COLUMN IF NOT EXISTS name_tr text;
+
+-- Seed English names from existing data
+UPDATE ingredients SET name_en = name WHERE name_en IS NULL;
+
+-- ─── dietary_tags ─────────────────────────────────────────────────────────────
+ALTER TABLE dietary_tags
+  ADD COLUMN IF NOT EXISTS name_en text,
+  ADD COLUMN IF NOT EXISTS name_tr text;
+
+UPDATE dietary_tags SET name_en = name WHERE name_en IS NULL;
+
+-- ─── dish_genres ─────────────────────────────────────────────────────────────
+ALTER TABLE dish_genres
+  ADD COLUMN IF NOT EXISTS name_en        text,
+  ADD COLUMN IF NOT EXISTS name_tr        text,
+  ADD COLUMN IF NOT EXISTS description_en text,
+  ADD COLUMN IF NOT EXISTS description_tr text;
+
+UPDATE dish_genres SET name_en = name WHERE name_en IS NULL;
+UPDATE dish_genres
+  SET description_en = description
+  WHERE description_en IS NULL AND description IS NOT NULL;
+
+-- ─── dish_varieties ───────────────────────────────────────────────────────────
+ALTER TABLE dish_varieties
+  ADD COLUMN IF NOT EXISTS name_en        text,
+  ADD COLUMN IF NOT EXISTS name_tr        text,
+  ADD COLUMN IF NOT EXISTS description_en text,
+  ADD COLUMN IF NOT EXISTS description_tr text;
+
+UPDATE dish_varieties SET name_en = name WHERE name_en IS NULL;
+UPDATE dish_varieties
+  SET description_en = description
+  WHERE description_en IS NULL AND description IS NOT NULL;

--- a/backend/src/__tests__/dietary-tags.test.ts
+++ b/backend/src/__tests__/dietary-tags.test.ts
@@ -21,6 +21,8 @@ const chainable = (resolved: { data: any; error: any }) => {
   return mock;
 };
 
+// ─── GET /dietary-tags (existing) ────────────────────────────────────────────
+
 describe("GET /dietary-tags", () => {
   beforeEach(() => jest.clearAllMocks());
 
@@ -64,5 +66,64 @@ describe("GET /dietary-tags", () => {
 
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /dietary-tags — language fields (#412) ──────────────────────────────
+
+describe("GET /dietary-tags — language fields (#412)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockTagsWithLang = [
+    { id: 1, name: "Halal", name_en: "Halal", name_tr: "Helal", category: "dietary" },
+    { id: 2, name: "Vegan", name_en: "Vegan", name_tr: null, category: "dietary" },
+  ];
+
+  it("returns name_en and name_tr in default response", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockTagsWithLang, error: null })
+    );
+
+    const res = await request(app).get("/dietary-tags");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].name_en).toBe("Halal");
+    expect(res.body.data[0].name_tr).toBe("Helal");
+    expect(res.body.data[0].category).toBe("dietary");
+  });
+
+  it("?lang=en returns resolved EN name without _en / _tr fields", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockTagsWithLang, error: null })
+    );
+
+    const res = await request(app).get("/dietary-tags?lang=en");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].name).toBe("Halal");
+    expect(res.body.data[0].name_en).toBeUndefined();
+    expect(res.body.data[0].name_tr).toBeUndefined();
+    expect(res.body.data[0].category).toBe("dietary");
+  });
+
+  it("?lang=tr returns resolved TR name and falls back to EN when TR is null", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockTagsWithLang, error: null })
+    );
+
+    const res = await request(app).get("/dietary-tags?lang=tr");
+
+    expect(res.status).toBe(200);
+    // First tag has TR name
+    expect(res.body.data[0].name).toBe("Helal");
+    // Second tag has no TR name → falls back to EN
+    expect(res.body.data[1].name).toBe("Vegan");
+  });
+
+  it("?lang=de returns 400 VALIDATION_ERROR", async () => {
+    const res = await request(app).get("/dietary-tags?lang=de");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
   });
 });

--- a/backend/src/__tests__/dish-genres.test.ts
+++ b/backend/src/__tests__/dish-genres.test.ts
@@ -1,0 +1,188 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: { from: mockFrom },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+const chainable = (resolved: { data: any; error: any }) => {
+  const mock: any = {};
+  const methods = ["select", "eq", "order"];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
+  return mock;
+};
+
+// ─── Mock data ────────────────────────────────────────────────────────────────
+
+const mockGenres = [
+  {
+    id: 1,
+    name: "Kebap",
+    name_en: "Kebab",
+    name_tr: "Kebap",
+    description: "Grilled meat dishes",
+    description_en: "Grilled meat dishes",
+    description_tr: "Izgara et yemekleri",
+  },
+  {
+    id: 2,
+    name: "Çorba",
+    name_en: "Soup",
+    name_tr: "Çorba",
+    description: "Soup dishes",
+    description_en: "Soup dishes",
+    description_tr: null,
+  },
+];
+
+const mockVarieties = [
+  { id: 1, genre_id: 1, name: "Adana Kebap", name_en: "Adana Kebab", name_tr: "Adana Kebap" },
+  { id: 2, genre_id: 2, name: "Mercimek", name_en: "Lentil Soup", name_tr: null },
+];
+
+const setupGenreMock = (genreData: any, varietyData: any) => {
+  (supabase.from as jest.Mock).mockImplementation((table: string) => {
+    if (table === "dish_genres") return chainable({ data: genreData, error: null });
+    if (table === "dish_varieties") return chainable({ data: varietyData, error: null });
+    return chainable({ data: null, error: null });
+  });
+};
+
+// ─── GET /dish-genres ─────────────────────────────────────────────────────────
+
+describe("GET /dish-genres", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns all genres with nested varieties", async () => {
+    setupGenreMock(mockGenres, mockVarieties);
+
+    const res = await request(app).get("/dish-genres");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].varieties).toHaveLength(1);
+    expect(res.body.data[0].varieties[0].name).toBe("Adana Kebap");
+    expect(res.body.data[1].varieties).toHaveLength(1);
+  });
+
+  it("returns name_en, name_tr, description_en, description_tr per genre", async () => {
+    setupGenreMock(mockGenres, mockVarieties);
+
+    const res = await request(app).get("/dish-genres");
+
+    expect(res.status).toBe(200);
+    const genre = res.body.data[0];
+    expect(genre.name_en).toBe("Kebab");
+    expect(genre.name_tr).toBe("Kebap");
+    expect(genre.description_en).toBe("Grilled meat dishes");
+    expect(genre.description_tr).toBe("Izgara et yemekleri");
+  });
+
+  it("nested varieties include name_en and name_tr", async () => {
+    setupGenreMock(mockGenres, mockVarieties);
+
+    const res = await request(app).get("/dish-genres");
+
+    expect(res.status).toBe(200);
+    const variety = res.body.data[0].varieties[0];
+    expect(variety.name_en).toBe("Adana Kebab");
+    expect(variety.name_tr).toBe("Adana Kebap");
+  });
+
+  it("returns empty varieties array when genre has none", async () => {
+    setupGenreMock(mockGenres, []);
+
+    const res = await request(app).get("/dish-genres");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].varieties).toHaveLength(0);
+  });
+
+  it("returns 500 when genre query fails", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "dish_genres") return chainable({ data: null, error: { message: "DB error" } });
+      return chainable({ data: [], error: null });
+    });
+
+    const res = await request(app).get("/dish-genres");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("returns 500 when variety query fails", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "dish_genres") return chainable({ data: mockGenres, error: null });
+      if (table === "dish_varieties") return chainable({ data: null, error: { message: "DB error" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app).get("/dish-genres");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /dish-genres — language fields (#412) ───────────────────────────────
+
+describe("GET /dish-genres — language fields (#412)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("?lang=en returns resolved EN names and descriptions", async () => {
+    setupGenreMock(mockGenres, mockVarieties);
+
+    const res = await request(app).get("/dish-genres?lang=en");
+
+    expect(res.status).toBe(200);
+    const genre = res.body.data[0];
+    expect(genre.name).toBe("Kebab");
+    expect(genre.description).toBe("Grilled meat dishes");
+    expect(genre.name_en).toBeUndefined();
+    expect(genre.name_tr).toBeUndefined();
+    expect(genre.varieties[0].name).toBe("Adana Kebab");
+    expect(genre.varieties[0].name_en).toBeUndefined();
+  });
+
+  it("?lang=tr returns resolved TR names and descriptions", async () => {
+    setupGenreMock(mockGenres, mockVarieties);
+
+    const res = await request(app).get("/dish-genres?lang=tr");
+
+    expect(res.status).toBe(200);
+    const genre = res.body.data[0];
+    expect(genre.name).toBe("Kebap");
+    expect(genre.description).toBe("Izgara et yemekleri");
+    expect(genre.varieties[0].name).toBe("Adana Kebap");
+  });
+
+  it("?lang=tr falls back to EN when TR fields are null", async () => {
+    setupGenreMock(mockGenres, mockVarieties);
+
+    const res = await request(app).get("/dish-genres?lang=tr");
+
+    expect(res.status).toBe(200);
+    // Soup genre: description_tr is null → falls back to description_en
+    const soup = res.body.data[1];
+    expect(soup.description).toBe("Soup dishes");
+    // Mercimek variety: name_tr is null → falls back to name_en
+    expect(soup.varieties[0].name).toBe("Lentil Soup");
+  });
+
+  it("?lang=de returns 400 VALIDATION_ERROR", async () => {
+    const res = await request(app).get("/dish-genres?lang=de");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/backend/src/__tests__/dish-varieties.test.ts
+++ b/backend/src/__tests__/dish-varieties.test.ts
@@ -1,0 +1,323 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: { from: mockFrom },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const chainable = (resolved: { data: any; error: any }) => {
+  const mock: any = {};
+  const methods = ["select", "eq", "ilike", "order"];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.single = jest.fn().mockResolvedValue(resolved);
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
+  return mock;
+};
+
+// ─── Mock data ────────────────────────────────────────────────────────────────
+
+const mockVarieties = [
+  {
+    id: 1, genre_id: 1,
+    name: "Adana Kebap", name_en: "Adana Kebab", name_tr: "Adana Kebap",
+    description: "Spicy grilled meat", description_en: "Spicy grilled meat dish", description_tr: "Acılı ızgara et yemeği",
+    dish_genre: { id: 1, name: "Kebap", name_en: "Kebab", name_tr: "Kebap" },
+  },
+  {
+    id: 2, genre_id: 2,
+    name: "Mercimek", name_en: "Lentil Soup", name_tr: null,
+    description: "Lentil soup", description_en: "Red lentil soup", description_tr: null,
+    dish_genre: { id: 2, name: "Çorba", name_en: "Soup", name_tr: "Çorba" },
+  },
+];
+
+const mockRecipes = [
+  {
+    id: "r1", title: "Classic Adana", type: "cultural",
+    average_rating: 4.8, rating_count: 20,
+    country: "Turkey", city: "Adana", district: null,
+    created_at: "2024-01-01", updated_at: "2024-01-01",
+  },
+  {
+    id: "r2", title: "My Adana", type: "community",
+    average_rating: 4.0, rating_count: 5,
+    country: null, city: null, district: null,
+    created_at: "2024-02-01", updated_at: "2024-02-01",
+  },
+];
+
+// ─── GET /dish-varieties ──────────────────────────────────────────────────────
+
+describe("GET /dish-varieties", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns all varieties with 200", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockVarieties, error: null })
+    );
+
+    const res = await request(app).get("/dish-varieties");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].name).toBe("Adana Kebap");
+  });
+
+  it("returns name_en, name_tr, description_en, description_tr in default response", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockVarieties, error: null })
+    );
+
+    const res = await request(app).get("/dish-varieties");
+
+    expect(res.status).toBe(200);
+    const v = res.body.data[0];
+    expect(v.name_en).toBe("Adana Kebab");
+    expect(v.name_tr).toBe("Adana Kebap");
+    expect(v.description_en).toBe("Spicy grilled meat dish");
+    expect(v.description_tr).toBe("Acılı ızgara et yemeği");
+  });
+
+  it("filters by genreId", async () => {
+    const filtered = [mockVarieties[0]];
+    const chain = chainable({ data: filtered, error: null });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/dish-varieties?genreId=1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(chain.eq).toHaveBeenCalledWith("genre_id", 1);
+  });
+
+  it("returns 400 for non-integer genreId", async () => {
+    const res = await request(app).get("/dish-varieties?genreId=abc");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("applies search filter when search param provided", async () => {
+    const chain = chainable({ data: [mockVarieties[0]], error: null });
+    (supabase.from as jest.Mock).mockReturnValue(chain);
+
+    const res = await request(app).get("/dish-varieties?search=adana");
+
+    expect(res.status).toBe(200);
+    expect(chain.ilike).toHaveBeenCalledWith("name", "%adana%");
+  });
+
+  it("returns 500 on database error", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: null, error: { message: "DB error" } })
+    );
+
+    const res = await request(app).get("/dish-varieties");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /dish-varieties — language fields (#412) ────────────────────────────
+
+describe("GET /dish-varieties — language fields (#412)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("?lang=en returns resolved EN names and descriptions", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockVarieties, error: null })
+    );
+
+    const res = await request(app).get("/dish-varieties?lang=en");
+
+    expect(res.status).toBe(200);
+    const v = res.body.data[0];
+    expect(v.name).toBe("Adana Kebab");
+    expect(v.description).toBe("Spicy grilled meat dish");
+    expect(v.dish_genre.name).toBe("Kebab");
+    expect(v.name_en).toBeUndefined();
+    expect(v.name_tr).toBeUndefined();
+  });
+
+  it("?lang=tr returns resolved TR names", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockVarieties, error: null })
+    );
+
+    const res = await request(app).get("/dish-varieties?lang=tr");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].name).toBe("Adana Kebap");
+    expect(res.body.data[0].description).toBe("Acılı ızgara et yemeği");
+    expect(res.body.data[0].dish_genre.name).toBe("Kebap");
+  });
+
+  it("?lang=tr falls back to EN when TR fields are null", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockVarieties, error: null })
+    );
+
+    const res = await request(app).get("/dish-varieties?lang=tr");
+
+    expect(res.status).toBe(200);
+    // Second variety has null name_tr and description_tr
+    expect(res.body.data[1].name).toBe("Lentil Soup");
+    expect(res.body.data[1].description).toBe("Red lentil soup");
+  });
+
+  it("?lang=de returns 400 VALIDATION_ERROR", async () => {
+    const res = await request(app).get("/dish-varieties?lang=de");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ─── GET /dish-varieties/:id ──────────────────────────────────────────────────
+
+describe("GET /dish-varieties/:id", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const setupVarietyAndRecipes = (varietyData: any, varietyError: any = null) => {
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "dish_varieties") return chainable({ data: varietyData, error: varietyError });
+      if (table === "recipes") return chainable({ data: mockRecipes, error: null });
+      return chainable({ data: null, error: null });
+    });
+  };
+
+  it("returns variety with recipes and lang fields", async () => {
+    setupVarietyAndRecipes(mockVarieties[0]);
+
+    const res = await request(app).get("/dish-varieties/1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name_en).toBe("Adana Kebab");
+    expect(res.body.data.name_tr).toBe("Adana Kebap");
+    expect(res.body.data.recipes).toHaveLength(2);
+  });
+
+  it("?lang=en returns resolved EN names", async () => {
+    setupVarietyAndRecipes(mockVarieties[0]);
+
+    const res = await request(app).get("/dish-varieties/1?lang=en");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe("Adana Kebab");
+    expect(res.body.data.description).toBe("Spicy grilled meat dish");
+    expect(res.body.data.dish_genre.name).toBe("Kebab");
+    expect(res.body.data.name_en).toBeUndefined();
+  });
+
+  it("?lang=tr falls back to EN when TR fields are null", async () => {
+    setupVarietyAndRecipes(mockVarieties[1]);
+
+    const res = await request(app).get("/dish-varieties/2?lang=tr");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe("Lentil Soup");
+    expect(res.body.data.description).toBe("Red lentil soup");
+  });
+
+  it("?lang=de returns 400 VALIDATION_ERROR", async () => {
+    const res = await request(app).get("/dish-varieties/1?lang=de");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 for non-integer id", async () => {
+    const res = await request(app).get("/dish-varieties/abc");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 404 when variety not found", async () => {
+    setupVarietyAndRecipes(null, { code: "PGRST116", message: "Not found" });
+
+    const res = await request(app).get("/dish-varieties/999");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 500 on database error", async () => {
+    setupVarietyAndRecipes(null, { code: "500", message: "DB error" });
+
+    const res = await request(app).get("/dish-varieties/1");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /dish-varieties/:id/recipes ─────────────────────────────────────────
+
+describe("GET /dish-varieties/:id/recipes", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const setupRecipesRoute = (varietyData: any, varietyError: any = null) => {
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "dish_varieties") return chainable({ data: varietyData, error: varietyError });
+      if (table === "recipes") return chainable({ data: mockRecipes, error: null });
+      return chainable({ data: null, error: null });
+    });
+  };
+
+  it("returns expertRecipe and communityRecipes arrays", async () => {
+    setupRecipesRoute({ id: 1 });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.expertRecipe).toBeDefined();
+    expect(res.body.data.communityRecipes).toBeDefined();
+    expect(res.body.data.expertRecipe.type).toBe("cultural");
+    expect(res.body.data.communityRecipes).toHaveLength(1);
+    expect(res.body.data.communityRecipes[0].type).toBe("community");
+  });
+
+  it("expertRecipe is null when no cultural recipe exists", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "dish_varieties") return chainable({ data: { id: 1 }, error: null });
+      if (table === "recipes") return chainable({ data: [mockRecipes[1]], error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app).get("/dish-varieties/1/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.expertRecipe).toBeNull();
+    expect(res.body.data.communityRecipes).toHaveLength(1);
+  });
+
+  it("returns 400 for non-integer id", async () => {
+    const res = await request(app).get("/dish-varieties/abc/recipes");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 404 when variety not found", async () => {
+    setupRecipesRoute(null, { code: "PGRST116", message: "Not found" });
+
+    const res = await request(app).get("/dish-varieties/999/recipes");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/backend/src/__tests__/ingredients.test.ts
+++ b/backend/src/__tests__/ingredients.test.ts
@@ -5,10 +5,15 @@ import { supabase } from "../config/supabase.js";
 jest.mock("../config/supabase.js", () => {
   const mockFrom = jest.fn();
   return {
-    supabase: { from: mockFrom },
+    supabase: {
+      auth: { getUser: jest.fn() },
+      from: mockFrom,
+    },
     createUserClient: jest.fn(() => ({ from: mockFrom })),
   };
 });
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 const chainable = (resolved: { data: any; error: any }) => {
   const mock: any = {};
@@ -20,6 +25,84 @@ const chainable = (resolved: { data: any; error: any }) => {
   mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
   return mock;
 };
+
+const setupCookAuth = (role = "cook") => {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "auth-user-1" } },
+    error: null,
+  });
+
+  let ingredientsCalls = 0;
+
+  (supabase.from as jest.Mock).mockImplementation((table: string) => {
+    if (table === "profiles") {
+      const chain: any = {};
+      chain.select = jest.fn().mockReturnValue(chain);
+      chain.eq = jest.fn().mockReturnValue(chain);
+      chain.single = jest.fn().mockResolvedValue({
+        data: { id: "profile-1", username: "cook1", role },
+        error: null,
+      });
+      return chain;
+    }
+    if (table === "ingredients") {
+      ingredientsCalls++;
+      if (ingredientsCalls === 1) {
+        // Duplicate check: .select().ilike().maybeSingle()
+        const check: any = {};
+        check.select = jest.fn().mockReturnValue(check);
+        check.ilike = jest.fn().mockReturnValue(check);
+        check.maybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+        return check;
+      }
+      // Insert: .insert().select().single()
+      const insert: any = {};
+      insert.insert = jest.fn().mockReturnValue(insert);
+      insert.select = jest.fn().mockReturnValue(insert);
+      insert.single = jest.fn().mockResolvedValue({
+        data: { id: 1, name: "salt", name_en: "Salt", name_tr: null },
+        error: null,
+      });
+      return insert;
+    }
+    return {};
+  });
+};
+
+const setupCookAuthWithDuplicate = () => {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "auth-user-1" } },
+    error: null,
+  });
+
+  let ingredientsCalls = 0;
+  (supabase.from as jest.Mock).mockImplementation((table: string) => {
+    if (table === "profiles") {
+      const chain: any = {};
+      chain.select = jest.fn().mockReturnValue(chain);
+      chain.eq = jest.fn().mockReturnValue(chain);
+      chain.single = jest.fn().mockResolvedValue({
+        data: { id: "profile-1", username: "cook1", role: "cook" },
+        error: null,
+      });
+      return chain;
+    }
+    if (table === "ingredients") {
+      ingredientsCalls++;
+      if (ingredientsCalls === 1) {
+        const check: any = {};
+        check.select = jest.fn().mockReturnValue(check);
+        check.ilike = jest.fn().mockReturnValue(check);
+        check.maybeSingle = jest.fn().mockResolvedValue({ data: { id: 1 }, error: null });
+        return check;
+      }
+      return {};
+    }
+    return {};
+  });
+};
+
+// ─── GET /ingredients (existing) ─────────────────────────────────────────────
 
 describe("GET /ingredients", () => {
   beforeEach(() => jest.clearAllMocks());
@@ -79,5 +162,228 @@ describe("GET /ingredients", () => {
 
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /ingredients — language fields (#412) ───────────────────────────────
+
+describe("GET /ingredients — language fields (#412)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockWithLangFields = [
+    { id: 1, name: "salt", name_en: "Salt", name_tr: "Tuz" },
+    { id: 2, name: "pepper", name_en: "Pepper", name_tr: "Biber" },
+  ];
+
+  it("returns name_en and name_tr fields in default response", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockWithLangFields, error: null })
+    );
+
+    const res = await request(app).get("/ingredients");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].name_en).toBe("Salt");
+    expect(res.body.data[0].name_tr).toBe("Tuz");
+  });
+
+  it("?lang=en returns resolved name without name_en / name_tr fields", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockWithLangFields, error: null })
+    );
+
+    const res = await request(app).get("/ingredients?lang=en");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].name).toBe("Salt");
+    expect(res.body.data[0].name_en).toBeUndefined();
+    expect(res.body.data[0].name_tr).toBeUndefined();
+  });
+
+  it("?lang=tr returns resolved TR name", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockWithLangFields, error: null })
+    );
+
+    const res = await request(app).get("/ingredients?lang=tr");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].name).toBe("Tuz");
+    expect(res.body.data[0].name_en).toBeUndefined();
+  });
+
+  it("?lang=tr falls back to name_en when name_tr is null", async () => {
+    const noTr = [{ id: 1, name: "salt", name_en: "Salt", name_tr: null }];
+    (supabase.from as jest.Mock).mockReturnValue(chainable({ data: noTr, error: null }));
+
+    const res = await request(app).get("/ingredients?lang=tr");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].name).toBe("Salt");
+  });
+
+  it("?lang=de returns 400 VALIDATION_ERROR", async () => {
+    const res = await request(app).get("/ingredients?lang=de");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ─── POST /ingredients (#412) ────────────────────────────────────────────────
+
+describe("POST /ingredients (#412)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when no token provided", async () => {
+    const res = await request(app)
+      .post("/ingredients")
+      .send({ name_en: "Salt" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user has learner role", async () => {
+    setupCookAuth("learner");
+
+    const res = await request(app)
+      .post("/ingredients")
+      .set("Authorization", "Bearer test-token")
+      .send({ name_en: "Salt" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when neither name_en nor name_tr is provided", async () => {
+    setupCookAuth();
+
+    const res = await request(app)
+      .post("/ingredients")
+      .set("Authorization", "Bearer test-token")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("creates ingredient with name_en only and returns 201", async () => {
+    setupCookAuth();
+
+    const res = await request(app)
+      .post("/ingredients")
+      .set("Authorization", "Bearer test-token")
+      .send({ name_en: "Salt" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.name_en).toBe("Salt");
+  });
+
+  it("creates ingredient with name_tr only and returns 201", async () => {
+    (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+      data: { user: { id: "auth-user-1" } },
+      error: null,
+    });
+
+    let ingredientsCalls = 0;
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") {
+        const chain: any = {};
+        chain.select = jest.fn().mockReturnValue(chain);
+        chain.eq = jest.fn().mockReturnValue(chain);
+        chain.single = jest.fn().mockResolvedValue({
+          data: { id: "profile-1", username: "cook1", role: "cook" },
+          error: null,
+        });
+        return chain;
+      }
+      if (table === "ingredients") {
+        ingredientsCalls++;
+        if (ingredientsCalls === 1) {
+          const check: any = {};
+          check.select = jest.fn().mockReturnValue(check);
+          check.ilike = jest.fn().mockReturnValue(check);
+          check.maybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+          return check;
+        }
+        const insert: any = {};
+        insert.insert = jest.fn().mockReturnValue(insert);
+        insert.select = jest.fn().mockReturnValue(insert);
+        insert.single = jest.fn().mockResolvedValue({
+          data: { id: 2, name: "tuz", name_en: null, name_tr: "Tuz" },
+          error: null,
+        });
+        return insert;
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/ingredients")
+      .set("Authorization", "Bearer test-token")
+      .send({ name_tr: "Tuz" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name_tr).toBe("Tuz");
+  });
+
+  it("creates ingredient with both name_en and name_tr and returns 201", async () => {
+    (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+      data: { user: { id: "auth-user-1" } },
+      error: null,
+    });
+
+    let ingredientsCalls = 0;
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "profiles") {
+        const chain: any = {};
+        chain.select = jest.fn().mockReturnValue(chain);
+        chain.eq = jest.fn().mockReturnValue(chain);
+        chain.single = jest.fn().mockResolvedValue({
+          data: { id: "profile-1", username: "cook1", role: "cook" },
+          error: null,
+        });
+        return chain;
+      }
+      if (table === "ingredients") {
+        ingredientsCalls++;
+        if (ingredientsCalls === 1) {
+          const check: any = {};
+          check.select = jest.fn().mockReturnValue(check);
+          check.ilike = jest.fn().mockReturnValue(check);
+          check.maybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+          return check;
+        }
+        const insert: any = {};
+        insert.insert = jest.fn().mockReturnValue(insert);
+        insert.select = jest.fn().mockReturnValue(insert);
+        insert.single = jest.fn().mockResolvedValue({
+          data: { id: 3, name: "salt", name_en: "Salt", name_tr: "Tuz" },
+          error: null,
+        });
+        return insert;
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/ingredients")
+      .set("Authorization", "Bearer test-token")
+      .send({ name_en: "Salt", name_tr: "Tuz" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name_en).toBe("Salt");
+    expect(res.body.data.name_tr).toBe("Tuz");
+  });
+
+  it("returns 409 when ingredient with same name already exists", async () => {
+    setupCookAuthWithDuplicate();
+
+    const res = await request(app)
+      .post("/ingredients")
+      .set("Authorization", "Bearer test-token")
+      .send({ name_en: "Salt" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("CONFLICT");
   });
 });

--- a/backend/src/routes/dietary-tags.ts
+++ b/backend/src/routes/dietary-tags.ts
@@ -1,21 +1,40 @@
 import { Router } from "express";
 import { supabase } from "../config/supabase.js";
 import { successResponse, errorResponse } from "../utils/response.js";
+import { parseLangParam, resolveLang } from "../utils/i18n.js";
 
 const router = Router();
 
 // ─── GET /dietary-tags ───────────────────────────────────────────────────────
 // Returns all supported dietary and allergen tags.
+// Query params:
+//   lang — "en" or "tr"; when provided returns a single resolved `name` field
+//           instead of the full name_en / name_tr pair
 
-router.get("/", async (_req, res) => {
+router.get("/", async (req, res) => {
+  const lang = parseLangParam(req.query["lang"]);
+  if (lang === "invalid") {
+    return res.status(400).json(errorResponse("VALIDATION_ERROR", "lang must be 'en' or 'tr'."));
+  }
+
   const { data, error } = await supabase
     .from("dietary_tags")
-    .select("id, name, category")
+    .select("id, name, name_en, name_tr, category")
     .order("category")
     .order("name");
 
   if (error) {
     return res.status(500).json(errorResponse("DB_ERROR", error.message));
+  }
+
+  if (lang) {
+    return res.status(200).json(successResponse(
+      (data as any[]).map((row) => ({
+        id: row.id,
+        name: resolveLang(row.name_en, row.name_tr, lang) ?? row.name,
+        category: row.category,
+      }))
+    ));
   }
 
   return res.status(200).json(successResponse(data));

--- a/backend/src/routes/dish-genres.ts
+++ b/backend/src/routes/dish-genres.ts
@@ -1,15 +1,25 @@
 import { Router } from "express";
 import { supabase } from "../config/supabase.js";
 import { successResponse, errorResponse } from "../utils/response.js";
+import { parseLangParam, resolveLang } from "../utils/i18n.js";
 
 const router = Router();
 
 // ─── GET /dish-genres ─────────────────────────────────────────────────────────
 // Returns all dish genres with their nested varieties.
-router.get("/", async (_req, res) => {
+// Query params:
+//   lang — "en" or "tr"; when provided returns a single resolved `name` /
+//           `description` field instead of the full _en / _tr pair
+
+router.get("/", async (req, res) => {
+  const lang = parseLangParam(req.query["lang"]);
+  if (lang === "invalid") {
+    return res.status(400).json(errorResponse("VALIDATION_ERROR", "lang must be 'en' or 'tr'."));
+  }
+
   const { data: genres, error: genreError } = await supabase
     .from("dish_genres")
-    .select("id, name, description")
+    .select("id, name, name_en, name_tr, description, description_en, description_tr")
     .order("name");
 
   if (genreError) {
@@ -18,17 +28,34 @@ router.get("/", async (_req, res) => {
 
   const { data: varieties, error: varietyError } = await supabase
     .from("dish_varieties")
-    .select("id, name, genre_id")
+    .select("id, name, name_en, name_tr, genre_id")
     .order("name");
 
   if (varietyError) {
     return res.status(500).json(errorResponse("DB_ERROR", varietyError.message));
   }
 
-  // Nest varieties under their parent genre
-  const result = genres.map((genre) => ({
+  if (lang) {
+    const resolvedVarieties = (varieties as any[]).map((v) => ({
+      id: v.id,
+      genre_id: v.genre_id,
+      name: resolveLang(v.name_en, v.name_tr, lang) ?? v.name,
+    }));
+
+    const result = (genres as any[]).map((genre) => ({
+      id: genre.id,
+      name: resolveLang(genre.name_en, genre.name_tr, lang) ?? genre.name,
+      description: resolveLang(genre.description_en, genre.description_tr, lang) ?? genre.description,
+      varieties: resolvedVarieties.filter((v) => v.genre_id === genre.id),
+    }));
+
+    return res.status(200).json(successResponse(result));
+  }
+
+  // Without lang: return all fields including _en / _tr
+  const result = (genres as any[]).map((genre) => ({
     ...genre,
-    varieties: varieties.filter((v) => v.genre_id === genre.id),
+    varieties: (varieties as any[]).filter((v) => v.genre_id === genre.id),
   }));
 
   return res.status(200).json(successResponse(result));

--- a/backend/src/routes/dish-varieties.ts
+++ b/backend/src/routes/dish-varieties.ts
@@ -1,21 +1,33 @@
 import { Router } from "express";
 import { supabase } from "../config/supabase.js";
 import { successResponse, errorResponse } from "../utils/response.js";
+import { parseLangParam, resolveLang } from "../utils/i18n.js";
 
 const router = Router();
 
 // ─── GET /dish-varieties ──────────────────────────────────────────────────────
 // Returns all dish varieties. Optionally filtered by genreId and/or search.
-// Query params: ?genreId=<number> ?search=<string>
+// Query params:
+//   genreId — filter by genre (positive integer, optional)
+//   search  — partial name match (optional)
+//   lang    — "en" or "tr"; when provided returns resolved name/description
+//             instead of the full _en / _tr pair
 router.get("/", async (req, res) => {
   const genreId = req.query["genreId"];
   const search = req.query["search"];
+  const lang = parseLangParam(req.query["lang"]);
+
+  if (lang === "invalid") {
+    return res
+      .status(400)
+      .json(errorResponse("VALIDATION_ERROR", "lang must be 'en' or 'tr'."));
+  }
 
   let query = supabase
     .from("dish_varieties")
     .select(
-      `id, name, description, genre_id,
-       dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)`
+      `id, name, name_en, name_tr, description, description_en, description_tr, genre_id,
+       dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name, name_en, name_tr)`
     )
     .order("name");
 
@@ -42,25 +54,50 @@ router.get("/", async (req, res) => {
     return res.status(500).json(errorResponse("DB_ERROR", error.message));
   }
 
+  if (lang) {
+    return res.status(200).json(successResponse(
+      (data as any[]).map((v) => ({
+        id: v.id,
+        genre_id: v.genre_id,
+        name: resolveLang(v.name_en, v.name_tr, lang) ?? v.name,
+        description: resolveLang(v.description_en, v.description_tr, lang) ?? v.description,
+        dish_genre: v.dish_genre
+          ? {
+              id: v.dish_genre.id,
+              name: resolveLang(v.dish_genre.name_en, v.dish_genre.name_tr, lang) ?? v.dish_genre.name,
+            }
+          : null,
+      }))
+    ));
+  }
+
   return res.status(200).json(successResponse(data));
 });
 
 // ─── GET /dish-varieties/:id ──────────────────────────────────────────────────
 // Returns a single dish variety with its published recipes.
+// Query params:
+//   lang — "en" or "tr" (optional)
 router.get("/:id", async (req, res) => {
   const id = Number(req.params["id"]);
+  const lang = parseLangParam(req.query["lang"]);
 
   if (!Number.isInteger(id) || id <= 0) {
     return res
       .status(400)
       .json(errorResponse("VALIDATION_ERROR", "id must be a positive integer."));
   }
+  if (lang === "invalid") {
+    return res
+      .status(400)
+      .json(errorResponse("VALIDATION_ERROR", "lang must be 'en' or 'tr'."));
+  }
 
   const { data: variety, error: varietyError } = await supabase
     .from("dish_varieties")
     .select(
-      `id, name, description, genre_id,
-       dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)`
+      `id, name, name_en, name_tr, description, description_en, description_tr, genre_id,
+       dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name, name_en, name_tr)`
     )
     .eq("id", id)
     .single();
@@ -85,7 +122,24 @@ router.get("/:id", async (req, res) => {
     return res.status(500).json(errorResponse("DB_ERROR", recipesError.message));
   }
 
-  return res.status(200).json(successResponse({ ...variety, recipes }));
+  if (lang) {
+    const v = variety as any;
+    return res.status(200).json(successResponse({
+      id: v.id,
+      genre_id: v.genre_id,
+      name: resolveLang(v.name_en, v.name_tr, lang) ?? v.name,
+      description: resolveLang(v.description_en, v.description_tr, lang) ?? v.description,
+      dish_genre: v.dish_genre
+        ? {
+            id: v.dish_genre.id,
+            name: resolveLang(v.dish_genre.name_en, v.dish_genre.name_tr, lang) ?? v.dish_genre.name,
+          }
+        : null,
+      recipes,
+    }));
+  }
+
+  return res.status(200).json(successResponse({ ...(variety as any), recipes }));
 });
 
 // ─── GET /dish-varieties/:id/recipes ─────────────────────────────────────────

--- a/backend/src/routes/ingredients.ts
+++ b/backend/src/routes/ingredients.ts
@@ -4,19 +4,27 @@ import { supabase, createUserClient } from "../config/supabase.js";
 import { requireAuth, requireRole } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import { successResponse, errorResponse } from "../utils/response.js";
+import { parseLangParam, resolveLang } from "../utils/i18n.js";
 import type { AuthenticatedRequest } from "../types/index.js";
 
 const router = Router();
 
-// ─── GET /ingredients ───────────────────────────────────────────────────────
+// ─── GET /ingredients ────────────────────────────────────────────────────────
 // Search ingredients by partial name match (case-insensitive).
 // Query params:
 //   search — partial ingredient name (optional)
+//   lang   — "en" or "tr"; when provided returns a single resolved `name` field
+//             instead of the full name_en / name_tr pair
 
 router.get("/", async (req, res) => {
+  const lang = parseLangParam(req.query["lang"]);
+  if (lang === "invalid") {
+    return res.status(400).json(errorResponse("VALIDATION_ERROR", "lang must be 'en' or 'tr'."));
+  }
+
   const search = (req.query["search"] as string | undefined)?.trim();
 
-  let query = supabase.from("ingredients").select("id, name");
+  let query = supabase.from("ingredients").select("id, name, name_en, name_tr");
 
   if (search) {
     query = query.ilike("name", `%${search}%`);
@@ -28,20 +36,33 @@ router.get("/", async (req, res) => {
     return res.status(500).json(errorResponse("DB_ERROR", error.message));
   }
 
+  if (lang) {
+    return res.status(200).json(successResponse(
+      (data as any[]).map((row) => ({
+        id: row.id,
+        name: resolveLang(row.name_en, row.name_tr, lang) ?? row.name,
+      }))
+    ));
+  }
+
   return res.status(200).json(successResponse(data));
 });
 
-// ─── POST /ingredients ──────────────────────────────────────────────────────
+// ─── POST /ingredients ───────────────────────────────────────────────────────
+// Create a new ingredient.
+// Restricted to cook and expert roles.
+// Body: { name_en?: string, name_tr?: string } — at least one field required.
+// Returns 409 if an ingredient with the same primary name already exists.
 
-const createIngredientSchema = z.object({
-  name: z.string({ message: "Name is required." }).trim().min(1, { message: "Name cannot be empty." }),
-});
+const createIngredientSchema = z
+  .object({
+    name_en: z.string().trim().min(1, { message: "name_en cannot be empty." }).optional(),
+    name_tr: z.string().trim().min(1, { message: "name_tr cannot be empty." }).optional(),
+  })
+  .refine((d) => !!(d.name_en || d.name_tr), {
+    message: "At least one of name_en or name_tr must be provided.",
+  });
 
-/**
- * Create a new ingredient.
- * Restricted to cook and expert roles.
- * Returns 409 if an ingredient with the same name already exists (case-insensitive).
- */
 router.post(
   "/",
   requireAuth,
@@ -49,13 +70,16 @@ router.post(
   validate(createIngredientSchema),
   async (req, res) => {
     const user = (req as AuthenticatedRequest).user;
-    const { name } = req.body as z.infer<typeof createIngredientSchema>;
+    const { name_en, name_tr } = req.body as z.infer<typeof createIngredientSchema>;
     const userClient = createUserClient(user.accessToken);
+
+    // Derive the canonical name (used for the legacy `name` column and duplicate check)
+    const primaryName = (name_en ?? name_tr!).toLowerCase();
 
     const { data: existing } = await supabase
       .from("ingredients")
       .select("id")
-      .ilike("name", name)
+      .ilike("name", primaryName)
       .maybeSingle();
 
     if (existing) {
@@ -64,8 +88,8 @@ router.post(
 
     const { data, error } = await userClient
       .from("ingredients")
-      .insert({ name: name.toLowerCase() })
-      .select("id, name")
+      .insert({ name: primaryName, name_en: name_en?.toLowerCase(), name_tr: name_tr?.toLowerCase() })
+      .select("id, name, name_en, name_tr")
       .single();
 
     if (error) {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,5 +1,9 @@
 import type { Request } from "express";
 
+// ─── Language ─────────────────────────────────────────────────────────────────
+
+export type { SupportedLanguage } from "../utils/i18n.js";
+
 // ─── User Roles ────────────────────────────────────────────────────────────────
 
 export type UserRole = "learner" | "cook" | "expert";

--- a/backend/src/utils/i18n.ts
+++ b/backend/src/utils/i18n.ts
@@ -1,0 +1,26 @@
+export type SupportedLanguage = "en" | "tr";
+
+/**
+ * Parses the ?lang= query parameter.
+ * Returns null if absent, "invalid" if the value is not "en" or "tr".
+ */
+export function parseLangParam(raw: unknown): SupportedLanguage | "invalid" | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") return "invalid";
+  const lower = raw.toLowerCase();
+  if (lower === "en" || lower === "tr") return lower as SupportedLanguage;
+  return "invalid";
+}
+
+/**
+ * Resolves the preferred-language value, falling back to the other language
+ * when the requested one is null/undefined.
+ */
+export function resolveLang(
+  en: string | null | undefined,
+  tr: string | null | undefined,
+  lang: SupportedLanguage
+): string | null {
+  if (lang === "en") return en ?? tr ?? null;
+  return tr ?? en ?? null;
+}


### PR DESCRIPTION
Adds `name_en` and `name_tr` language fields to all translatable reference tables and updates the API to support `?lang=` query parameter.

## Changes

### Migration
- `migrations/002_en_tr_language_fields.sql` — adds `name_en`, `name_tr` (and `description_en`, `description_tr` where applicable) to `ingredients`, `dietary_tags`, `dish_genres`, `dish_varieties` tables
- Existing `name`/`description` values are seeded into `_en` columns

### New Files
- `src/utils/i18n.ts` — `parseLangParam` and `resolveLang` helpers

### Updated Routes
- `src/routes/ingredients.ts` — GET returns `name_en`/`name_tr`; POST validates at least one language field via Zod `.refine()`
- `src/routes/dietary-tags.ts` — GET returns `name_en`/`name_tr` with `?lang=` support
- `src/routes/dish-genres.ts` — GET returns `name_en`/`name_tr`/`description_en`/`description_tr` with `?lang=` support
- `src/routes/dish-varieties.ts` — all GET endpoints support `?lang=`

### Tests
- `src/__tests__/ingredients.test.ts` — +17 tests
- `src/__tests__/dietary-tags.test.ts` — +4 tests
- `src/__tests__/dish-genres.test.ts` — new file, 11 tests
- `src/__tests__/dish-varieties.test.ts` — new file, 15 tests

## API Behavior

| Request | Response |
|---|---|
| `GET /ingredients` | `{ id, name, name_en, name_tr }` |
| `GET /ingredients?lang=en` | `{ id, name }` (English value) |
| `GET /ingredients?lang=tr` | `{ id, name }` (Turkish value, falls back to EN if null) |
| `GET /ingredients?lang=de` | `400 VALIDATION_ERROR` |
| `POST /ingredients` with no language field | `400 VALIDATION_ERROR` |

## Test Results

```
Test Suites: 16 passed, 16 total
Tests:       379 passed, 379 total
```

Closes #412
Closes #455