### PR TITLE
feat(discovery): apply origin filter at recipe level with cascade (#401)

### DIFF
--- a/backend/src/__tests__/discovery.test.ts
+++ b/backend/src/__tests__/discovery.test.ts
@@ -830,6 +830,164 @@ describe("GET /discovery/recipes", () => {
     expect(chain.ilike).toHaveBeenCalledWith("country", "Narnia");
     expect(chain.or).not.toHaveBeenCalled();
   });
+
+  // ─── Origin filter cascade (#401) ────────────────────────────────────────
+  // Matched recipes cascade up: their parent variety and genre are collected
+  // into distinct `varieties` and `genres` arrays in the response.
+
+  it("response always includes varieties and genres fields", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: mockRecipes, error: null, count: 1 })
+    );
+
+    const res = await request(app).get("/discovery/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty("varieties");
+    expect(res.body.data).toHaveProperty("genres");
+  });
+
+  it("cascade: recipe variety appears in varieties list", async () => {
+    const recipe = {
+      ...mockRecipes[0],
+      country: "Turkey",
+      dish_variety: { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } },
+    };
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: [recipe], error: null, count: 1 })
+    );
+
+    const res = await request(app).get("/discovery/recipes?country=Turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties).toHaveLength(1);
+    expect(res.body.data.varieties[0].id).toBe(1);
+    expect(res.body.data.varieties[0].name).toBe("Adana Kebap");
+  });
+
+  it("cascade: recipe genre appears in genres list", async () => {
+    const recipe = {
+      ...mockRecipes[0],
+      country: "Turkey",
+      dish_variety: { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } },
+    };
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: [recipe], error: null, count: 1 })
+    );
+
+    const res = await request(app).get("/discovery/recipes?country=Turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.genres).toHaveLength(1);
+    expect(res.body.data.genres[0].id).toBe(1);
+    expect(res.body.data.genres[0].name).toBe("Kebap");
+  });
+
+  it("cascade: multiple recipes from the same variety yield a single variety entry", async () => {
+    const sharedVariety = { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } };
+    const recipes = [
+      { ...mockRecipes[0], id: 1, country: "Turkey", dish_variety: sharedVariety },
+      { ...mockRecipes[0], id: 2, country: "Turkey", dish_variety: sharedVariety },
+    ];
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: recipes, error: null, count: 2 })
+    );
+
+    const res = await request(app).get("/discovery/recipes?country=Turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties).toHaveLength(1);
+  });
+
+  it("cascade: multiple varieties from the same genre yield a single genre entry", async () => {
+    const genre = { id: 1, name: "Kebap" };
+    const recipes = [
+      { ...mockRecipes[0], id: 1, country: "Turkey", dish_variety: { id: 1, name: "Adana Kebap", dish_genre: genre } },
+      { ...mockRecipes[0], id: 2, country: "Turkey", dish_variety: { id: 2, name: "Urfa Kebap", dish_genre: genre } },
+    ];
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: recipes, error: null, count: 2 })
+    );
+
+    const res = await request(app).get("/discovery/recipes?country=Turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties).toHaveLength(2);
+    expect(res.body.data.genres).toHaveLength(1);
+  });
+
+  it("cascade: multiple genres appear when recipes span different genres", async () => {
+    const recipes = [
+      { ...mockRecipes[0], id: 1, dish_variety: { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } } },
+      { ...mockRecipes[0], id: 2, dish_variety: { id: 2, name: "Mercimek", dish_genre: { id: 2, name: "Çorba" } } },
+    ];
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: recipes, error: null, count: 2 })
+    );
+
+    const res = await request(app).get("/discovery/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties).toHaveLength(2);
+    expect(res.body.data.genres).toHaveLength(2);
+  });
+
+  it("cascade: empty varieties and genres when no recipes match", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: [], error: null, count: 0 })
+    );
+
+    const res = await request(app).get("/discovery/recipes?country=Narnia");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties).toHaveLength(0);
+    expect(res.body.data.genres).toHaveLength(0);
+  });
+
+  it("cascade: recipe with null dish_variety produces no variety or genre entry", async () => {
+    const recipe = { ...mockRecipes[0], dish_variety: null };
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: [recipe], error: null, count: 1 })
+    );
+
+    const res = await request(app).get("/discovery/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties).toHaveLength(0);
+    expect(res.body.data.genres).toHaveLength(0);
+  });
+
+  it("cascade: variety with null dish_genre produces no genre entry but variety is included", async () => {
+    const recipe = {
+      ...mockRecipes[0],
+      dish_variety: { id: 1, name: "Adana Kebap", dish_genre: null },
+    };
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: [recipe], error: null, count: 1 })
+    );
+
+    const res = await request(app).get("/discovery/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties).toHaveLength(1);
+    expect(res.body.data.genres).toHaveLength(0);
+  });
+
+  it("cascade: variety object in response includes dish_genre field", async () => {
+    const recipe = {
+      ...mockRecipes[0],
+      country: "Turkey",
+      dish_variety: { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } },
+    };
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: [recipe], error: null, count: 1 })
+    );
+
+    const res = await request(app).get("/discovery/recipes?country=Turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties[0].dish_genre).toMatchObject({ id: 1, name: "Kebap" });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -247,6 +247,24 @@ router.get("/recipes", async (req, res) => {
         .json(errorResponse("DB_ERROR", recipesError.message));
     }
 
+    // ── Step 5: Cascade — derive distinct varieties and genres from results ──
+    // Matched recipes' parent variety and genre appear in the aggregated lists,
+    // which lets callers know which categories are represented in the results.
+    const varietyMap = new Map<number, { id: number; name: string; dish_genre: any }>();
+    const genreMap = new Map<number, { id: number; name: string }>();
+
+    for (const r of recipes ?? []) {
+      const v = (r as any).dish_variety;
+      if (v) {
+        if (!varietyMap.has(v.id)) {
+          varietyMap.set(v.id, { id: v.id, name: v.name, dish_genre: v.dish_genre ?? null });
+        }
+        if (v.dish_genre && !genreMap.has(v.dish_genre.id)) {
+          genreMap.set(v.dish_genre.id, { id: v.dish_genre.id, name: v.dish_genre.name });
+        }
+      }
+    }
+
     return res.status(200).json(
       successResponse({
         recipes: (recipes ?? []).map((r: any) => {
@@ -254,6 +272,8 @@ router.get("/recipes", async (req, res) => {
           const { recipe_media, ...rest } = r;
           return { ...rest, image_url: firstImage?.url ?? null };
         }),
+        varieties: [...varietyMap.values()],
+        genres: [...genreMap.values()],
         pagination: {
           page,
           limit,


### PR DESCRIPTION

## Description

Refactors origin filtering logic so it is applied at the recipe level and cascades upward to Dish Variety and Dish Genre.

## Changes

### Updated Routes
- `src/routes/discovery.ts` — origin filter now applied at recipe level; response includes deduplicated `varieties` and `genres` derived from matching recipes

### Updated Tests
- `src/__tests__/discovery.test.ts` — +10 cascade tests covering:
  - `varieties` and `genres` fields present in response
  - Correct cascade from matching recipe → variety → genre
  - Deduplication (2 recipes same variety → 1 variety entry)
  - Deduplication (2 varieties same genre → 1 genre entry)
  - Empty arrays when no matches
  - `dish_variety: null` and `dish_genre: null` edge cases

## API Behavior

| Request | Response |
|---|---|
| `GET /discovery/recipes` | includes `varieties` and `genres` arrays |
| `GET /discovery/recipes?country=Italy` | only Italian recipes + their varieties + genres |
| `GET /discovery/recipes?city=Kayseri` | only Kayseri recipes + their varieties + genres |

## Test Results

```
Test Suites: 18 passed, 18 total
Tests:       389 passed, 389 total
```

Closes #401