### PR TITLE
[Frontend/Task] Display comment scores and add edit mode (#460)

### DIFF
--- a/frontend/src/components/Comments/Comments.css
+++ b/frontend/src/components/Comments/Comments.css
@@ -93,6 +93,74 @@
   border-color: #c0392b;
 }
 
+.comment-item__actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.comment-item__edit {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-subtle, #e8e0d8);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.comment-item__edit:hover {
+  color: var(--color-main);
+  border-color: var(--color-main);
+}
+
+.comment-item__score {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  background: rgba(212, 134, 10, 0.1);
+  color: var(--color-accent, #d4860a);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.comment-item__score-star {
+  line-height: 1;
+}
+
+.comment-item__edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-top: 0.25rem;
+}
+
+.comments__cancel {
+  padding: 0.45rem 1.25rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-subtle, #e8e0d8);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.comments__cancel:hover:not(:disabled) {
+  color: var(--color-main);
+  border-color: var(--color-main);
+}
+
+.comments__cancel:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* ── Load more ── */
 
 .comments__load-more {

--- a/frontend/src/components/Comments/CommentsSection.tsx
+++ b/frontend/src/components/Comments/CommentsSection.tsx
@@ -39,11 +39,20 @@ function StarInput({ value, onChange }: { value: number; onChange: (v: number) =
   )
 }
 
+function ScoreBadge({ score }: { score: number }) {
+  return (
+    <span className="comment-item__score" aria-label={`${score} star rating`}>
+      <span className="comment-item__score-star">★</span>
+      <span className="comment-item__score-value">{score}</span>
+    </span>
+  )
+}
+
 export function CommentsSection({ recipeId, isOwnRecipe, myRatingScore }: Props) {
   const { t } = useTranslation('common')
   const navigate = useNavigate()
   const isAuthenticated = useAppSelector((s) => s.auth.isAuthenticated)
-  const currentUserId = useAppSelector((s) => s.profile.userId)
+  const currentUsername = useAppSelector((s) => s.profile.username)
 
   const [comments, setComments] = useState<Comment[]>([])
   const [total, setTotal] = useState(0)
@@ -55,6 +64,10 @@ export function CommentsSection({ recipeId, isOwnRecipe, myRatingScore }: Props)
   const [score, setScore] = useState(0)
   const [submitting, setSubmitting] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
+
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editBody, setEditBody] = useState('')
+  const [editError, setEditError] = useState<string | null>(null)
 
   const LIMIT = 10
 
@@ -73,6 +86,11 @@ export function CommentsSection({ recipeId, isOwnRecipe, myRatingScore }: Props)
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [recipeId])
+
+  const myComment =
+    currentUsername != null
+      ? comments.find((c) => c.username === currentUsername) ?? null
+      : null
 
   async function handleLoadMore() {
     const nextPage = page + 1
@@ -108,10 +126,39 @@ export function CommentsSection({ recipeId, isOwnRecipe, myRatingScore }: Props)
         const code = (err.response?.data as { error?: { code?: string } } | undefined)?.error?.code
         if (code === 'RATING_REQUIRED') {
           setFormError(t('comments.ratingRequired'))
+        } else if (code === 'COMMENT_ALREADY_EXISTS') {
+          setFormError(t('comments.alreadyCommented'))
         } else {
           setFormError(t('comments.submitError'))
         }
       }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function startEditing(comment: Comment) {
+    setEditingId(comment.id)
+    setEditBody(comment.body)
+    setEditError(null)
+  }
+
+  function cancelEditing() {
+    setEditingId(null)
+    setEditBody('')
+    setEditError(null)
+  }
+
+  async function handleSaveEdit() {
+    if (!editingId || !editBody.trim()) return
+    setEditError(null)
+    setSubmitting(true)
+    try {
+      const updated = await commentService.edit(editingId, editBody.trim())
+      setComments((prev) => prev.map((c) => (c.id === editingId ? { ...c, ...updated } : c)))
+      cancelEditing()
+    } catch {
+      setEditError(t('comments.submitError'))
     } finally {
       setSubmitting(false)
     }
@@ -122,6 +169,7 @@ export function CommentsSection({ recipeId, isOwnRecipe, myRatingScore }: Props)
       await commentService.remove(commentId)
       setComments((prev) => prev.filter((c) => c.id !== commentId))
       setTotal((n) => n - 1)
+      if (editingId === commentId) cancelEditing()
     } catch {
       // ignore
     }
@@ -142,26 +190,70 @@ export function CommentsSection({ recipeId, isOwnRecipe, myRatingScore }: Props)
         <p className="comments__empty">{t('comments.empty')}</p>
       ) : (
         <div className="comments__list">
-          {comments.map((c) => (
-            <div key={c.id} className="comment-item">
-              <div className="comment-item__header">
-                <div className="comment-item__meta">
-                  <span className="comment-item__username">{c.username}</span>
-                  <span className="comment-item__date">{formatDate(c.createdAt)}</span>
+          {comments.map((c) => {
+            const isMine = currentUsername != null && c.username === currentUsername
+            const isEditing = editingId === c.id
+            return (
+              <div key={c.id} className="comment-item">
+                <div className="comment-item__header">
+                  <div className="comment-item__meta">
+                    <span className="comment-item__username">{c.username}</span>
+                    {c.score !== null && <ScoreBadge score={c.score} />}
+                    <span className="comment-item__date">{formatDate(c.createdAt)}</span>
+                  </div>
+                  {isMine && !isEditing && (
+                    <div className="comment-item__actions">
+                      <button
+                        type="button"
+                        className="comment-item__edit"
+                        onClick={() => startEditing(c)}
+                      >
+                        {t('comments.edit')}
+                      </button>
+                      <button
+                        type="button"
+                        className="comment-item__delete"
+                        onClick={() => void handleDelete(c.id)}
+                      >
+                        {t('comments.delete')}
+                      </button>
+                    </div>
+                  )}
                 </div>
-                {String(c.userId) === String(currentUserId) && (
-                  <button
-                    type="button"
-                    className="comment-item__delete"
-                    onClick={() => void handleDelete(c.id)}
-                  >
-                    {t('comments.delete')}
-                  </button>
+                {isEditing ? (
+                  <div className="comment-item__edit-form">
+                    <textarea
+                      className="comments__textarea"
+                      value={editBody}
+                      onChange={(e) => setEditBody(e.target.value)}
+                      maxLength={2000}
+                    />
+                    {editError && <p className="comments__form-error">{editError}</p>}
+                    <div className="comments__form-actions">
+                      <button
+                        type="button"
+                        className="comments__cancel"
+                        onClick={cancelEditing}
+                        disabled={submitting}
+                      >
+                        {t('comments.cancel')}
+                      </button>
+                      <button
+                        type="button"
+                        className="comments__submit"
+                        onClick={() => void handleSaveEdit()}
+                        disabled={submitting || !editBody.trim() || editBody.trim() === c.body}
+                      >
+                        {submitting ? t('common.loading') : t('comments.save')}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="comment-item__body">{c.body}</p>
                 )}
               </div>
-              <p className="comment-item__body">{c.body}</p>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
 
@@ -176,7 +268,7 @@ export function CommentsSection({ recipeId, isOwnRecipe, myRatingScore }: Props)
         </button>
       )}
 
-      {/* Comment form */}
+      {/* Comment form — hidden if the user already has a comment (use edit button on their item instead) */}
       {!isAuthenticated ? (
         <p className="comments__login-prompt">
           {t('comments.loginPrompt')}{' '}
@@ -184,7 +276,7 @@ export function CommentsSection({ recipeId, isOwnRecipe, myRatingScore }: Props)
             {t('comments.loginLink')}
           </button>
         </p>
-      ) : (
+      ) : myComment ? null : (
         <form className="comments__form" onSubmit={(e) => void handleSubmit(e)}>
           {!isOwnRecipe && myRatingScore === null && (
             <div className="comments__form-rating">

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -242,7 +242,8 @@
   "common": {
     "retry": "Try again",
     "errorRetry": "Something went wrong. Please try again.",
-    "goBack": "Go back"
+    "goBack": "Go back",
+    "loading": "Loading…"
   },
   "recipeDetail": {
     "notFound": "Recipe not found.",
@@ -443,6 +444,10 @@
     "loginLink": "Log in",
     "rateLabel": "Your rating (optional):",
     "ratingRequired": "Please rate this recipe before commenting.",
-    "submitError": "Failed to post comment. Please try again."
+    "submitError": "Failed to post comment. Please try again.",
+    "edit": "Edit",
+    "save": "Save",
+    "cancel": "Cancel",
+    "alreadyCommented": "You have already commented on this recipe. Edit your existing comment instead."
   }
 }

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -242,7 +242,8 @@
   "common": {
     "retry": "Tekrar dene",
     "errorRetry": "Bir şeyler ters gitti. Lütfen tekrar deneyin.",
-    "goBack": "Geri dön"
+    "goBack": "Geri dön",
+    "loading": "Yükleniyor…"
   },
   "recipeDetail": {
     "notFound": "Tarif bulunamadı.",
@@ -443,6 +444,10 @@
     "loginLink": "Giriş yap",
     "rateLabel": "Puanın (isteğe bağlı):",
     "ratingRequired": "Yorum yapmadan önce bu tarifi puanlamanız gerekiyor.",
-    "submitError": "Yorum gönderilemedi. Tekrar deneyin."
+    "submitError": "Yorum gönderilemedi. Tekrar deneyin.",
+    "edit": "Düzenle",
+    "save": "Kaydet",
+    "cancel": "İptal",
+    "alreadyCommented": "Bu tarife zaten yorum yapmışsınız. Mevcut yorumunuzu düzenleyebilirsiniz."
   }
 }

--- a/frontend/src/services/comment-service.ts
+++ b/frontend/src/services/comment-service.ts
@@ -12,6 +12,7 @@ export interface Comment {
   userId: string
   username: string
   body: string
+  score: number | null
   createdAt: string
   updatedAt: string
 }
@@ -31,11 +32,16 @@ export const commentService = {
   },
 
   async create(recipeId: string, body: string, score?: number): Promise<Comment> {
-    const { data } = await httpClient.post<ApiEnvelope<{ comment: Comment; rating: unknown }>>(
+    const { data } = await httpClient.post<
+      ApiEnvelope<{
+        comment: Omit<Comment, 'score'>
+        rating: { score: number } | null
+      }>
+    >(
       `/recipes/${recipeId}/comments`,
       { body, ...(score !== undefined ? { score } : {}) }
     )
-    return data.data.comment
+    return { ...data.data.comment, score: data.data.rating?.score ?? null }
   },
 
   async remove(commentId: string): Promise<void> {


### PR DESCRIPTION
## Summary
Wire the new backend capabilities from #453 into the existing comments UI on the recipe detail page.

## What
- Show each commenter's rating (★ N) next to their comment
- Replace the new-comment form with an Edit/Delete UI when the current user has already commented
- Handle the new \`409 COMMENT_ALREADY_EXISTS\` response with a user-friendly message
- Merge \`rating.score\` from POST response so a freshly created comment shows its score immediately
- Compare ownership by \`username\` since \`/auth/me\` exposes \`userId\` (auth.users.id) but comments are keyed by \`profiles.id\`
- Add \`common.loading\` i18n key

## How to test
- [ ] Existing comments show ★ score next to commenter (creator's comment shows no score)
- [ ] Submit a new comment with a rating → list updates and ★ N appears immediately
- [ ] After commenting, the form is replaced by Edit/Delete buttons on your comment
- [ ] Edit → textarea pre-fills with existing body, Save updates the comment in place, score is preserved
- [ ] Save button disabled when text is empty or unchanged
- [ ] Cancel returns to display mode without changes
- [ ] Delete your comment → form returns and you can post again
- [ ] \`npm run build\` passes

## Related issue
Closes #460