### PR TITLE
[Frontend/Fix] Transliterate Turkish chars when generating username (#403)

### DIFF
--- a/frontend/src/pages/Register/RegisterPage.tsx
+++ b/frontend/src/pages/Register/RegisterPage.tsx
@@ -37,6 +37,18 @@ interface FieldErrors {
 const REGIONS = ['Turkey', 'Greece', 'Italy', 'Mexico', 'India', 'Japan']
 const LANGUAGES = ['English', 'Türkçe']
 
+/** Fold Turkish characters to ASCII for backend username regex (^[a-zA-Z0-9_]+$). */
+function asciiSlug(value: string): string {
+  return value
+    .normalize('NFC')
+    .replace(/İ/g, 'I')
+    .replace(/ı/g, 'i')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+}
+
 const PW_STRENGTH_KEYS = ['weak', 'fair', 'good', 'strong'] as const
 
 function getPasswordStrengthLevel(pw: string): number {
@@ -119,7 +131,7 @@ export function RegisterPage() {
     ev.preventDefault()
     if (!validate()) return
 
-    const username = `${form.firstName.trim().toLowerCase()}_${form.lastName.trim().toLowerCase()}`
+    const username = `${asciiSlug(form.firstName)}_${asciiSlug(form.lastName)}`
     try {
       await dispatch(
         registerAsync({


### PR DESCRIPTION
## Summary
Registration with a Turkish first/last name (e.g. \`İrem Çiğdem\`) was failing with \`Username can only contain letters, numbers, and underscores.\` because:
- Backend username regex is \`^[a-zA-Z0-9_]+$\` (ASCII only)
- Default \`toLowerCase()\` turns \`İ\` into \`i + combining dot above\`, which the regex also rejects
- Plus Turkish letters \`ç ğ ı ö ş ü\` are non-ASCII and rejected outright

## Fix
Add an \`asciiSlug()\` helper in \`RegisterPage.tsx\` that:
1. Pairs Turkish dotted-i (\`İ\`→\`I\`, \`ı\`→\`i\`)
2. Strips combining marks via NFD
3. Lowercases and removes any remaining non-\`[a-z0-9]\` characters

\`İrem Çiğdem\` → \`irem_cigdem\` — passes backend regex.

## How to test
- [ ] Register with \`İrem Çiğdem\` → succeeds, username stored as \`irem_cigdem\`
- [ ] Register with \`Ömer Şükrü\` → succeeds, username \`omer_sukru\`
- [ ] Register with ASCII names → behavior unchanged
- [ ] \`npm run build\` passes

## Related issue
Closes #403