### PR TITLE
[Backend/Fix] Discovery cascade reflects all filtered recipes, not paginated page (#463)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -199,6 +199,7 @@ Migration `002_en_tr_language_fields.sql` adds these columns and seeds `_en` fro
 - `GET /discovery/recipes` — Filtered recipe discovery
   - Query params: `genreId`, `varietyId`, `excludeAllergens` (comma-separated IDs), `tagIds` (comma-separated dietary tag IDs — only recipes with ALL specified tags), `search` (case-insensitive partial match on recipe title), `country`, `city`, `district` (case-insensitive, whitespace-/diacritic-tolerant; country also resolves common aliases — `"tr"`/`"Türkiye"`/`"TUR"` all match recipes stored as `"Turkey"`. See Location Normalization below), `page`, `limit`
   - Response recipe objects include `country`, `city`, `district` fields (nullable)
+  - Response also includes `varieties[]` and `genres[]` cascade arrays — distinct varieties and genres derived from **every** recipe matching the active filters (not just the current page), so callers can use them as cross-page-stable filter dropdowns. Implementation runs the cascade aggregation as a separate query in parallel with the paginated list (issue #463).
 - `GET /discovery/recipes/by-ingredients` — Recipes fully makeable with provided ingredients
   - Query params: `ingredientIds` (comma-separated IDs, required), `page`, `limit`
   - Only returns recipes whose every ingredient is in the provided list; partial matches excluded

--- a/backend/src/__tests__/discovery.test.ts
+++ b/backend/src/__tests__/discovery.test.ts
@@ -472,6 +472,40 @@ describe("GET /discovery/recipes", () => {
     expect(res.body.data.pagination).toMatchObject({ page: 2, limit: 10, total: 50 });
   });
 
+  it("cascade reflects all filtered recipes, not just the current page (#463)", async () => {
+    // Page 1 only returns the first recipe, but the cascade aggregation sees
+    // every filtered recipe — so genres/varieties from later pages still
+    // appear in the response.
+    const pagedRecipes = [
+      {
+        id: 1, title: "Adana Kebap", type: "community",
+        average_rating: 4.8, rating_count: 20, created_at: "2024-01-01", updated_at: "2024-01-01",
+        dish_variety: { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } },
+        profile: { id: "p1", username: "cook1" },
+      },
+    ];
+    const cascadeRecipes = [
+      { dish_variety: { id: 1, name: "Adana Kebap", dish_genre: { id: 1, name: "Kebap" } } },
+      { dish_variety: { id: 2, name: "Mercimek Çorbası", dish_genre: { id: 2, name: "Soup" } } },
+      { dish_variety: { id: 3, name: "Baklava", dish_genre: { id: 3, name: "Pastries" } } },
+    ];
+    let call = 0;
+    (supabase.from as jest.Mock).mockImplementation(() => {
+      call += 1;
+      // First .from("recipes") call is the paginated list, second is the cascade aggregation.
+      return call === 1
+        ? chainable({ data: pagedRecipes, error: null, count: 30 })
+        : chainable({ data: cascadeRecipes, error: null });
+    });
+
+    const res = await request(app).get("/discovery/recipes?country=Turkey&page=1&limit=1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(res.body.data.varieties.map((v: any) => v.id).sort()).toEqual([1, 2, 3]);
+    expect(res.body.data.genres.map((g: any) => g.id).sort()).toEqual([1, 2, 3]);
+  });
+
   it("returns 500 on database error", async () => {
     (supabase.from as jest.Mock).mockReturnValue(
       chainable({ data: null, error: { message: "DB timeout" }, count: null })
@@ -665,7 +699,7 @@ describe("GET /discovery/recipes", () => {
     expect(res.body.data.recipes).toHaveLength(1);
     // "turkey" is in the alias table, so the filter expands to an OR over
     // every known variant (Turkey/Türkiye/tr/...) instead of a single ilike.
-    expect(chain.or).toHaveBeenCalledTimes(1);
+    expect(chain.or).toHaveBeenCalledTimes(2);
     const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
     expect(orArg).toContain("country.ilike.Turkey");
     expect(orArg).toContain("country.ilike.tr");
@@ -708,7 +742,7 @@ describe("GET /discovery/recipes", () => {
     expect(res.body.data.recipes).toHaveLength(1);
     // Whitespace-padded "Turkey" is trimmed before alias lookup; the result
     // is an OR over Turkey variants (no leading/trailing spaces in any).
-    expect(chain.or).toHaveBeenCalledTimes(1);
+    expect(chain.or).toHaveBeenCalledTimes(2);
     const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
     expect(orArg).toContain("country.ilike.Turkey");
     expect(orArg).not.toContain("  Turkey  ");
@@ -741,7 +775,7 @@ describe("GET /discovery/recipes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data.recipes).toHaveLength(1);
-    expect(chain.or).toHaveBeenCalledTimes(1);
+    expect(chain.or).toHaveBeenCalledTimes(2);
     const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
     expect(orArg).toContain("country.ilike.Turkey");
     expect(orArg).toContain("country.ilike.tr");
@@ -762,7 +796,7 @@ describe("GET /discovery/recipes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data.recipes).toHaveLength(1);
-    expect(chain.or).toHaveBeenCalledTimes(1);
+    expect(chain.or).toHaveBeenCalledTimes(2);
     const orArg = (chain.or as jest.Mock).mock.calls[0][0] as string;
     expect(orArg).toContain("country.ilike.Turkey");
   });
@@ -799,7 +833,7 @@ describe("GET /discovery/recipes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data.recipes).toHaveLength(1);
-    expect(chain.or).toHaveBeenCalledTimes(1);
+    expect(chain.or).toHaveBeenCalledTimes(2);
   });
 
   it("expands 'usa' to United States variants (not turkey-only)", async () => {

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -214,7 +214,30 @@ router.get("/recipes", async (req, res) => {
     }
 
     // ── Step 3: Build the main recipe query ───────────────────────────────────
-    let query = supabase
+    // Apply every filter shared between the paginated list and the cascade
+    // aggregation. Origin filters tolerate casing/whitespace differences and
+    // known aliases (e.g. "tr"/"Türkiye" → "Turkey") via applyLocationFilter
+    // (issue #398).
+    const applyFilters = (q: any): any => {
+      if (search) q = applyTextSearch(q, "title", search);
+      if (country) q = applyLocationFilter(q, "country", country);
+      if (city) q = applyLocationFilter(q, "city", city);
+      if (district) q = applyLocationFilter(q, "district", district);
+      if (varietyId !== undefined) {
+        q = q.eq("dish_variety_id", varietyId);
+      } else if (varietyIdsForGenre !== null) {
+        q = q.in("dish_variety_id", varietyIdsForGenre);
+      }
+      if (excludedRecipeIds.length > 0) {
+        q = q.not("id", "in", `(${excludedRecipeIds.join(",")})`);
+      }
+      if (tagFilteredRecipeIds !== null) {
+        q = q.in("id", tagFilteredRecipeIds);
+      }
+      return q;
+    };
+
+    let recipeQuery = supabase
       .from("recipes")
       .select(
         `id, title, type, average_rating, rating_count,
@@ -230,51 +253,48 @@ router.get("/recipes", async (req, res) => {
       )
       .eq("is_published", true);
 
-    if (search) {
-      query = applyTextSearch(query, "title", search);
-    }
-
-    // Origin filters tolerate casing/whitespace differences and known
-    // aliases (e.g. "tr"/"Türkiye" → "Turkey") via applyLocationFilter
-    // (issue #398).
-    if (country) query = applyLocationFilter(query, "country", country);
-    if (city) query = applyLocationFilter(query, "city", city);
-    if (district) query = applyLocationFilter(query, "district", district);
-
-    if (varietyId !== undefined) {
-      query = query.eq("dish_variety_id", varietyId);
-    } else if (varietyIdsForGenre !== null) {
-      query = query.in("dish_variety_id", varietyIdsForGenre);
-    }
-
-    if (excludedRecipeIds.length > 0) {
-      query = query.not("id", "in", `(${excludedRecipeIds.join(",")})`);
-    }
-
-    if (tagFilteredRecipeIds !== null) {
-      query = query.in("id", tagFilteredRecipeIds);
-    }
+    recipeQuery = applyFilters(recipeQuery);
 
     // ── Step 4: Pagination ────────────────────────────────────────────────────
     const from = (page - 1) * limit;
     const to = from + limit - 1;
-    query = query.range(from, to).order("average_rating", { ascending: false });
+    recipeQuery = recipeQuery.range(from, to).order("average_rating", { ascending: false });
 
-    const { data: recipes, error: recipesError, count } = await query;
+    // ── Step 5: Cascade aggregation — same filters, no pagination ─────────────
+    // Cascade reflects every filtered recipe's parent variety and genre, not
+    // just the current page. Issue #463.
+    let cascadeQuery = supabase
+      .from("recipes")
+      .select(
+        `dish_variety:dish_varieties!recipes_dish_variety_id_fkey(
+           id, name,
+           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)
+         )`
+      )
+      .eq("is_published", true);
+
+    cascadeQuery = applyFilters(cascadeQuery);
+
+    const [
+      { data: recipes, error: recipesError, count },
+      { data: cascadeRows, error: cascadeError },
+    ] = await Promise.all([recipeQuery, cascadeQuery]);
 
     if (recipesError) {
       return res
         .status(500)
         .json(errorResponse("DB_ERROR", recipesError.message));
     }
+    if (cascadeError) {
+      return res
+        .status(500)
+        .json(errorResponse("DB_ERROR", cascadeError.message));
+    }
 
-    // ── Step 5: Cascade — derive distinct varieties and genres from results ──
-    // Matched recipes' parent variety and genre appear in the aggregated lists,
-    // which lets callers know which categories are represented in the results.
     const varietyMap = new Map<number, { id: number; name: string; dish_genre: any }>();
     const genreMap = new Map<number, { id: number; name: string }>();
 
-    for (const r of recipes ?? []) {
+    for (const r of cascadeRows ?? []) {
       const v = (r as any).dish_variety;
       if (v) {
         if (!varietyMap.has(v.id)) {


### PR DESCRIPTION
## Summary
Cascade arrays (\`varieties[]\`, \`genres[]\`) on \`GET /discovery/recipes\` were derived from the paginated slice, so they shifted as the user moved between pages — making them unreliable as a filter dropdown source.

## Fix
- Extracted shared filters into an \`applyFilters()\` closure
- Run the cascade aggregation as a second Supabase query in parallel with the paginated list, using the same filters but without \`.range()\`
- Build \`varietyMap\` / \`genreMap\` from the aggregation result
- Updated existing tests where \`chain.or\` is now invoked twice (one query each) and added a new test covering cross-page cascade stability
- Updated \`backend/CLAUDE.md\` to document the cascade behavior

## How to test
- [ ] \`npm test\` — all 411 tests pass
- [ ] Hit \`GET /discovery/recipes?page=1&limit=3\` and \`?page=2&limit=3\` — \`varieties[]\` and \`genres[]\` arrays should be identical
- [ ] Apply a filter (e.g. \`?country=Turkey\`) — cascade should reflect every matching recipe's parent variety/genre, not just the current page's

## Related issue
Closes #463