### PR TITLE
[Docs] Add cultural tagging feature spec, scenario 4, and mobile design notes

### DIFF
--- a/docs/design/mobile/instructions/05-search.md
+++ b/docs/design/mobile/instructions/05-search.md
@@ -16,11 +16,12 @@ Unified search and browse experience. Default state shows genre browsing; typing
 - **Allergen filter:** Multi-select; excludes varieties containing selected allergens
 - **Ingredients I have:** Multi-select; shows varieties makeable with those ingredients
 - **Region filter:** Country/region selector
+- **Cultural tags filter:** Multi-select chip selector backed by the curated cultural-tag taxonomy. **Region-scoped:** when a region is chosen above, the chip list re-renders to show only that region's tags plus global tags. Selecting a tag returns recipes carrying it, plus the cascaded varieties and genres that contain such recipes.
 - **Dietary tags:** Vegan, vegetarian, halal, kosher, gluten-free, etc.
 - "Apply" and "Clear All" buttons
 
 ## Active Search / Results State (05-search-refined)
-- Search bar with active query and active filter chips below (dismissable per chip)
+- Search bar with active query and active filter chips below (dismissable per chip) — including any active cultural-tag chips alongside region/dietary chips
 - **Sort row:** Best Rating | Most Recent | By Region (req 1.2.4)
   - Active sort highlighted in primary color
 - **Results count heading** (e.g., "6 Results for 'kebap'")

--- a/docs/design/mobile/instructions/09-recipe-detail.md
+++ b/docs/design/mobile/instructions/09-recipe-detail.md
@@ -38,6 +38,7 @@ Full recipe view — the most feature-rich page in the app.
 ### Story (req 1.2.1)
 - Cultural or personal story section
 - Displayed in a bordered card with serif italic text
+- **Cultural tag chips:** small terracotta chips rendered in a wrap row directly below the story text (e.g. *Sıra Gecesi*, *Social Gathering*). Tapping a chip opens the navigator pre-filtered by that tag and the recipe's region.
 
 ### Interaction
 - "View all comments" → Comments & Ratings (page 10)

--- a/docs/design/mobile/instructions/12-create-basic.md
+++ b/docs/design/mobile/instructions/12-create-basic.md
@@ -20,6 +20,7 @@ Two side-by-side cards presented before the manual form:
 - **Origin:** Country selector + Region text input
 - **Description** text area
 - **Story** text area — personal or cultural narrative
+- **Cultural tags:** multi-select chip selector backed by a curated taxonomy (e.g. *Wedding*, *Sıra Gecesi*, *Social Gathering*). The available tags are filtered by the region chosen in *Origin* — pick a region and the chip list re-renders to that region's tags plus global tags. Optional for community recipes; **required** when recipe type is *Cultural*.
 - **Dietary tags:** Vegan, Vegetarian, Halal, Kosher, Gluten-Free (chip selector — req 1.4.6)
 - **Allergen tags:** chip selector
 - "Next" button → Create: Ingredients & Tools (page 13)
@@ -29,6 +30,7 @@ Two side-by-side cards presented before the manual form:
 - Title required
 - Cultural recipe type only available for Expert role
 - Cultural recipe type requires a cultural story
+- Cultural recipes require at least one cultural tag
 
 ## States
 - **Default:** Import cards + empty form

--- a/docs/design/mobile/instructions/15-create-review.md
+++ b/docs/design/mobile/instructions/15-create-review.md
@@ -14,7 +14,7 @@ Final step of recipe creation. Preview the full recipe before publishing or savi
   - Ingredients with quantities and units
   - Tools list
   - Steps (numbered with titles, descriptions, and photos per step)
-  - Story
+  - Story (with selected cultural tag chips rendered below the story text)
   - Allergen and dietary tags
 - **"Publish" button** → publishes recipe (req 1.3.4)
 - **"Save as Draft" button** → saves to drafts (req 1.3.3)

--- a/docs/features/CulturalTagging.html
+++ b/docs/features/CulturalTagging.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Roots & Recipes — Cultural Tagging</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Newsreader:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&display=swap" rel="stylesheet">
+<style>
+  html, body { margin: 0; padding: 0; background: #f0eee9; font-family: 'Inter', system-ui, sans-serif; color: #2a251f; }
+  body { min-height: 100vh; }
+  *, *::before, *::after { box-sizing: border-box; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<!-- React + Babel -->
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<!-- Components -->
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="cultural-tag-chip.jsx"></script>
+<script type="text/babel" src="mobile-chrome.jsx"></script>
+<script type="text/babel" src="screens-search.jsx"></script>
+<script type="text/babel" src="screens-recipes.jsx"></script>
+<script type="text/babel" src="chip-showcase.jsx"></script>
+
+<script type="text/babel">
+  const PHONE_W = 390;
+  const PHONE_H = 844;
+
+  function App() {
+    return (
+      <DesignCanvas>
+        <DCSection
+          id="overview"
+          title="Roots & Recipes — Cultural Tagging"
+          subtitle="Additive change · 5 mobile frames + reusable component · Mirrors existing baseline">
+
+          <DCArtboard id="component" label="CulturalTagChip · component" width={720} height={420}>
+            <div style={{
+              width: 720, height: 420, background: '#FBF3EA',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              padding: 24,
+            }}>
+              <ChipShowcase />
+            </div>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection
+          id="search"
+          title="05 — Search"
+          subtitle="Filter sheet adds a region-scoped Cultural Tags multi-select. Active sıra-gecesi chip carries through to results.">
+
+          <DCArtboard id="filter-sheet" label="05-Search-Filter-Sheet" width={PHONE_W} height={PHONE_H}>
+            <SearchFilterSheet />
+          </DCArtboard>
+
+          <DCArtboard id="results" label="05-Search-Results" width={PHONE_W} height={PHONE_H}>
+            <SearchResults />
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection
+          id="recipe"
+          title="09 — Recipe Detail"
+          subtitle="Cultural-tag chip row directly below the Story card. Tapping a chip opens the navigator pre-filtered.">
+
+          <DCArtboard id="recipe-detail" label="09-Recipe-Detail" width={PHONE_W} height={PHONE_H}>
+            <RecipeDetail />
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection
+          id="create"
+          title="12 / 15 — Create flow"
+          subtitle="Cultural tags chip selector inserted between Story and Dietary on Basic Info. Chips also rendered in Review & Publish preview.">
+
+          <DCArtboard id="create-basic" label="12-Create-Basic" width={PHONE_W} height={PHONE_H}>
+            <CreateBasic />
+          </DCArtboard>
+
+          <DCArtboard id="create-review" label="15-Create-Review" width={PHONE_W} height={PHONE_H}>
+            <CreateReview />
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/features/cultural-tagging.md
+++ b/docs/features/cultural-tagging.md
@@ -1,0 +1,55 @@
+# Cultural Tagging
+
+## Purpose
+Each recipe carries a *Story* describing its cultural or personal context. Cultural tagging lets contributors label that story with one or more **cultural-event tags** (e.g. *wedding*, *funeral*, *new-year*, *sıra gecesi*, *social gathering*) so that other users can discover recipes through the lens of the occasions they're tied to. The intent is to surface food heritage by *event*, not just by ingredient or geography.
+
+## Tag Taxonomy
+Tags are drawn from a **curated, translatable taxonomy** — not free-form text. This keeps filtering consistent and makes EN/TR (and future locales) trivial.
+
+Initial tag pool (illustrative, not exhaustive):
+
+| Tag key            | EN label              | TR label             | Typical regions      |
+|--------------------|-----------------------|----------------------|----------------------|
+| `wedding`          | Wedding               | Düğün                | global               |
+| `funeral`          | Funeral / Mourning    | Cenaze / Yas         | global               |
+| `birth`            | Birth / Newborn       | Doğum                | global               |
+| `new-year`         | New Year              | Yılbaşı              | global               |
+| `harvest`          | Harvest               | Hasat                | global               |
+| `religious-feast`  | Religious Feast       | Dini Bayram          | global               |
+| `social-gathering` | Social Gathering      | Sosyal Toplantı      | global               |
+| `sira-gecesi`      | Sıra Gecesi           | Sıra Gecesi          | Turkey (Şanlıurfa)   |
+| `mochitsuki`       | Mochitsuki            | Mochitsuki           | Japan                |
+| `iftar`            | Iftar                 | İftar                | MENA, Turkey         |
+
+Each tag has an optional **region scope**. A tag with no region is considered global and shown for any region.
+
+## Data Model (sketch — not implemented in this ticket)
+- `cultural_tags` — `id`, `key`, `default_label`, `region_id` (nullable FK)
+- `cultural_tag_translations` — `tag_id`, `locale`, `label`
+- `recipe_cultural_tags` — `recipe_id`, `tag_id` (composite PK)
+
+## Cascade Filter Rule
+When the user filters by tag *X* in the navigator, the system returns:
+
+1. every **Recipe** with tag *X*
+2. every **DishVariety** that has at least one recipe with tag *X*
+3. every **DishGenre** that has at least one such variety
+
+The same cascade is reused if the user combines a tag filter with region, dietary, or genre filters — tag filtering is just another predicate ANDed onto existing search.
+
+## Region Scoping in the Navigator
+The cultural-tag filter in the search filter sheet is **region-scoped**. When the user picks a region, the cultural-tag chip list re-renders to show only tags whose `region_id` matches the chosen region (plus global tags). With no region selected, all tags are shown.
+
+This guides discovery — picking *Turkey* surfaces *sıra gecesi* and *düğün*; picking *Japan* surfaces *mochitsuki*.
+
+## Affected Mobile Screens
+- **Recipe Detail (09)** — chips rendered under the Story section; tapping a chip opens the navigator pre-filtered by that tag and the recipe's region.
+- **Create: Basic Info (12)** — chip selector below the Story textarea; required for *Cultural* recipe type.
+- **Create: Review & Publish (15)** — chips shown in the preview's Story block.
+- **Search & Browse (05)** — cultural-tag filter inside the filter sheet; active-filter chips shown above results.
+
+## Out of Scope (this ticket)
+- Backend implementation (schema migrations, endpoints, indexing)
+- Web frontend changes
+- Free-form tag entry / user-suggested tags
+- Tag moderation tooling

--- a/docs/scenarios/scenario-04-cultural-tagging.md
+++ b/docs/scenarios/scenario-04-cultural-tagging.md
@@ -1,0 +1,41 @@
+# Scenario 4 — Discovering Recipes by Cultural Event
+
+**Feature:** Cultural Tagging
+**Persona:** *Learner* — a curious home cook based in Turkey
+
+## Story
+A user opens the navigator and searches for recipes from **Japan**. Browsing the results, they tap into **Mochitsuki** and read its story — a Japanese New Year tradition of pounding rice into mochi as a community ritual. In the story they spot a chip labelled **Social Gathering**, one of the recipe's cultural tags.
+
+Now curious about *social-gathering* foods in their own region, they go back to the navigator and open the filter sheet. They set:
+
+- **Region:** Turkey
+- **Cultural Tag:** Social Gathering
+
+The cultural-tag chip list narrows to Turkey-relevant tags as soon as the region is chosen. Applying the filter, the results cascade: **Stews / Salads** genres surface, with **Çiğ Köfte** as one of the dish varieties, and a recipe for **Çiğ Köfte** tagged **Sıra Gecesi** appears.
+
+The user opens the recipe and reads its story, learning that *sıra gecesi* is a Şanlıurfa tradition where friends gather, take turns hosting, share folk music and food — and çiğ köfte is the centrepiece of the night.
+
+## Step-by-Step
+1. User taps **Search** in the bottom nav.
+2. Sets **Region = Japan** in the filter sheet, applies.
+3. Taps **Mochitsuki** in the variety results → Dish Variety detail.
+4. Opens the featured Mochitsuki recipe → Recipe Detail.
+5. Reads the *Story* section; sees the *Social Gathering* chip below it.
+6. Returns to Search; opens filter sheet again.
+7. Changes **Region** to **Turkey** — cultural-tag list re-renders to Turkey-scoped tags.
+8. Selects **Cultural Tag = Social Gathering**, applies.
+9. Sees cascaded results: genres → varieties → recipes containing tag *social-gathering* in the Turkey region.
+10. Taps the **Çiğ Köfte for Sıra Gecesi** recipe.
+11. Reads its story and learns about *sıra gecesi*.
+
+## Requirements Exercised
+- 1.4.1 / 1.4.3 — Region and tag filters in search
+- 1.4.4 — Filter results update dynamically
+- 1.2.1 — Recipe story is rendered
+- 2.x — Cross-cultural discovery / heritage exposition (cultural-tagging feature)
+
+## Success Criteria
+- Cultural-tag chips appear in the recipe's Story section and are tappable.
+- Filter sheet exposes a *Cultural Tag* multi-select that re-scopes when *Region* changes.
+- Filtered results obey the cascade rule (recipe → variety → genre).
+- The Çiğ Köfte / *Sıra Gecesi* story is reachable in ≤ 4 taps from the Mochitsuki recipe.


### PR DESCRIPTION
## What does this PR do?
Create the logic and design files for #373 — the **cultural tagging** feature:
- `docs/features/cultural-tagging.md` — feature brief: curated tag taxonomy, region scoping, recipe→variety→genre cascade rule.
- `docs/features/CulturalTagging.html` — design file for the feature.
- `docs/scenarios/scenario-04-cultural-tagging.md` — Scenario 4 (mirrored on the wiki): a learner discovers Mochitsuki's *Social Gathering* tag in Japan, switches the navigator to Turkey, and lands on a Çiğ Köfte recipe tagged *Sıra Gecesi*.
- Additive annotations on the affected mobile design instructions (`05-search`, `09-recipe-detail`, `12-create-basic`, `15-create-review`) describing the new chip selectors and region-scoped filter behavior. No other content in those files is changed.

Docs-only — no backend, frontend, or mobile code touched.

## How to test
- Open the new files and read them for clarity.
- Diff the four mobile design instruction files; confirm only additive cultural-tag content was added.
- Visit the wiki and confirm Scenario 4 appears under the Scenarios sidebar entry.

## Related issue
Create the logic and design files for #373.