### PR TITLE
Add speech-to-text functionality with parser retry logic for recipes

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -39,6 +39,7 @@ jobs:
         run: npm run build
         env:
           GEMINI_API_KEY: dummy-key-for-ci
+          ELEVENLABS_API_KEY: dummy-key-for-ci
           SUPABASE_URL: https://dummy.supabase.co
           SUPABASE_ANON_KEY: dummy-anon-key
 
@@ -46,5 +47,6 @@ jobs:
         run: npm test -- --testPathIgnorePatterns="src/__tests__/parse.test.ts"
         env:
           GEMINI_API_KEY: dummy-key-for-ci
+          ELEVENLABS_API_KEY: dummy-key-for-ci
           SUPABASE_URL: https://dummy.supabase.co
           SUPABASE_ANON_KEY: dummy-anon-key

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -22,6 +22,7 @@ Wiki: https://github.com/bounswe/bounswe2026group10/wiki
 | File Uploads | Multer |
 | Security | Helmet, CORS |
 | AI | Google Gemini 2.5 Flash (@google/generative-ai) |
+| Speech-to-Text | ElevenLabs Scribe v1 (`scribe_v1`) via REST |
 | Testing | Jest + Supertest + ts-jest |
 | Containerization | Docker (multi-stage, node:20-alpine) |
 
@@ -43,9 +44,11 @@ backend/
 │   ├── index.ts                 # Express app setup, middleware, route mounting
 │   ├── config/
 │   │   ├── supabase.ts          # Supabase client (anon + user-scoped)
-│   │   └── gemini.ts            # Google Gemini AI client config
+│   │   ├── gemini.ts            # Google Gemini AI client config
+│   │   └── elevenlabs.ts        # ElevenLabs STT client config (#413)
 │   ├── services/
-│   │   └── recipe-parser.ts     # Free-text recipe parser (Gemini AI)
+│   │   ├── recipe-parser.ts     # Free-text recipe parser (Gemini AI)
+│   │   └── transcription.ts     # ElevenLabs Scribe speech-to-text wrapper (#413)
 │   ├── middleware/
 │   │   ├── auth.ts              # requireAuth, requireRole middleware
 │   │   └── validate.ts          # Zod-based request body validation
@@ -264,6 +267,21 @@ Comments are coupled to ratings (Amazon-style): a non-creator must have a rating
   - Returns `{ ingredients: [{ name, originalQuantity, originalUnit, standardQuantity, standardUnit }], steps: [{ stepOrder, originalDescription, standardDescription }] }`
   - Region-aware: uses region hint (e.g. "Turkey") to resolve locale-specific units (çay bardağı → 100 ml) and expressions (kulak memesi kıvamı → clear description)
   - Uses Gemini 2.5 Flash AI for conversion
+- `POST /parse/recipe-audio` — Transcribe a recipe recording and parse it into structured recipe components (cook/expert only, #413)
+  - Accepts both **audio** files (mp3/wav/webm/m4a/ogg/flac) and **video** files (mp4/mov/webm/mkv); ElevenLabs Scribe extracts the audio track from videos server-side. Most recipe content in this project is captured on video, so the same endpoint serves both.
+  - Request: `multipart/form-data`
+    - `audio` (file, required) — audio or video file, max 100 MB. Field name is `audio` for both kinds.
+    - `language` (text, optional) — `"en"` | `"tr"` | `"auto"` (default `"auto"`); ignored if not one of these
+  - Pipeline: ElevenLabs Scribe (`scribe_v1`) for transcription → existing `parseRecipeText` (Gemini) for structuring
+  - Response: `{ transcription: { text, languageCode, languageProbability, truncated, source: "audio" | "video" }, recipe: { title, ingredients[], steps[], tools[] } }`
+  - Transcriptions longer than 5000 chars are truncated before being sent to the parser; the full transcript is still returned with `truncated: true` so the client can display what was heard
+  - Errors:
+    - 400 `MISSING_FILE` — no `audio` field
+    - 400 `INVALID_FILE_TYPE` — unsupported MIME type
+    - 400 `FILE_TOO_LARGE` — over 100 MB
+    - 400 `TRANSCRIPTION_TOO_SHORT` — transcription <10 chars (likely silence/noise)
+    - 500 `TRANSCRIPTION_FAILED` — ElevenLabs API failure
+    - 500 `PARSE_FAILED` — Gemini parser failure after a successful transcription
 
 ## User Roles & Permissions
 
@@ -303,6 +321,9 @@ Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/r
 - `INCOMPLETE_RECIPE` (400) — Missing fields for publish
 - `PARSE_FAILED` (500) — AI parsing of recipe text failed
 - `STANDARDIZATION_FAILED` (500) — AI unit standardization failed
+- `TRANSCRIPTION_FAILED` (500) — ElevenLabs speech-to-text request failed
+- `TRANSCRIPTION_TOO_SHORT` (400) — Transcription returned <10 chars (likely silence/noise)
+- `MISSING_FILE` / `INVALID_FILE_TYPE` / `FILE_TOO_LARGE` / `UPLOAD_ERROR` (400) — multipart upload errors (shared between `/media/upload` and `/parse/recipe-audio`)
 
 ### Validation
 - Zod schemas defined inline in route files
@@ -429,6 +450,7 @@ SUPABASE_ANON_KEY=<supabase-anon-key>
 DATABASE_URL=<postgres-connection-string>
 DIRECT_URL=<postgres-direct-connection-string>
 GEMINI_API_KEY=<google-gemini-api-key>
+ELEVENLABS_API_KEY=<elevenlabs-api-key>   # Speech-to-Text (Scribe v1) for /parse/recipe-audio
 ```
 
 ## Docker

--- a/backend/src/__tests__/parse.test.ts
+++ b/backend/src/__tests__/parse.test.ts
@@ -23,7 +23,14 @@ jest.mock("../services/recipe-parser.js", () => ({
   standardizeUnits: jest.fn(),
 }));
 
+// ─── Mock ElevenLabs (transcription service) ──────────────────────────────────
+
+jest.mock("../services/transcription.js", () => ({
+  transcribeAudio: jest.fn(),
+}));
+
 import { parseRecipeText, standardizeUnits } from "../services/recipe-parser.js";
+import { transcribeAudio } from "../services/transcription.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -331,5 +338,278 @@ describe("POST /parse/standardize-units", () => {
 
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe("STANDARDIZATION_FAILED");
+  });
+});
+
+// ─── POST /parse/recipe-audio ────────────────────────────────────────────────
+
+const mockTranscriptionEn = {
+  text: "Take two cups of flour, one egg, and mix them together. Knead the dough for ten minutes using a rolling pin. Bake in the oven at 350F for 20 minutes.",
+  languageCode: "eng",
+  languageProbability: 0.99,
+};
+
+const mockTranscriptionTr = {
+  text: "İki su bardağı un, bir yumurta alın ve karıştırın. Hamuru on dakika yoğurun ve fırında pişirin.",
+  languageCode: "tur",
+  languageProbability: 0.97,
+};
+
+describe("POST /parse/recipe-audio", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 if not authenticated", async () => {
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .attach("audio", Buffer.from("fake audio bytes"), {
+        filename: "recipe.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 if user is a learner", async () => {
+    setupAuthMock("learner");
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .attach("audio", Buffer.from("fake audio bytes"), {
+        filename: "recipe.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.message).toContain("roles: cook, expert");
+  });
+
+  it("returns 400 if no audio file is provided", async () => {
+    setupAuthMock("cook");
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_FILE");
+  });
+
+  it("returns 400 for unsupported file type", async () => {
+    setupAuthMock("cook");
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .attach("audio", Buffer.from("not really audio"), {
+        filename: "fake.txt",
+        contentType: "text/plain",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_FILE_TYPE");
+  });
+
+  it("returns 400 if transcription is too short to parse", async () => {
+    setupAuthMock("cook");
+    (transcribeAudio as jest.Mock).mockResolvedValue({
+      text: "hi",
+      languageCode: "eng",
+      languageProbability: 0.5,
+    });
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .attach("audio", Buffer.from("fake audio bytes"), {
+        filename: "recipe.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("TRANSCRIPTION_TOO_SHORT");
+  });
+
+  it("returns 500 if transcription service fails", async () => {
+    setupAuthMock("cook");
+    (transcribeAudio as jest.Mock).mockRejectedValue(new Error("ElevenLabs 429"));
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .attach("audio", Buffer.from("fake audio bytes"), {
+        filename: "recipe.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("TRANSCRIPTION_FAILED");
+  });
+
+  it("returns 500 if parser fails after a successful transcription", async () => {
+    setupAuthMock("cook");
+    (transcribeAudio as jest.Mock).mockResolvedValue(mockTranscriptionEn);
+    (parseRecipeText as jest.Mock).mockRejectedValue(new Error("Gemini timeout"));
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .attach("audio", Buffer.from("fake audio bytes"), {
+        filename: "recipe.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("PARSE_FAILED");
+  });
+
+  it("returns 200 with transcription + structured recipe (English, auto-detect)", async () => {
+    setupAuthMock("cook");
+    (transcribeAudio as jest.Mock).mockResolvedValue(mockTranscriptionEn);
+    (parseRecipeText as jest.Mock).mockResolvedValue(mockParsedResult);
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .attach("audio", Buffer.from("fake audio bytes"), {
+        filename: "recipe.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.transcription.text).toBe(mockTranscriptionEn.text);
+    expect(res.body.data.transcription.languageCode).toBe("eng");
+    expect(res.body.data.transcription.truncated).toBe(false);
+    expect(res.body.data.transcription.source).toBe("audio");
+    expect(res.body.data.recipe.title).toBe("Simple Bread");
+    expect(res.body.data.recipe.ingredients).toHaveLength(2);
+    expect(res.body.data.recipe.steps).toHaveLength(3);
+
+    // Auto-detect should pass language="auto" to the transcription service.
+    expect(transcribeAudio).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "audio/mpeg",
+      "recipe.mp3",
+      "auto"
+    );
+    // Parser is invoked with the raw transcription text.
+    expect(parseRecipeText).toHaveBeenCalledWith(mockTranscriptionEn.text);
+  });
+
+  it("accepts an MP4 video and tags the source as 'video'", async () => {
+    setupAuthMock("expert");
+    (transcribeAudio as jest.Mock).mockResolvedValue(mockTranscriptionEn);
+    (parseRecipeText as jest.Mock).mockResolvedValue(mockParsedResult);
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .attach("audio", Buffer.from("fake mp4 bytes"), {
+        filename: "cooking.mp4",
+        contentType: "video/mp4",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.transcription.source).toBe("video");
+    expect(transcribeAudio).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "video/mp4",
+      "cooking.mp4",
+      "auto"
+    );
+  });
+
+  it("accepts a MOV video", async () => {
+    setupAuthMock("expert");
+    (transcribeAudio as jest.Mock).mockResolvedValue(mockTranscriptionTr);
+    (parseRecipeText as jest.Mock).mockResolvedValue(mockParsedResult);
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .field("language", "tr")
+      .attach("audio", Buffer.from("fake mov bytes"), {
+        filename: "tarif.mov",
+        contentType: "video/quicktime",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.transcription.source).toBe("video");
+    expect(res.body.data.transcription.languageCode).toBe("tur");
+  });
+
+  it("forwards the language hint when caller specifies tr", async () => {
+    setupAuthMock("expert");
+    (transcribeAudio as jest.Mock).mockResolvedValue(mockTranscriptionTr);
+    (parseRecipeText as jest.Mock).mockResolvedValue(mockParsedResult);
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .field("language", "tr")
+      .attach("audio", Buffer.from("fake turkish audio"), {
+        filename: "tarif.m4a",
+        contentType: "audio/m4a",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.transcription.languageCode).toBe("tur");
+    expect(transcribeAudio).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "audio/m4a",
+      "tarif.m4a",
+      "tr"
+    );
+  });
+
+  it("ignores invalid language values and falls back to auto-detect", async () => {
+    setupAuthMock("cook");
+    (transcribeAudio as jest.Mock).mockResolvedValue(mockTranscriptionEn);
+    (parseRecipeText as jest.Mock).mockResolvedValue(mockParsedResult);
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .field("language", "klingon")
+      .attach("audio", Buffer.from("fake audio"), {
+        filename: "recipe.wav",
+        contentType: "audio/wav",
+      });
+
+    expect(res.status).toBe(200);
+    expect(transcribeAudio).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "audio/wav",
+      "recipe.wav",
+      "auto"
+    );
+  });
+
+  it("truncates very long transcriptions before passing to the parser", async () => {
+    setupAuthMock("cook");
+    const longText = "a".repeat(5500);
+    (transcribeAudio as jest.Mock).mockResolvedValue({
+      text: longText,
+      languageCode: "eng",
+      languageProbability: 0.95,
+    });
+    (parseRecipeText as jest.Mock).mockResolvedValue(mockParsedResult);
+
+    const res = await request(app)
+      .post("/parse/recipe-audio")
+      .set("Authorization", "Bearer valid_token")
+      .attach("audio", Buffer.from("fake audio"), {
+        filename: "long.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.transcription.truncated).toBe(true);
+    // Parser receives only the first 5000 characters.
+    const [parserArg] = (parseRecipeText as jest.Mock).mock.calls[0];
+    expect(parserArg).toHaveLength(5000);
+    // But the response still exposes the full transcription so the user can see it.
+    expect(res.body.data.transcription.text).toHaveLength(5500);
   });
 });

--- a/backend/src/__tests__/recipe-parser.test.ts
+++ b/backend/src/__tests__/recipe-parser.test.ts
@@ -1,0 +1,90 @@
+// Unit tests for the recipe-parser service. Specifically verifies the
+// transparent retry logic around Gemini, since the route-level tests
+// mock parseRecipeText wholesale and don't exercise the internals.
+
+jest.mock("../config/gemini.js", () => {
+  // Stable model object so every call to getGenerativeModel returns the
+  // same generateContent mock — required to assert call counts across
+  // retry attempts.
+  const generateContent = jest.fn();
+  const mockModel = { generateContent };
+  return {
+    genAI: { getGenerativeModel: jest.fn(() => mockModel) },
+    GEMINI_MODEL: "gemini-test",
+  };
+});
+
+import { genAI } from "../config/gemini.js";
+import { parseRecipeText } from "../services/recipe-parser.js";
+
+const getGenerateContentMock = (): jest.Mock => {
+  const model = genAI.getGenerativeModel({} as any) as unknown as {
+    generateContent: jest.Mock;
+  };
+  return model.generateContent;
+};
+
+const mockSuccessResponse = () => ({
+  response: {
+    text: () =>
+      JSON.stringify({
+        title: "Test Recipe",
+        ingredients: [{ name: "flour", quantity: 1, unit: "cup" }],
+        steps: [{ stepOrder: 1, description: "Mix it." }],
+        tools: [{ name: "bowl" }],
+      }),
+  },
+});
+
+describe("parseRecipeText retry behavior", () => {
+  beforeEach(() => {
+    getGenerateContentMock().mockReset();
+  });
+
+  it("returns the parsed recipe on first attempt when Gemini succeeds", async () => {
+    const generateContent = getGenerateContentMock();
+    generateContent.mockResolvedValueOnce(mockSuccessResponse());
+
+    const result = await parseRecipeText("a recipe long enough to pass min length");
+
+    expect(result.title).toBe("Test Recipe");
+    expect(generateContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries when Gemini throws and succeeds on the second attempt", async () => {
+    const generateContent = getGenerateContentMock();
+    generateContent
+      .mockRejectedValueOnce(new Error("Gemini transient 500"))
+      .mockResolvedValueOnce(mockSuccessResponse());
+
+    const result = await parseRecipeText("another long-enough recipe text");
+
+    expect(result.title).toBe("Test Recipe");
+    expect(generateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries when Gemini returns malformed JSON and succeeds on a later attempt", async () => {
+    const generateContent = getGenerateContentMock();
+    generateContent
+      .mockResolvedValueOnce({ response: { text: () => "not-json-at-all {{" } })
+      .mockResolvedValueOnce(mockSuccessResponse());
+
+    const result = await parseRecipeText("another long-enough recipe text");
+
+    expect(result.title).toBe("Test Recipe");
+    expect(generateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after 3 attempts and surfaces the last error", async () => {
+    const generateContent = getGenerateContentMock();
+    generateContent
+      .mockRejectedValueOnce(new Error("fail 1"))
+      .mockRejectedValueOnce(new Error("fail 2"))
+      .mockRejectedValueOnce(new Error("fail 3 final"));
+
+    await expect(parseRecipeText("another long-enough recipe text")).rejects.toThrow(
+      "fail 3 final"
+    );
+    expect(generateContent).toHaveBeenCalledTimes(3);
+  });
+});

--- a/backend/src/config/elevenlabs.ts
+++ b/backend/src/config/elevenlabs.ts
@@ -1,0 +1,17 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const apiKey = process.env["ELEVENLABS_API_KEY"];
+
+if (!apiKey) {
+  throw new Error("Missing ELEVENLABS_API_KEY environment variable.");
+}
+
+export const ELEVENLABS_API_KEY: string = apiKey;
+
+/** ElevenLabs Speech-to-Text endpoint. */
+export const ELEVENLABS_STT_URL = "https://api.elevenlabs.io/v1/speech-to-text";
+
+/** Default Speech-to-Text model — Scribe v1 supports 99+ languages incl. English & Turkish. */
+export const ELEVENLABS_STT_MODEL = "scribe_v1";

--- a/backend/src/routes/parse.ts
+++ b/backend/src/routes/parse.ts
@@ -1,12 +1,54 @@
-import { Router, type Response } from "express";
+import { Router, type Request, type Response } from "express";
+import multer from "multer";
 import { z } from "zod";
 import { requireAuth, requireRole } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import type { AuthenticatedRequest } from "../types/index.js";
 import { errorResponse, successResponse } from "../utils/response.js";
 import { parseRecipeText, standardizeUnits } from "../services/recipe-parser.js";
+import {
+  transcribeAudio,
+  type TranscriptionLanguage,
+} from "../services/transcription.js";
 
 const router = Router();
+
+// ─── Recipe-Audio/Video Upload Constants ─────────────────────────────────────
+//
+// ElevenLabs Scribe accepts both audio files and video containers (it extracts
+// the audio track server-side), so we whitelist both. The 100 MB cap matches
+// the video limit on /media/upload.
+
+const ALLOWED_AUDIO_TYPES = [
+  "audio/mpeg",        // mp3
+  "audio/mp3",
+  "audio/wav",
+  "audio/wave",
+  "audio/x-wav",
+  "audio/webm",
+  "audio/mp4",         // some m4a clients
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/ogg",
+  "audio/flac",
+  "audio/x-flac",
+];
+const ALLOWED_VIDEO_TYPES = [
+  "video/mp4",
+  "video/quicktime",   // .mov
+  "video/webm",
+  "video/x-matroska",  // .mkv
+];
+const ALLOWED_MEDIA_TYPES = [...ALLOWED_AUDIO_TYPES, ...ALLOWED_VIDEO_TYPES];
+
+const MAX_MEDIA_SIZE = 100 * 1024 * 1024; // 100 MB (matches /media/upload video limit)
+const MIN_TRANSCRIPTION_LENGTH = 10;      // matches /recipe-text minimum
+const MAX_TRANSCRIPTION_LENGTH = 5000;    // matches /recipe-text maximum
+
+const audioUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_MEDIA_SIZE },
+});
 
 // ─── Zod Schema ───────────────────────────────────────────────────────────────
 
@@ -45,10 +87,15 @@ router.post(
         })
       );
     } catch (err: any) {
-      console.error("Recipe parse error:", err);
+      console.error("Recipe parse error (after retries):", err);
       res
         .status(500)
-        .json(errorResponse("PARSE_FAILED", "Failed to parse recipe text. Please try again."));
+        .json(
+          errorResponse(
+            "PARSE_FAILED",
+            "Failed to parse recipe text after multiple attempts. Please try again in a moment."
+          )
+        );
     }
   }
 );
@@ -107,6 +154,165 @@ router.post(
           errorResponse(
             "STANDARDIZATION_FAILED",
             "Failed to standardize recipe. Please try again."
+          )
+        );
+    }
+  }
+);
+
+// ─── POST /parse/recipe-audio ───────────────────────────────────────────────
+
+/**
+ * Transcribe an uploaded recipe recording (English or Turkish) using
+ * ElevenLabs Scribe, then run the transcription through the existing
+ * Gemini recipe parser. Returns both the raw transcription and the
+ * structured recipe so the caller can show the user what was heard.
+ *
+ * Accepts both audio-only files and video containers — Scribe extracts
+ * the audio track from the video server-side. Most recipe content in this
+ * project is captured on video, so the same endpoint serves both.
+ *
+ * Request: multipart/form-data
+ *   - field "audio"     : audio (mp3/wav/webm/m4a/ogg/flac) or video
+ *                         (mp4/mov/webm/mkv) file, max 100 MB
+ *   - field "language"  : optional — "en" | "tr" | "auto" (default "auto")
+ *
+ * Auth required: Yes (cook or expert).
+ */
+router.post(
+  "/recipe-audio",
+  requireAuth,
+  requireRole("cook", "expert"),
+  (req: Request, res: Response, next) => {
+    audioUpload.single("audio")(req, res, (err) => {
+      if (err instanceof multer.MulterError) {
+        if (err.code === "LIMIT_FILE_SIZE") {
+          res
+            .status(400)
+            .json(errorResponse("FILE_TOO_LARGE", "File must be under 100 MB."));
+          return;
+        }
+        res.status(400).json(errorResponse("UPLOAD_ERROR", err.message));
+        return;
+      }
+      if (err) {
+        res.status(400).json(errorResponse("UPLOAD_ERROR", (err as Error).message));
+        return;
+      }
+      next();
+    });
+  },
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.file) {
+      res
+        .status(400)
+        .json(
+          errorResponse(
+            "MISSING_FILE",
+            "No file provided. Use field name 'audio' (also accepts video files)."
+          )
+        );
+      return;
+    }
+
+    const { mimetype, originalname, buffer } = req.file;
+
+    if (!ALLOWED_MEDIA_TYPES.includes(mimetype)) {
+      res
+        .status(400)
+        .json(
+          errorResponse(
+            "INVALID_FILE_TYPE",
+            "Unsupported format. Allowed audio: mp3, wav, webm, m4a, ogg, flac. Allowed video: mp4, mov, webm, mkv."
+          )
+        );
+      return;
+    }
+
+    const langInput = String(req.body?.["language"] ?? "auto").toLowerCase();
+    const language: TranscriptionLanguage =
+      langInput === "en" || langInput === "tr" ? langInput : "auto";
+
+    // ── Step 1: transcribe via ElevenLabs ──
+    let transcriptionText: string;
+    let languageCode: string;
+    let languageProbability: number;
+    try {
+      const result = await transcribeAudio(
+        buffer,
+        mimetype,
+        originalname || "audio",
+        language
+      );
+      transcriptionText = result.text;
+      languageCode = result.languageCode;
+      languageProbability = result.languageProbability;
+    } catch (err) {
+      console.error("Transcription error:", err);
+      res
+        .status(500)
+        .json(
+          errorResponse(
+            "TRANSCRIPTION_FAILED",
+            "Failed to transcribe audio. Please ensure the recording is clear and try again."
+          )
+        );
+      return;
+    }
+
+    // ── Step 2: guard against unusable transcripts ──
+    if (transcriptionText.length < MIN_TRANSCRIPTION_LENGTH) {
+      res
+        .status(400)
+        .json(
+          errorResponse(
+            "TRANSCRIPTION_TOO_SHORT",
+            "The transcribed text was too short to parse as a recipe. Please record a longer or clearer audio."
+          )
+        );
+      return;
+    }
+
+    // Cap to the same upper bound the text endpoint enforces, so the parser
+    // does not get an unbounded blob from a long recording.
+    const textForParser =
+      transcriptionText.length > MAX_TRANSCRIPTION_LENGTH
+        ? transcriptionText.slice(0, MAX_TRANSCRIPTION_LENGTH)
+        : transcriptionText;
+
+    // ── Step 3: parse the transcription into a structured recipe ──
+    try {
+      const parsed = await parseRecipeText(textForParser);
+
+      const sourceKind: "audio" | "video" = ALLOWED_VIDEO_TYPES.includes(mimetype)
+        ? "video"
+        : "audio";
+
+      res.status(200).json(
+        successResponse({
+          transcription: {
+            text: transcriptionText,
+            languageCode,
+            languageProbability,
+            truncated: transcriptionText.length > MAX_TRANSCRIPTION_LENGTH,
+            source: sourceKind,
+          },
+          recipe: {
+            title: parsed.title,
+            ingredients: parsed.ingredients,
+            steps: parsed.steps,
+            tools: parsed.tools,
+          },
+        })
+      );
+    } catch (err) {
+      console.error("Recipe parse error after transcription (after retries):", err);
+      res
+        .status(500)
+        .json(
+          errorResponse(
+            "PARSE_FAILED",
+            "Audio transcribed successfully but the recipe parser failed after multiple attempts. Please try again in a moment."
           )
         );
     }

--- a/backend/src/services/recipe-parser.ts
+++ b/backend/src/services/recipe-parser.ts
@@ -134,13 +134,54 @@ Return ONLY the JSON object, nothing else.`;
 // ─── Parser ───────────────────────────────────────────────────────────────────
 
 /**
+ * Number of times we'll try the Gemini parse before giving up. Gemini
+ * occasionally returns non-JSON output or 5xxs even with `responseMimeType:
+ * application/json`, and these failures are transient — retrying nearly
+ * always succeeds. The delays before retry attempts 2 and 3 (in ms).
+ */
+const MAX_PARSE_ATTEMPTS = 3;
+const PARSE_RETRY_DELAYS_MS = [300, 800];
+
+/** Sleep helper for retry backoff. */
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
  * Parses a free-text recipe narrative into structured components using Gemini AI.
+ * Retries up to MAX_PARSE_ATTEMPTS times on transient failures (Gemini API
+ * errors or malformed JSON). Only the final failure is surfaced to the caller.
  *
  * @param freeText - The free-text recipe narrative to parse.
  * @returns Parsed recipe with title, ingredients, steps, and tools.
- * @throws Error if the AI response cannot be parsed or the API call fails.
+ * @throws Error if every attempt fails.
  */
 export async function parseRecipeText(freeText: string): Promise<ParsedRecipe> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_PARSE_ATTEMPTS; attempt++) {
+    try {
+      return await parseRecipeTextOnce(freeText);
+    } catch (err) {
+      lastError = err;
+      if (attempt < MAX_PARSE_ATTEMPTS) {
+        console.warn(
+          `[parseRecipeText] attempt ${attempt}/${MAX_PARSE_ATTEMPTS} failed, retrying:`,
+          err instanceof Error ? err.message : err
+        );
+        await sleep(PARSE_RETRY_DELAYS_MS[attempt - 1] ?? 0);
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("parseRecipeText failed after all retries");
+}
+
+/**
+ * Single-attempt parse. Extracted from `parseRecipeText` so the retry loop
+ * stays simple. Throws on Gemini API failure or malformed JSON.
+ */
+async function parseRecipeTextOnce(freeText: string): Promise<ParsedRecipe> {
   const model = genAI.getGenerativeModel({ model: GEMINI_MODEL });
 
   const result = await model.generateContent({

--- a/backend/src/services/transcription.ts
+++ b/backend/src/services/transcription.ts
@@ -1,0 +1,93 @@
+import {
+  ELEVENLABS_API_KEY,
+  ELEVENLABS_STT_MODEL,
+  ELEVENLABS_STT_URL,
+} from "../config/elevenlabs.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type TranscriptionLanguage = "en" | "tr" | "auto";
+
+export interface TranscriptionResult {
+  text: string;
+  /** ISO 639-3 code returned by ElevenLabs (e.g. "eng", "tur"). */
+  languageCode: string;
+  /** Confidence in the detected language, 0..1. */
+  languageProbability: number;
+}
+
+// ─── Mappings ─────────────────────────────────────────────────────────────────
+
+/** Map our 2-letter UI codes to the ISO 639-3 codes ElevenLabs expects. */
+const LANGUAGE_HINT_MAP: Record<Exclude<TranscriptionLanguage, "auto">, string> = {
+  en: "eng",
+  tr: "tur",
+};
+
+// ─── Transcription ────────────────────────────────────────────────────────────
+
+/**
+ * Transcribes audio data using the ElevenLabs Scribe Speech-to-Text API.
+ * Auto-detects language by default; pass "en" or "tr" to force a language hint
+ * for noisy or short clips.
+ *
+ * @param audio - Raw audio buffer (mp3/wav/webm/m4a/ogg/flac).
+ * @param mimetype - MIME type of the audio (e.g. "audio/mpeg").
+ * @param filename - Original filename — included in the multipart payload so
+ *   ElevenLabs can detect the format from the extension as a fallback.
+ * @param language - "en" | "tr" | "auto". Defaults to "auto".
+ * @throws Error when the API call fails or the response contains no text.
+ */
+export async function transcribeAudio(
+  audio: Buffer,
+  mimetype: string,
+  filename: string,
+  language: TranscriptionLanguage = "auto"
+): Promise<TranscriptionResult> {
+  // Wrap the buffer in a Blob so the global FormData attaches it as a file part.
+  // Convert Buffer → Uint8Array (the bytes are the same view) so the Blob
+  // constructor type matches across Node fetch/undici versions.
+  const blob = new Blob([new Uint8Array(audio)], {
+    type: mimetype || "application/octet-stream",
+  });
+
+  const form = new FormData();
+  form.append("file", blob, filename || "audio");
+  form.append("model_id", ELEVENLABS_STT_MODEL);
+
+  if (language !== "auto") {
+    form.append("language_code", LANGUAGE_HINT_MAP[language]);
+  }
+
+  const response = await fetch(ELEVENLABS_STT_URL, {
+    method: "POST",
+    headers: {
+      "xi-api-key": ELEVENLABS_API_KEY,
+    },
+    body: form,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "");
+    throw new Error(
+      `ElevenLabs STT failed (${response.status}): ${errorBody.slice(0, 200) || response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as {
+    text?: unknown;
+    language_code?: unknown;
+    language_probability?: unknown;
+  };
+
+  const text = String(data?.text ?? "").trim();
+  if (!text) {
+    throw new Error("ElevenLabs STT returned empty transcription.");
+  }
+
+  return {
+    text,
+    languageCode: String(data?.language_code ?? "unknown"),
+    languageProbability: Number(data?.language_probability) || 0,
+  };
+}


### PR DESCRIPTION
This pull request introduces a new speech-to-text pipeline for recipes using ElevenLabs Scribe, allowing both audio and video uploads to be transcribed and parsed into structured recipe data. It also adds robust tests for the new endpoint and the Gemini-based recipe parser, and documents all changes in the backend docs. Key error cases and environment variable requirements are also handled.
(#413, #467)