### PR TITLE
Add continuous deployment job to backend CI workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -50,3 +50,30 @@ jobs:
           ELEVENLABS_API_KEY: dummy-key-for-ci
           SUPABASE_URL: https://dummy.supabase.co
           SUPABASE_ANON_KEY: dummy-anon-key
+
+  deploy:
+    name: Deploy to DigitalOcean
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push Docker image
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            -t registry.digitalocean.com/roots-recipes/roots-recipes-backend:latest \
+            --push \
+            .
+        working-directory: backend

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";


### PR DESCRIPTION
This pull request introduces a deployment workflow to the CI pipeline and includes a minor formatting change in the backend source code. The main focus is automating deployments to DigitalOcean when changes are pushed to the `main` branch.

**CI/CD Enhancements:**

* Added a `deploy` job to `.github/workflows/backend-ci.yml` that builds and pushes a Docker image to DigitalOcean Container Registry when changes are pushed to `main`. This job checks out the code, installs `doctl`, logs into the registry, and builds/pushes the Docker image from the `backend` directory.

**Code Formatting:**

* Added a blank line after the `dotenv/config` import in `backend/src/index.ts` to test deploy job.

Closes #480 