### PR TITLE
Add Swagger UI with OpenAPI 3.1 spec for all endpoints

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -493,4 +493,5 @@ Multi-stage build: TypeScript compile in builder stage, production deps only in 
 5. Mount the router in `src/index.ts` if new
 6. Add tests in `src/__tests__/`
 7. Run `npm test` to verify
-8. **Update this CLAUDE.md file** to reflect the changes
+8. **Update `src/docs/openapi.ts`** — add/modify/remove the corresponding path entry. The Swagger UI at `/api-docs` is auto-generated from this file, so it must stay in sync with the actual routes at all times.
+9. **Update this CLAUDE.md file** to reflect the changes

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@supabase/supabase-js": "^2.100.1",
+        "@types/swagger-ui-express": "^4.1.8",
         "cors": "^2.8.6",
         "deepl-node": "^1.25.0",
         "dotenv": "^17.3.1",
@@ -18,6 +19,7 @@
         "helmet": "^8.1.0",
         "multer": "^2.1.1",
         "pg": "^8.20.0",
+        "swagger-ui-express": "^5.0.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -1148,6 +1150,13 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
@@ -1349,7 +1358,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -1360,7 +1368,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1387,7 +1394,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1399,7 +1405,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1422,7 +1427,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -1493,21 +1497,18 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1517,7 +1518,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1553,6 +1553,16 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -5831,6 +5841,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.5.tgz",
+      "integrity": "sha512-7/FQfWe9A4qoyYFdAwy0chD0uDYidDp/ZT9VQ9LZlgD4AnnHJk8/+ytAA1HkJYOPySmK6helPDdJQMlcumt7HA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/synckit": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.100.1",
+    "@types/swagger-ui-express": "^4.1.8",
     "cors": "^2.8.6",
     "deepl-node": "^1.25.0",
     "dotenv": "^17.3.1",
@@ -25,6 +26,7 @@
     "helmet": "^8.1.0",
     "multer": "^2.1.1",
     "pg": "^8.20.0",
+    "swagger-ui-express": "^5.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -1,0 +1,1570 @@
+// OpenAPI 3.1.0 specification for Roots & Recipes API
+
+const bearerAuth = { bearerAuth: [] };
+
+export const openApiSpec = {
+  openapi: "3.1.0",
+  info: {
+    title: "Roots & Recipes API",
+    version: "1.0.0",
+    description:
+      "REST API for the Roots & Recipes cross-generational recipe and food heritage platform. " +
+      "All responses follow the envelope `{ success, data, error }`. " +
+      "Protected endpoints require `Authorization: Bearer <access_token>`.",
+  },
+  servers: [
+    {
+      url: "https://urchin-app-w5w4g.ondigitalocean.app",
+      description: "Production",
+    },
+    {
+      url: "http://localhost:3000",
+      description: "Local development",
+    },
+  ],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+        description: "Supabase JWT access token obtained from /auth/login",
+      },
+    },
+    schemas: {
+      // ── Envelope ────────────────────────────────────────────────────────────
+      ApiError: {
+        type: "object",
+        properties: {
+          success: { type: "boolean", example: false },
+          data: { type: "null" },
+          error: {
+            type: "object",
+            properties: {
+              code: { type: "string", example: "VALIDATION_ERROR" },
+              message: { type: "string", example: "Title must be at least 3 characters" },
+            },
+            required: ["code", "message"],
+          },
+        },
+      },
+      // ── Domain schemas ───────────────────────────────────────────────────────
+      UserProfile: {
+        type: "object",
+        properties: {
+          userId: { type: "string", format: "uuid" },
+          email: { type: "string", format: "email" },
+          username: { type: "string" },
+          role: { type: "string", enum: ["learner", "cook", "expert"] },
+          bio: { type: ["string", "null"] },
+          avatarUrl: { type: ["string", "null"] },
+          preferredLanguage: { type: ["string", "null"] },
+          region: { type: ["string", "null"] },
+        },
+      },
+      RecipeSummary: {
+        type: "object",
+        properties: {
+          id: { type: "string", format: "uuid" },
+          title: { type: "string" },
+          type: { type: "string", enum: ["community", "cultural"] },
+          averageRating: { type: ["number", "null"] },
+          ratingCount: { type: "integer" },
+          creatorId: { type: ["string", "null"], format: "uuid" },
+          creatorUsername: { type: ["string", "null"] },
+          dishVarietyId: { type: ["integer", "null"] },
+          dishVarietyName: { type: ["string", "null"] },
+          genreName: { type: ["string", "null"] },
+          country: { type: ["string", "null"] },
+          city: { type: ["string", "null"] },
+          district: { type: ["string", "null"] },
+          coverImageUrl: { type: ["string", "null"] },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+        },
+      },
+      RecipeIngredient: {
+        type: "object",
+        properties: {
+          ingredientId: { type: "integer" },
+          quantity: { type: "number" },
+          unit: { type: "string" },
+        },
+      },
+      RecipeStep: {
+        type: "object",
+        properties: {
+          stepOrder: { type: "integer" },
+          description: { type: "string" },
+          videoTimestamp: { type: ["number", "null"] },
+        },
+      },
+      RecipeTool: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+      },
+      MediaItem: {
+        type: "object",
+        properties: {
+          id: { type: "string", format: "uuid" },
+          url: { type: "string", format: "uri" },
+          type: { type: "string", enum: ["image", "video"] },
+          createdAt: { type: "string", format: "date-time" },
+        },
+      },
+      DietaryTag: {
+        type: "object",
+        properties: {
+          id: { type: "integer" },
+          name: { type: "string" },
+          nameEn: { type: ["string", "null"] },
+          nameTr: { type: ["string", "null"] },
+          category: { type: "string", enum: ["dietary", "allergen"] },
+        },
+      },
+      Allergen: {
+        type: "object",
+        properties: {
+          id: { type: "integer" },
+          name: { type: "string" },
+        },
+      },
+      DishVarietySummary: {
+        type: "object",
+        properties: {
+          id: { type: "integer" },
+          name: { type: "string" },
+          nameEn: { type: ["string", "null"] },
+          nameTr: { type: ["string", "null"] },
+          genreId: { type: "integer" },
+        },
+      },
+      DishGenre: {
+        type: "object",
+        properties: {
+          id: { type: "integer" },
+          name: { type: "string" },
+          nameEn: { type: ["string", "null"] },
+          nameTr: { type: ["string", "null"] },
+          description: { type: ["string", "null"] },
+          descriptionEn: { type: ["string", "null"] },
+          descriptionTr: { type: ["string", "null"] },
+          varieties: {
+            type: "array",
+            items: { $ref: "#/components/schemas/DishVarietySummary" },
+          },
+        },
+      },
+      Comment: {
+        type: "object",
+        properties: {
+          id: { type: "integer" },
+          recipeId: { type: "string", format: "uuid" },
+          userId: { type: "string", format: "uuid" },
+          username: { type: "string" },
+          body: { type: "string" },
+          score: { type: ["integer", "null"] },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: ["string", "null"], format: "date-time" },
+        },
+      },
+      Rating: {
+        type: "object",
+        properties: {
+          recipeId: { type: "string", format: "uuid" },
+          userId: { type: "string", format: "uuid" },
+          score: { type: "integer", minimum: 1, maximum: 5 },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: ["string", "null"], format: "date-time" },
+        },
+      },
+      Pagination: {
+        type: "object",
+        properties: {
+          page: { type: "integer", example: 1 },
+          limit: { type: "integer", example: 20 },
+          total: { type: "integer" },
+        },
+      },
+    },
+  },
+  paths: {
+    // ── Health ──────────────────────────────────────────────────────────────────
+    "/health": {
+      get: {
+        summary: "Health check",
+        tags: ["Meta"],
+        responses: {
+          "200": {
+            description: "Service is healthy",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    status: { type: "string", example: "ok" },
+                    timestamp: { type: "string", format: "date-time" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Auth ────────────────────────────────────────────────────────────────────
+    "/auth/register": {
+      post: {
+        summary: "Register a new user",
+        tags: ["Auth"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["email", "password", "username", "role"],
+                properties: {
+                  email: { type: "string", format: "email" },
+                  password: { type: "string", minLength: 6 },
+                  username: { type: "string" },
+                  role: { type: "string", enum: ["learner", "cook", "expert"] },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": { description: "User registered successfully" },
+          "400": { description: "Validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "409": { description: "Email or username already taken", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/auth/login": {
+      post: {
+        summary: "Login and obtain tokens",
+        tags: ["Auth"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["email", "password"],
+                properties: {
+                  email: { type: "string", format: "email" },
+                  password: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Login successful",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        accessToken: { type: "string" },
+                        refreshToken: { type: "string" },
+                        user: { $ref: "#/components/schemas/UserProfile" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Invalid credentials", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/auth/logout": {
+      post: {
+        summary: "Logout (invalidate session)",
+        tags: ["Auth"],
+        security: [bearerAuth],
+        responses: {
+          "200": { description: "Logged out successfully" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/auth/refresh": {
+      post: {
+        summary: "Refresh access token",
+        tags: ["Auth"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["refreshToken"],
+                properties: {
+                  refreshToken: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "New tokens issued" },
+          "401": { description: "Invalid or expired refresh token", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/auth/me": {
+      get: {
+        summary: "Get current user profile",
+        tags: ["Auth"],
+        security: [bearerAuth],
+        responses: {
+          "200": {
+            description: "Current user info",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { $ref: "#/components/schemas/UserProfile" },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/auth/profile": {
+      patch: {
+        summary: "Update current user profile",
+        tags: ["Auth"],
+        security: [bearerAuth],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  username: { type: "string" },
+                  bio: { type: "string" },
+                  avatarUrl: { type: "string", format: "uri" },
+                  preferredLanguage: { type: "string", enum: ["en", "tr"] },
+                  region: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Profile updated" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "409": { description: "Username already taken", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Recipes ─────────────────────────────────────────────────────────────────
+    "/recipes": {
+      get: {
+        summary: "List published recipes",
+        tags: ["Recipes"],
+        parameters: [
+          { name: "creatorId", in: "query", schema: { type: "string", format: "uuid" }, description: "Filter by creator's profile ID" },
+          { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 20 } },
+        ],
+        responses: {
+          "200": {
+            description: "Paginated list of published recipes",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        recipes: { type: "array", items: { $ref: "#/components/schemas/RecipeSummary" } },
+                        pagination: { $ref: "#/components/schemas/Pagination" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        summary: "Create a new recipe (cook/expert only)",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["title", "type"],
+                properties: {
+                  dishVarietyId: { type: "integer" },
+                  title: { type: "string", minLength: 3, maxLength: 200 },
+                  story: { type: "string", maxLength: 5000 },
+                  videoUrl: { type: "string", format: "uri" },
+                  servingSize: { type: "integer", minimum: 1, maximum: 100 },
+                  type: { type: "string", enum: ["community", "cultural"] },
+                  isPublished: { type: "boolean", default: false },
+                  country: { type: "string" },
+                  city: { type: "string" },
+                  district: { type: "string" },
+                  ingredients: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/RecipeIngredient" },
+                    default: [],
+                  },
+                  steps: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/RecipeStep" },
+                    default: [],
+                  },
+                  tools: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/RecipeTool" },
+                    default: [],
+                  },
+                  tagIds: { type: "array", items: { type: "integer" }, default: [] },
+                  allergenIds: { type: "array", items: { type: "integer" }, default: [] },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": { description: "Recipe created" },
+          "400": { description: "Validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Insufficient role", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/recipes/mine": {
+      get: {
+        summary: "List current user's own recipes (published + drafts)",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          {
+            name: "status",
+            in: "query",
+            schema: { type: "string", enum: ["published", "draft"] },
+            description: "Filter by publish status. Omit to return all.",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "List of the authenticated user's recipes",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { $ref: "#/components/schemas/RecipeSummary" } },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/recipes/{id}": {
+      get: {
+        summary: "Get recipe detail",
+        tags: ["Recipes"],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+          { name: "lang", in: "query", schema: { type: "string", enum: ["en", "tr"] }, description: "Return translated fields if available" },
+        ],
+        responses: {
+          "200": { description: "Recipe detail with ingredients, steps, tools, media, and tags" },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      patch: {
+        summary: "Update a draft recipe (creator only, cook/expert)",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                description: "All fields are optional — only provided fields are updated.",
+                properties: {
+                  dishVarietyId: { type: "integer" },
+                  title: { type: "string", minLength: 3, maxLength: 200 },
+                  story: { type: "string", maxLength: 5000 },
+                  videoUrl: { type: "string", format: "uri" },
+                  servingSize: { type: "integer", minimum: 1, maximum: 100 },
+                  type: { type: "string", enum: ["community", "cultural"] },
+                  country: { type: "string" },
+                  city: { type: "string" },
+                  district: { type: "string" },
+                  ingredients: { type: "array", items: { $ref: "#/components/schemas/RecipeIngredient" } },
+                  steps: { type: "array", items: { $ref: "#/components/schemas/RecipeStep" } },
+                  tools: { type: "array", items: { $ref: "#/components/schemas/RecipeTool" } },
+                  tagIds: { type: "array", items: { type: "integer" } },
+                  allergenIds: { type: "array", items: { type: "integer" } },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Recipe updated" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Not the creator or wrong role", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      delete: {
+        summary: "Delete a recipe (creator only)",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "204": { description: "Recipe deleted" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Not the creator", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/recipes/{id}/publish": {
+      post: {
+        summary: "Publish a draft recipe (creator only)",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "200": { description: "Recipe published" },
+          "400": { description: "Recipe incomplete for publishing", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Not the creator", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "409": { description: "Already published", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/recipes/{id}/scale": {
+      get: {
+        summary: "Scale recipe ingredient quantities to desired serving size",
+        tags: ["Recipes"],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+          { name: "servings", in: "query", required: true, schema: { type: "integer", minimum: 1, maximum: 1000 } },
+        ],
+        responses: {
+          "200": {
+            description: "Scaled ingredient quantities",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        recipeId: { type: "string", format: "uuid" },
+                        baseServings: { type: "integer" },
+                        requestedServings: { type: "integer" },
+                        ingredients: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              ingredientId: { type: "integer" },
+                              name: { type: "string" },
+                              scaledQuantity: { type: "number" },
+                              unit: { type: "string" },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "Invalid servings param or recipe has no base serving size", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/recipes/{id}/ratings": {
+      post: {
+        summary: "Rate a recipe (1-5). Cannot self-rate. Upserts existing rating.",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["score"],
+                properties: {
+                  score: { type: "integer", minimum: 1, maximum: 5 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Rating saved" },
+          "400": { description: "Validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Cannot self-rate", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/recipes/{id}/ratings/me": {
+      get: {
+        summary: "Get own rating for a recipe",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "200": {
+            description: "Own rating or null if not yet rated",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { oneOf: [{ $ref: "#/components/schemas/Rating" }, { type: "null" }] },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      delete: {
+        summary: "Delete own rating for a recipe",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "204": { description: "Rating deleted" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Rating not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/recipes/{id}/media": {
+      post: {
+        summary: "Attach a previously uploaded media item to a recipe (creator only)",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["url", "type"],
+                properties: {
+                  url: { type: "string", format: "uri" },
+                  type: { type: "string", enum: ["image", "video"] },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": { description: "Media attached" },
+          "403": { description: "Not the creator", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      get: {
+        summary: "List media for a recipe",
+        tags: ["Recipes"],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "200": {
+            description: "Media list",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { $ref: "#/components/schemas/MediaItem" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/recipes/{id}/media/{mediaId}": {
+      delete: {
+        summary: "Remove a media attachment (creator only)",
+        tags: ["Recipes"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+          { name: "mediaId", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "204": { description: "Media removed" },
+          "403": { description: "Not the creator", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Media not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/recipes/{id}/comments": {
+      post: {
+        summary: "Create a comment on a recipe. Requires a rating unless user is the recipe creator.",
+        tags: ["Comments"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["body"],
+                properties: {
+                  body: { type: "string", minLength: 1, maxLength: 2000 },
+                  score: { type: "integer", minimum: 1, maximum: 5, description: "If provided, upserts the user's rating in the same call." },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": { description: "Comment created" },
+          "400": { description: "Rating required or validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Creator tried to self-rate", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "409": { description: "User already has a comment on this recipe", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      get: {
+        summary: "List comments on a recipe (newest first)",
+        tags: ["Comments"],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+          { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 20, maximum: 100 } },
+        ],
+        responses: {
+          "200": {
+            description: "Paginated comments",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        comments: { type: "array", items: { $ref: "#/components/schemas/Comment" } },
+                        pagination: { $ref: "#/components/schemas/Pagination" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Comments ────────────────────────────────────────────────────────────────
+    "/comments/{id}": {
+      patch: {
+        summary: "Edit own comment",
+        tags: ["Comments"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "integer" } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["body"],
+                properties: {
+                  body: { type: "string", minLength: 1, maxLength: 2000 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Comment updated" },
+          "403": { description: "Not the comment author", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Comment not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      delete: {
+        summary: "Delete own comment",
+        tags: ["Comments"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "integer" } },
+        ],
+        responses: {
+          "204": { description: "Comment deleted" },
+          "403": { description: "Not the comment author", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Comment not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Dish Genres ─────────────────────────────────────────────────────────────
+    "/dish-genres": {
+      get: {
+        summary: "List all dish genres with nested varieties",
+        tags: ["Dish Genres"],
+        parameters: [
+          { name: "lang", in: "query", schema: { type: "string", enum: ["en", "tr"] }, description: "Return single resolved name/description instead of _en/_tr pair" },
+        ],
+        responses: {
+          "200": {
+            description: "All genres",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { $ref: "#/components/schemas/DishGenre" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Dish Varieties ──────────────────────────────────────────────────────────
+    "/dish-varieties": {
+      get: {
+        summary: "List dish varieties with optional filters",
+        tags: ["Dish Varieties"],
+        parameters: [
+          { name: "genreId", in: "query", schema: { type: "integer" } },
+          { name: "search", in: "query", schema: { type: "string" }, description: "Case-insensitive, Turkish-aware partial name match" },
+          { name: "lang", in: "query", schema: { type: "string", enum: ["en", "tr"] } },
+        ],
+        responses: {
+          "200": { description: "List of varieties" },
+        },
+      },
+    },
+    "/dish-varieties/{id}": {
+      get: {
+        summary: "Get a single dish variety with its published recipes",
+        tags: ["Dish Varieties"],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "integer" } },
+          { name: "lang", in: "query", schema: { type: "string", enum: ["en", "tr"] } },
+        ],
+        responses: {
+          "200": { description: "Variety detail" },
+          "404": { description: "Variety not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/dish-varieties/{id}/recipes": {
+      get: {
+        summary: "Get recipes for a variety split into expert and community",
+        tags: ["Dish Varieties"],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "integer" } },
+        ],
+        responses: {
+          "200": {
+            description: "Expert recipe + community recipes",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        expertRecipe: { oneOf: [{ $ref: "#/components/schemas/RecipeSummary" }, { type: "null" }] },
+                        communityRecipes: { type: "array", items: { $ref: "#/components/schemas/RecipeSummary" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Ingredients ─────────────────────────────────────────────────────────────
+    "/ingredients": {
+      get: {
+        summary: "List or search ingredients",
+        tags: ["Ingredients"],
+        parameters: [
+          { name: "search", in: "query", schema: { type: "string" }, description: "Turkish-aware case-insensitive partial match" },
+          { name: "lang", in: "query", schema: { type: "string", enum: ["en", "tr"] } },
+        ],
+        responses: {
+          "200": { description: "List of ingredients" },
+        },
+      },
+      post: {
+        summary: "Create a new ingredient (cook/expert only)",
+        tags: ["Ingredients"],
+        security: [bearerAuth],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  nameEn: { type: "string" },
+                  nameTr: { type: "string" },
+                },
+                description: "At least one of nameEn or nameTr is required.",
+              },
+            },
+          },
+        },
+        responses: {
+          "201": { description: "Ingredient created" },
+          "400": { description: "Validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "409": { description: "Ingredient with same name already exists", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/ingredients/{id}/substitutions": {
+      get: {
+        summary: "Get ingredient substitutions with optional quantity scaling",
+        tags: ["Ingredients"],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "integer" } },
+          { name: "amount", in: "query", schema: { type: "number" }, description: "Source amount to scale substitution quantities" },
+          { name: "unit", in: "query", schema: { type: "string" }, description: "Source unit (e.g. gr)" },
+        ],
+        responses: {
+          "200": { description: "List of substitutions with proportionally scaled amounts if amount+unit provided" },
+          "400": { description: "Invalid params", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Ingredient not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Allergens ───────────────────────────────────────────────────────────────
+    "/allergens": {
+      get: {
+        summary: "List all allergens",
+        tags: ["Allergens"],
+        responses: {
+          "200": {
+            description: "All allergens",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { $ref: "#/components/schemas/Allergen" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/allergens/detect": {
+      post: {
+        summary: "Detect allergens for a list of ingredient IDs",
+        tags: ["Allergens"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["ingredientIds"],
+                properties: {
+                  ingredientIds: { type: "array", items: { type: "integer" }, minItems: 1 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Distinct allergens found across the given ingredients",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { $ref: "#/components/schemas/Allergen" } },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "Validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Dietary Tags ────────────────────────────────────────────────────────────
+    "/dietary-tags": {
+      get: {
+        summary: "List all dietary and allergen tags",
+        tags: ["Dietary Tags"],
+        parameters: [
+          { name: "lang", in: "query", schema: { type: "string", enum: ["en", "tr"] } },
+        ],
+        responses: {
+          "200": {
+            description: "All dietary tags",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { $ref: "#/components/schemas/DietaryTag" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Discovery ───────────────────────────────────────────────────────────────
+    "/discovery/recipes": {
+      get: {
+        summary: "Filtered recipe discovery",
+        tags: ["Discovery"],
+        parameters: [
+          { name: "genreId", in: "query", schema: { type: "integer" } },
+          { name: "varietyId", in: "query", schema: { type: "integer" } },
+          { name: "excludeAllergens", in: "query", schema: { type: "string" }, description: "Comma-separated allergen IDs to exclude" },
+          { name: "tagIds", in: "query", schema: { type: "string" }, description: "Comma-separated dietary tag IDs — recipes must have ALL specified tags" },
+          { name: "search", in: "query", schema: { type: "string" }, description: "Case-insensitive partial match on recipe title" },
+          { name: "country", in: "query", schema: { type: "string" }, description: "Alias-aware (e.g. 'tr'/'Türkiye' both match 'Turkey')" },
+          { name: "city", in: "query", schema: { type: "string" } },
+          { name: "district", in: "query", schema: { type: "string" } },
+          { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 20 } },
+        ],
+        responses: {
+          "200": {
+            description: "Filtered recipes with cross-page-stable varieties and genres for filter dropdowns",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        recipes: { type: "array", items: { $ref: "#/components/schemas/RecipeSummary" } },
+                        pagination: { $ref: "#/components/schemas/Pagination" },
+                        varieties: { type: "array", items: { $ref: "#/components/schemas/DishVarietySummary" } },
+                        genres: { type: "array", items: { $ref: "#/components/schemas/DishGenre" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/discovery/recipes/by-ingredients": {
+      get: {
+        summary: "Find recipes fully makeable with the provided ingredients",
+        tags: ["Discovery"],
+        parameters: [
+          { name: "ingredientIds", in: "query", required: true, schema: { type: "string" }, description: "Comma-separated ingredient IDs. Only returns recipes whose every ingredient is in this list." },
+          { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 20 } },
+        ],
+        responses: {
+          "200": { description: "Recipes fully makeable with given ingredients" },
+          "400": { description: "Missing ingredientIds", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/discovery/locations": {
+      get: {
+        summary: "Get distinct location values for published recipes",
+        tags: ["Discovery"],
+        parameters: [
+          { name: "country", in: "query", schema: { type: "string" }, description: "If provided, returns distinct cities in that country" },
+          { name: "city", in: "query", schema: { type: "string" }, description: "If provided alongside country, returns distinct districts" },
+        ],
+        responses: {
+          "200": {
+            description: "Deduplicated, alias-aware location values",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "object", properties: { results: { type: "array", items: { type: "string" } } } },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "city provided without country", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Parse ───────────────────────────────────────────────────────────────────
+    "/parse/recipe-text": {
+      post: {
+        summary: "Parse free-text recipe into structured components (Gemini AI, cook/expert only)",
+        tags: ["Parse"],
+        security: [bearerAuth],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["text"],
+                properties: {
+                  text: { type: "string", minLength: 10, maxLength: 5000 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Structured recipe components (not persisted)",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        title: { type: "string" },
+                        ingredients: { type: "array", items: { type: "object" } },
+                        steps: { type: "array", items: { type: "object" } },
+                        tools: { type: "array", items: { type: "string" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "Text too short/long", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Insufficient role", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "500": { description: "AI parsing failed", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/parse/standardize-units": {
+      post: {
+        summary: "Standardize informal ingredient units and step descriptions (Gemini AI, cook/expert only)",
+        tags: ["Parse"],
+        security: [bearerAuth],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["ingredients"],
+                properties: {
+                  ingredients: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        name: { type: "string" },
+                        quantity: { type: ["number", "string"] },
+                        unit: { type: "string" },
+                      },
+                    },
+                  },
+                  steps: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        stepOrder: { type: "integer" },
+                        description: { type: "string" },
+                      },
+                    },
+                  },
+                  region: { type: "string", description: "e.g. 'Turkey' for locale-specific unit resolution" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Standardized ingredients and steps" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Insufficient role", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "500": { description: "AI standardization failed", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/parse/recipe-audio": {
+      post: {
+        summary: "Transcribe audio/video and parse into structured recipe (ElevenLabs + Gemini, cook/expert only)",
+        tags: ["Parse"],
+        security: [bearerAuth],
+        requestBody: {
+          required: true,
+          content: {
+            "multipart/form-data": {
+              schema: {
+                type: "object",
+                required: ["audio"],
+                properties: {
+                  audio: {
+                    type: "string",
+                    format: "binary",
+                    description: "Audio (mp3/wav/webm/m4a/ogg/flac) or video (mp4/mov/webm/mkv) file, max 100 MB",
+                  },
+                  language: {
+                    type: "string",
+                    enum: ["en", "tr", "auto"],
+                    default: "auto",
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Transcription + structured recipe components",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        transcription: {
+                          type: "object",
+                          properties: {
+                            text: { type: "string" },
+                            languageCode: { type: "string" },
+                            truncated: { type: "boolean" },
+                            source: { type: "string", enum: ["audio", "video"] },
+                          },
+                        },
+                        recipe: { type: "object" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "Missing file, invalid type, or file too large", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "500": { description: "Transcription or parsing failed", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Media ───────────────────────────────────────────────────────────────────
+    "/media/upload": {
+      post: {
+        summary: "Upload an image or video file (cook/expert only)",
+        tags: ["Media"],
+        security: [bearerAuth],
+        requestBody: {
+          required: true,
+          content: {
+            "multipart/form-data": {
+              schema: {
+                type: "object",
+                required: ["file"],
+                properties: {
+                  file: {
+                    type: "string",
+                    format: "binary",
+                    description: "Images: JPEG/PNG/WebP max 10 MB. Videos: MP4/MOV max 100 MB.",
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Upload successful — returns the Supabase storage URL",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        url: { type: "string", format: "uri" },
+                        type: { type: "string", enum: ["image", "video"] },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "Invalid file type or size exceeded", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Tools ───────────────────────────────────────────────────────────────────
+    "/tools": {
+      get: {
+        summary: "List or search cooking tools",
+        tags: ["Tools & Units"],
+        parameters: [
+          { name: "search", in: "query", schema: { type: "string" }, description: "Turkish-aware partial match" },
+        ],
+        responses: {
+          "200": {
+            description: "Distinct tool names",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Units ───────────────────────────────────────────────────────────────────
+    "/units": {
+      get: {
+        summary: "List or search measurement units",
+        tags: ["Tools & Units"],
+        parameters: [
+          { name: "search", in: "query", schema: { type: "string" }, description: "Turkish-aware partial match" },
+        ],
+        responses: {
+          "200": {
+            description: "Distinct unit values",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Users ───────────────────────────────────────────────────────────────────
+    "/users/me/favorites": {
+      get: {
+        summary: "List current user's favorited recipes",
+        tags: ["Users"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 20, maximum: 100 } },
+        ],
+        responses: {
+          "200": {
+            description: "Paginated favorite recipes with allergen details",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        recipes: { type: "array", items: { $ref: "#/components/schemas/RecipeSummary" } },
+                        pagination: { $ref: "#/components/schemas/Pagination" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/users/me/favorites/{recipeId}": {
+      post: {
+        summary: "Add a recipe to favorites",
+        tags: ["Users"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "recipeId", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "201": { description: "Recipe added to favorites" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found or not published", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "409": { description: "Already in favorites", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      delete: {
+        summary: "Remove a recipe from favorites",
+        tags: ["Users"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "recipeId", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "204": { description: "Removed from favorites" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Favorite not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/users/me/drafts": {
+      get: {
+        summary: "List current user's draft recipes",
+        tags: ["Users"],
+        security: [bearerAuth],
+        responses: {
+          "200": {
+            description: "Draft recipes ordered newest first",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { $ref: "#/components/schemas/RecipeSummary" } },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+  },
+
+  tags: [
+    { name: "Meta", description: "Health and service info" },
+    { name: "Auth", description: "Registration, login, token management, profile" },
+    { name: "Recipes", description: "Recipe CRUD, publish, ratings, media" },
+    { name: "Comments", description: "Recipe comments" },
+    { name: "Dish Genres", description: "Cuisine genre catalogue" },
+    { name: "Dish Varieties", description: "Specific dish catalogue" },
+    { name: "Ingredients", description: "Ingredient search and substitutions" },
+    { name: "Allergens", description: "Allergen listing and detection" },
+    { name: "Dietary Tags", description: "Dietary and allergen tag catalogue" },
+    { name: "Discovery", description: "Filtered recipe discovery and location lookup" },
+    { name: "Parse", description: "AI-powered recipe parsing from text and audio" },
+    { name: "Media", description: "File upload" },
+    { name: "Tools & Units", description: "Cooking tool and measurement unit lookup" },
+    { name: "Users", description: "Favorites and drafts" },
+  ],
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,8 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";
+import swaggerUi from "swagger-ui-express";
+import { openApiSpec } from "./docs/openapi";
 import { detectLanguage } from "./middleware/language.js";
 import authRouter from "./routes/auth.js";
 import recipesRouter from "./routes/recipes.js";
@@ -22,6 +24,9 @@ import allergensRouter from "./routes/allergens.js";
 
 const app = express();
 const PORT = process.env["PORT"] ?? 3000;
+
+// ─── Swagger UI (mounted before helmet so CSP doesn't block the UI assets) ────
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(openApiSpec));
 
 // ─── Global Middleware ────────────────────────────────────────────────────────
 app.use(helmet());


### PR DESCRIPTION
This pull request adds Swagger UI documentation to the backend API, making it easier for developers and users to explore and understand available endpoints. It introduces the `swagger-ui-express` middleware, ensures OpenAPI documentation stays in sync with routes, and updates dependencies accordingly.

**API Documentation Integration:**

* Added `swagger-ui-express` and its type definitions as dependencies, enabling interactive API documentation at `/api-docs`. 

**Documentation Process Improvements:**

* Updated `CLAUDE.md` to require updating `src/docs/openapi.ts` for any new, modified, or removed routes, ensuring documentation matches implementation. (`backend/CLAUDE.md`)

**Dependency Management:**

* Added new dependencies (`swagger-ui-express`, `swagger-ui-dist`, `@types/swagger-ui-express`, and `@scarf/scarf`) and updated `package-lock.json` accordingly. (`backend/package-lock.json`)

Closes #486 