### PR TITLE
[Backend/Feature] Manual video timestamp annotations

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -67,6 +67,7 @@ backend/
 │   │   ├── tools.ts             # Tool search/autocomplete
 │   │   ├── units.ts             # Unit search/autocomplete
 │   │   ├── comments.ts          # Recipe comments (create, list, delete)
+│   │   ├── video-annotations.ts # Manual timestamp annotations on recipe videos
 │   │   └── parse.ts             # Free-text recipe parser endpoint
 │   ├── types/
 │   │   └── index.ts             # TypeScript interfaces (roles, auth, response, SupportedLanguage, LanguageRequest)
@@ -112,6 +113,7 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - **ratings** — `id`, `recipe_id` (FK), `user_id` (FK profiles), `score` (1-5), `created_at`, `updated_at` — unique constraint on (recipe_id, user_id)
 - **recipe_dietary_tags** — `recipe_id` (FK recipes), `tag_id` (FK dietary_tags) — composite PK
 - **comments** — `id` (serial PK), `recipe_id` (FK recipes ON DELETE CASCADE), `user_id` (FK profiles ON DELETE CASCADE), `text` (1–2000 chars, CHECK), `created_at`, `updated_at` (nullable). Indexed on `recipe_id`, `user_id`, and `(recipe_id, created_at DESC)`. **Unique constraint on `(recipe_id, user_id)`** — one comment per user per recipe; the API enforces this with a pre-insert existence check and also maps Postgres `unique_violation` (23505) on insert to 409 `COMMENT_ALREADY_EXISTS` to handle the race window. The API exposes the column as `body`; the route maps `body` ↔ `text` at the DB boundary.
+- **video_annotations** — `id` (serial PK), `recipe_id` (FK recipes), `start_time` / `end_time` (numeric seconds into the video, both `>= 0`, `end_time >= start_time` enforced both at the DB CHECK level and in the route), `note` (1–500 chars, CHECK), `technique` (text, nullable — short label like "Searing"), `created_at`. Used for manual timestamp **ranges** placed by the recipe creator (cook/expert) on top of an uploaded video — e.g. "putting the chicken in the oven" from 42.5s to 56.78s. Two complementary surfaces, both creator-only: per-step start markers via `recipe_steps.video_timestamp` (single point — when the step begins), and standalone time-range annotations via this table.
 
 ### Reference Tables
 
@@ -164,6 +166,10 @@ Migration `002_en_tr_language_fields.sql` adds these columns and seeds `_en` fro
 - `GET /recipes/:id/media` — List recipe media
 - `DELETE /recipes/:id/media/:mediaId` — Remove media (creator only)
 - `GET /recipes/:id/scale` — Scale ingredient quantities to a desired serving size (#163)
+  
+  **Note (#422 — manual video timestamps):**
+  - `GET /recipes/:id` now also returns `videoAnnotations[]` (sorted by `timestamp` asc), so the frontend can render step descriptions and standalone markers in a single call.
+  - `recipe_steps[].videoTimestamp` is the per-step timestamp (already in the DB as `video_timestamp`); both `POST /recipes` and `PATCH /recipes/:id` now persist it on insert and on full step replace.
   - Query params: `servings` (required, integer 1–1000)
   - Returns `{ recipeId, baseServings, requestedServings, ingredients[] }` with proportionally scaled quantities
   - Returns 400 if `servings` param is invalid or recipe has no base serving size set
@@ -261,6 +267,25 @@ Comments are coupled to ratings (Amazon-style): a non-creator must have a rating
 - `DELETE /comments/:id` — Delete own comment (auth required, author only)
   - Returns 403 if the user is not the comment author
   - Returns 404 if the comment does not exist
+
+### Video Annotations (#422)
+
+Manual timestamp **ranges** a cook/expert places on the recipe's uploaded video (e.g. "putting the chicken in the oven" from `42.5s` to `56.78s`). Annotations are independent of `recipe_steps`: steps still own their own `videoTimestamp` (single start point), while annotations are time intervals that can sit anywhere on the video. Reads are public for published recipes; writes (POST/PATCH/DELETE) are creator-only and require `cook` or `expert` role for create.
+
+- `POST /recipes/:id/annotations` — Create an annotation on a recipe (auth required, cook/expert, creator only)
+  - Body: `{ startTime: number (>=0), endTime: number (>= startTime), note: string (1–500 chars, trimmed), technique?: string | null }`
+  - Returns 404 if the recipe does not exist, 403 if the caller is not the creator (or wrong role), 400 on validation failures (including `endTime < startTime`)
+  - Response: a single `VideoAnnotation` (`id`, `recipeId`, `startTime`, `endTime`, `note`, `technique`, `createdAt`)
+- `GET /recipes/:id/annotations` — List annotations sorted by `startTime` ascending
+  - Public for published recipes. Drafts are 403 unless the caller is the creator (token resolved via the same path as `GET /recipes/:id`)
+  - Returns 404 if the recipe does not exist
+- `PATCH /annotations/:annotationId` — Edit an existing annotation (auth required, recipe creator only)
+  - Body: `{ startTime?: number, endTime?: number, note?: string, technique?: string | null }` — at least one field required. The route fetches the existing row and validates the merged (existing + patched) range so that single-sided updates never produce `endTime < startTime` (returns 400 `VALIDATION_ERROR` if they would)
+  - Returns 404 if the annotation does not exist, 403 if the caller is not the recipe creator
+- `DELETE /annotations/:annotationId` — Delete an annotation (auth required, recipe creator only)
+  - Returns 204 on success, 404 if missing, 403 if not the creator
+
+`GET /recipes/:id` includes `videoAnnotations[]` (sorted by `startTime` asc) in the response envelope so the frontend can render the video player overlay alongside steps in a single call.
 
 ### Parse (`/parse`)
 - `POST /parse/recipe-text` — Parse free-text recipe into structured components (cook/expert only)

--- a/backend/src/__tests__/video-annotations.test.ts
+++ b/backend/src/__tests__/video-annotations.test.ts
@@ -1,0 +1,564 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+
+  return {
+    supabase: {
+      auth: { getUser: jest.fn() },
+      from: mockFrom,
+    },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+// ─── Helpers (mirrors the pattern in comments.test.ts) ──────────────────────
+
+const setupAuthAndTables = (
+  role: string,
+  profileId: string,
+  tableMock: (table: string) => any,
+  username = "tester"
+) => {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "user-123", email: "test@example.com" } },
+    error: null,
+  });
+
+  (supabase.from as jest.Mock).mockImplementation((table) => {
+    if (table === "profiles") {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: profileId, username, role },
+        error: null,
+      });
+      const mockMaybeSingle = jest.fn().mockResolvedValue({
+        data: { id: profileId },
+        error: null,
+      });
+      const mockEq = jest.fn().mockReturnValue({
+        single: mockSingle,
+        maybeSingle: mockMaybeSingle,
+      });
+      return { select: jest.fn().mockReturnValue({ eq: mockEq }) };
+    }
+    return tableMock(table);
+  });
+};
+
+const chainable = (resolved: { data: any; error: any; count?: number | null }) => {
+  const mock: any = {};
+  const methods = [
+    "select",
+    "eq",
+    "single",
+    "maybeSingle",
+    "insert",
+    "delete",
+    "update",
+    "order",
+  ];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  return mock;
+};
+
+const okAnnotation = {
+  id: 7,
+  recipe_id: "recipe-1",
+  start_time: 42.5,
+  end_time: 56.78,
+  note: "Putting the chicken in the oven",
+  technique: null,
+  created_at: "2026-05-09T00:00:00Z",
+};
+
+// ─── POST /recipes/:id/annotations ───────────────────────────────────────────
+
+describe("POST /recipes/:id/annotations", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .send({ startTime: 10, endTime: 20, note: "Step note" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is a learner", async () => {
+    setupAuthAndTables("learner", "profile-123", () => chainable({ data: null, error: null }));
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({ startTime: 10, endTime: 20, note: "Step note" });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 when startTime is negative", async () => {
+    setupAuthAndTables("cook", "profile-123", () => chainable({ data: null, error: null }));
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({ startTime: -1, endTime: 5, note: "Step note" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when endTime is before startTime", async () => {
+    setupAuthAndTables("cook", "profile-123", () => chainable({ data: null, error: null }));
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({ startTime: 30, endTime: 20, note: "Step note" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when endTime is missing", async () => {
+    setupAuthAndTables("cook", "profile-123", () => chainable({ data: null, error: null }));
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({ startTime: 10, note: "Step note" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when note is empty", async () => {
+    setupAuthAndTables("cook", "profile-123", () => chainable({ data: null, error: null }));
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({ startTime: 10, endTime: 20, note: "" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when note exceeds 500 characters", async () => {
+    setupAuthAndTables("cook", "profile-123", () => chainable({ data: null, error: null }));
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({ startTime: 10, endTime: 20, note: "x".repeat(501) });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 404 when recipe does not exist", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/missing/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({ startTime: 10, endTime: 20, note: "Step note" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 403 when caller is not the creator", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({
+          data: { id: "recipe-1", creator_id: "someone-else" },
+          error: null,
+        });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({ startTime: 10, endTime: 20, note: "Step note" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 201 with normalized payload when creator adds an annotation", async () => {
+    const insertMock = chainable({ data: okAnnotation, error: null });
+
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({
+          data: { id: "recipe-1", creator_id: "profile-123" },
+          error: null,
+        });
+      if (table === "video_annotations") return insertMock;
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({
+        startTime: 42.5,
+        endTime: 56.78,
+        note: "Putting the chicken in the oven",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      id: 7,
+      recipeId: "recipe-1",
+      startTime: 42.5,
+      endTime: 56.78,
+      note: "Putting the chicken in the oven",
+      technique: null,
+    });
+    expect(insertMock.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipe_id: "recipe-1",
+        start_time: 42.5,
+        end_time: 56.78,
+        note: "Putting the chicken in the oven",
+        technique: null,
+      })
+    );
+  });
+
+  it("stores technique when provided", async () => {
+    const insertMock = chainable({
+      data: { ...okAnnotation, technique: "Searing" },
+      error: null,
+    });
+
+    setupAuthAndTables("expert", "profile-123", (table) => {
+      if (table === "recipes")
+        return chainable({
+          data: { id: "recipe-1", creator_id: "profile-123" },
+          error: null,
+        });
+      if (table === "video_annotations") return insertMock;
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .post("/recipes/recipe-1/annotations")
+      .set("Authorization", "Bearer valid_token")
+      .send({
+        startTime: 10,
+        endTime: 14,
+        note: "Sear both sides",
+        technique: "Searing",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.technique).toBe("Searing");
+    expect(insertMock.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ technique: "Searing" })
+    );
+  });
+});
+
+// ─── GET /recipes/:id/annotations ────────────────────────────────────────────
+
+describe("GET /recipes/:id/annotations", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 404 when recipe does not exist", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app).get("/recipes/missing/annotations");
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 403 for an unauthenticated viewer on a draft recipe", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes")
+        return chainable({
+          data: { id: "recipe-1", is_published: false, creator_id: "creator-1" },
+          error: null,
+        });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app).get("/recipes/recipe-1/annotations");
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns annotations sorted by startTime asc when published", async () => {
+    const rows = [
+      {
+        id: 2,
+        recipe_id: "recipe-1",
+        start_time: 5,
+        end_time: 12,
+        note: "Mix",
+        technique: null,
+        created_at: "t1",
+      },
+      {
+        id: 3,
+        recipe_id: "recipe-1",
+        start_time: 30,
+        end_time: 90,
+        note: "Bake",
+        technique: null,
+        created_at: "t2",
+      },
+    ];
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes")
+        return chainable({
+          data: { id: "recipe-1", is_published: true, creator_id: "creator-1" },
+          error: null,
+        });
+      if (table === "video_annotations") return chainable({ data: rows, error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app).get("/recipes/recipe-1/annotations");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0]).toMatchObject({
+      id: 2,
+      recipeId: "recipe-1",
+      startTime: 5,
+      endTime: 12,
+      note: "Mix",
+      technique: null,
+    });
+  });
+
+  it("returns empty array when no annotations exist", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes")
+        return chainable({
+          data: { id: "recipe-1", is_published: true, creator_id: "creator-1" },
+          error: null,
+        });
+      if (table === "video_annotations") return chainable({ data: [], error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app).get("/recipes/recipe-1/annotations");
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+// ─── PATCH /annotations/:annotationId ────────────────────────────────────────
+
+describe("PATCH /annotations/:annotationId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app).patch("/annotations/7").send({ note: "Updated" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when no fields provided", async () => {
+    setupAuthAndTables("cook", "profile-123", () => chainable({ data: null, error: null }));
+    const res = await request(app)
+      .patch("/annotations/7")
+      .set("Authorization", "Bearer valid_token")
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 404 when annotation does not exist", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "video_annotations")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .patch("/annotations/9999")
+      .set("Authorization", "Bearer valid_token")
+      .send({ note: "Updated" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 403 when caller is not the recipe creator", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "video_annotations")
+        return chainable({
+          data: {
+            id: 7,
+            recipe_id: "recipe-1",
+            start_time: 10,
+            end_time: 20,
+            recipe: { creator_id: "someone-else" },
+          },
+          error: null,
+        });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .patch("/annotations/7")
+      .set("Authorization", "Bearer valid_token")
+      .send({ note: "Updated" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 when patched endTime falls below existing startTime", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "video_annotations")
+        return chainable({
+          data: {
+            id: 7,
+            recipe_id: "recipe-1",
+            start_time: 50,
+            end_time: 60,
+            recipe: { creator_id: "profile-123" },
+          },
+          error: null,
+        });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .patch("/annotations/7")
+      .set("Authorization", "Bearer valid_token")
+      .send({ endTime: 40 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 200 with updated payload when creator edits the range", async () => {
+    let videoAnnotationsCallCount = 0;
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "video_annotations") {
+        videoAnnotationsCallCount++;
+        if (videoAnnotationsCallCount === 1) {
+          // Ownership-check fetch
+          return chainable({
+            data: {
+              id: 7,
+              recipe_id: "recipe-1",
+              start_time: 42.5,
+              end_time: 56.78,
+              recipe: { creator_id: "profile-123" },
+            },
+            error: null,
+          });
+        }
+        // Update
+        return chainable({
+          data: {
+            ...okAnnotation,
+            note: "Updated note",
+            start_time: 60,
+            end_time: 75,
+          },
+          error: null,
+        });
+      }
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .patch("/annotations/7")
+      .set("Authorization", "Bearer valid_token")
+      .send({ note: "Updated note", startTime: 60, endTime: 75 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: 7,
+      note: "Updated note",
+      startTime: 60,
+      endTime: 75,
+    });
+  });
+});
+
+// ─── DELETE /annotations/:annotationId ───────────────────────────────────────
+
+describe("DELETE /annotations/:annotationId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await request(app).delete("/annotations/7");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when annotation does not exist", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "video_annotations")
+        return chainable({ data: null, error: { code: "PGRST116", message: "Not found" } });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .delete("/annotations/9999")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 403 when caller is not the recipe creator", async () => {
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "video_annotations")
+        return chainable({
+          data: {
+            id: 7,
+            recipe_id: "recipe-1",
+            recipe: { creator_id: "someone-else" },
+          },
+          error: null,
+        });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .delete("/annotations/7")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 204 when creator deletes their own annotation", async () => {
+    let videoAnnotationsCallCount = 0;
+    setupAuthAndTables("cook", "profile-123", (table) => {
+      if (table === "video_annotations") {
+        videoAnnotationsCallCount++;
+        if (videoAnnotationsCallCount === 1) {
+          return chainable({
+            data: {
+              id: 7,
+              recipe_id: "recipe-1",
+              recipe: { creator_id: "profile-123" },
+            },
+            error: null,
+          });
+        }
+        return chainable({ data: null, error: null });
+      }
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app)
+      .delete("/annotations/7")
+      .set("Authorization", "Bearer valid_token");
+
+    expect(res.status).toBe(204);
+  });
+});

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -188,6 +188,18 @@ export const openApiSpec = {
           total: { type: "integer" },
         },
       },
+      VideoAnnotation: {
+        type: "object",
+        properties: {
+          id: { type: "integer" },
+          recipeId: { type: "string", format: "uuid" },
+          startTime: { type: "number", description: "Seconds into the recipe video where the annotation begins", minimum: 0 },
+          endTime: { type: "number", description: "Seconds into the recipe video where the annotation ends (>= startTime)", minimum: 0 },
+          note: { type: "string", minLength: 1, maxLength: 500 },
+          technique: { type: ["string", "null"] },
+          createdAt: { type: "string", format: "date-time" },
+        },
+      },
     },
   },
   paths: {
@@ -875,6 +887,138 @@ export const openApiSpec = {
       },
     },
 
+    // ── Video Annotations ───────────────────────────────────────────────────────
+    "/recipes/{id}/annotations": {
+      post: {
+        summary: "Add a manual video annotation (timestamp + note) to a recipe",
+        tags: ["Video Annotations"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["startTime", "endTime", "note"],
+                properties: {
+                  startTime: { type: "number", minimum: 0, description: "Seconds into the recipe video where the annotation begins" },
+                  endTime: { type: "number", minimum: 0, description: "Seconds into the recipe video where the annotation ends (>= startTime)" },
+                  note: { type: "string", minLength: 1, maxLength: 500 },
+                  technique: { type: ["string", "null"], maxLength: 120 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Annotation created",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { $ref: "#/components/schemas/VideoAnnotation" },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "Validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Caller is not the recipe creator (or wrong role)", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      get: {
+        summary: "List video annotations for a recipe (sorted by timestamp asc)",
+        tags: ["Video Annotations"],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
+        ],
+        responses: {
+          "200": {
+            description: "Annotations list",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { type: "array", items: { $ref: "#/components/schemas/VideoAnnotation" } },
+                  },
+                },
+              },
+            },
+          },
+          "403": { description: "Recipe is a draft and the caller is not the creator", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Recipe not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/annotations/{annotationId}": {
+      patch: {
+        summary: "Edit a video annotation (recipe creator only)",
+        tags: ["Video Annotations"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "annotationId", in: "path", required: true, schema: { type: "integer" } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  startTime: { type: "number", minimum: 0 },
+                  endTime: { type: "number", minimum: 0 },
+                  note: { type: "string", minLength: 1, maxLength: 500 },
+                  technique: { type: ["string", "null"], maxLength: 120 },
+                },
+                description: "At least one of startTime / endTime / note / technique must be provided. Resulting endTime must be >= startTime.",
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Annotation updated",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: { $ref: "#/components/schemas/VideoAnnotation" },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "Validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Caller is not the recipe creator", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Annotation not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+      delete: {
+        summary: "Delete a video annotation (recipe creator only)",
+        tags: ["Video Annotations"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "annotationId", in: "path", required: true, schema: { type: "integer" } },
+        ],
+        responses: {
+          "204": { description: "Annotation deleted" },
+          "403": { description: "Caller is not the recipe creator", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "404": { description: "Annotation not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
     // ── Dish Genres ─────────────────────────────────────────────────────────────
     "/dish-genres": {
       get: {
@@ -1556,6 +1700,7 @@ export const openApiSpec = {
     { name: "Auth", description: "Registration, login, token management, profile" },
     { name: "Recipes", description: "Recipe CRUD, publish, ratings, media" },
     { name: "Comments", description: "Recipe comments" },
+    { name: "Video Annotations", description: "Manual timestamp annotations on recipe videos" },
     { name: "Dish Genres", description: "Cuisine genre catalogue" },
     { name: "Dish Varieties", description: "Specific dish catalogue" },
     { name: "Ingredients", description: "Ingredient search and substitutions" },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import substitutionsRouter from "./routes/substitutions.js";
 import commentsRouter from "./routes/comments.js";
 import usersRouter from "./routes/users.js";
 import allergensRouter from "./routes/allergens.js";
+import videoAnnotationsRouter from "./routes/video-annotations.js";
 
 const app = express();
 const PORT = process.env["PORT"] ?? 3000;
@@ -53,6 +54,7 @@ app.use("/tools", toolsRouter);
 app.use("/units", unitsRouter);
 app.use("/ingredients", substitutionsRouter);
 app.use("/", commentsRouter);
+app.use("/", videoAnnotationsRouter);
 app.use("/users", usersRouter);
 app.use("/allergens", allergensRouter);
 

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -244,7 +244,8 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
        recipe_steps(id, step_order, description, video_timestamp),
        recipe_tools(id, name),
        recipe_media(id, url, type),
-       recipe_dietary_tags(dietary_tag:dietary_tags(id, name, category))`
+       recipe_dietary_tags(dietary_tag:dietary_tags(id, name, category)),
+       video_annotations(id, start_time, end_time, note, technique, created_at)`
     )
     .eq("id", recipeId)
     .single();
@@ -390,6 +391,16 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
         name: rt.dietary_tag?.name ?? null,
         category: rt.dietary_tag?.category ?? null,
       })),
+      videoAnnotations: [...((data as any).video_annotations ?? [])]
+        .sort((a: any, b: any) => Number(a.start_time) - Number(b.start_time))
+        .map((a: any) => ({
+          id: a.id,
+          startTime: Number(a.start_time),
+          endTime: Number(a.end_time),
+          note: a.note,
+          technique: a.technique ?? null,
+          createdAt: a.created_at,
+        })),
       createdAt: data.created_at,
       updatedAt: data.updated_at,
     })
@@ -727,6 +738,7 @@ router.patch(
               recipe_id: recipeId,
               step_order: s.stepOrder,
               description: s.description,
+              video_timestamp: s.videoTimestamp ?? null,
             }))
           ).then(r => r)
         );

--- a/backend/src/routes/video-annotations.ts
+++ b/backend/src/routes/video-annotations.ts
@@ -1,0 +1,359 @@
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth, requireRole } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest } from "../types/index.js";
+import { errorResponse, successResponse } from "../utils/response.js";
+import { normalizeText } from "../utils/text.js";
+
+const router = Router();
+
+// ─── Zod Schemas ──────────────────────────────────────────────────────────────
+
+const noteSchema = z
+  .string()
+  .trim()
+  .min(1, { message: "Note must not be empty." })
+  .max(500, { message: "Note must be at most 500 characters." });
+
+const techniqueSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(120)
+  .nullable()
+  .optional();
+
+const createAnnotationSchema = z
+  .object({
+    startTime: z
+      .number({ message: "startTime must be a number." })
+      .min(0, { message: "startTime must be at least 0 seconds." }),
+    endTime: z
+      .number({ message: "endTime must be a number." })
+      .min(0, { message: "endTime must be at least 0 seconds." }),
+    note: noteSchema,
+    technique: techniqueSchema,
+  })
+  .refine((b) => b.endTime >= b.startTime, {
+    message: "endTime must be greater than or equal to startTime.",
+    path: ["endTime"],
+  });
+
+const updateAnnotationSchema = z
+  .object({
+    startTime: z.number().min(0).optional(),
+    endTime: z.number().min(0).optional(),
+    note: noteSchema.optional(),
+    technique: techniqueSchema,
+  })
+  .refine(
+    (b) =>
+      b.startTime !== undefined ||
+      b.endTime !== undefined ||
+      b.note !== undefined ||
+      b.technique !== undefined,
+    { message: "At least one field (startTime, endTime, note, technique) must be provided." }
+  );
+
+// ─── Serializer ──────────────────────────────────────────────────────────────
+
+const toApiAnnotation = (row: any) => ({
+  id: row.id,
+  recipeId: row.recipe_id,
+  startTime: Number(row.start_time),
+  endTime: Number(row.end_time),
+  note: row.note,
+  technique: row.technique ?? null,
+  createdAt: row.created_at,
+});
+
+// ─── POST /recipes/:id/annotations ────────────────────────────────────────────
+
+/**
+ * Create a video annotation (timestamp + note) on a recipe.
+ * Restricted to cook/expert. Caller must be the recipe creator.
+ */
+router.post(
+  "/recipes/:id/annotations",
+  requireAuth,
+  requireRole("cook", "expert"),
+  validate(createAnnotationSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const recipeId = (req.params["id"] ?? "") as string;
+    const body = req.body as z.infer<typeof createAnnotationSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    // 1. Verify recipe exists and caller is the creator
+    const { data: recipe, error: fetchError } = await userClient
+      .from("recipes")
+      .select("id, creator_id")
+      .eq("id", recipeId)
+      .single();
+
+    if (fetchError || !recipe) {
+      if (fetchError?.code === "PGRST116") {
+        res.status(404).json(errorResponse("NOT_FOUND", "Recipe not found."));
+        return;
+      }
+      res
+        .status(500)
+        .json(errorResponse("DB_ERROR", fetchError?.message ?? "Failed to fetch recipe."));
+      return;
+    }
+
+    if ((recipe as any).creator_id !== user.profileId) {
+      res
+        .status(403)
+        .json(errorResponse("FORBIDDEN", "Only the recipe creator can add annotations."));
+      return;
+    }
+
+    // 2. Insert annotation — NFC-normalize free text (#402)
+    const normalizedNote = normalizeText(body.note) ?? body.note;
+    const normalizedTechnique =
+      body.technique == null ? null : normalizeText(body.technique);
+
+    const { data: inserted, error: insertError } = await userClient
+      .from("video_annotations")
+      .insert({
+        recipe_id: recipeId,
+        start_time: body.startTime,
+        end_time: body.endTime,
+        note: normalizedNote,
+        technique: normalizedTechnique,
+      })
+      .select("id, recipe_id, start_time, end_time, note, technique, created_at")
+      .single();
+
+    if (insertError || !inserted) {
+      res
+        .status(500)
+        .json(errorResponse("DB_ERROR", insertError?.message ?? "Failed to create annotation."));
+      return;
+    }
+
+    res.status(201).json(successResponse(toApiAnnotation(inserted)));
+  }
+);
+
+// ─── GET /recipes/:id/annotations ─────────────────────────────────────────────
+
+/**
+ * List video annotations for a recipe, ordered by timestamp ascending.
+ * Public for published recipes; for drafts only the creator may read.
+ */
+router.get(
+  "/recipes/:id/annotations",
+  async (req: Request, res: Response): Promise<void> => {
+    const recipeId = (req.params["id"] ?? "") as string;
+
+    // Resolve viewer (optional) so drafts are visible to their creator
+    const authHeader = req.headers["authorization"];
+    const token =
+      authHeader && authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+    const { data: recipe, error: recipeError } = await supabase
+      .from("recipes")
+      .select("id, is_published, creator_id")
+      .eq("id", recipeId)
+      .single();
+
+    if (recipeError || !recipe) {
+      if (recipeError?.code === "PGRST116") {
+        res.status(404).json(errorResponse("NOT_FOUND", "Recipe not found."));
+        return;
+      }
+      res
+        .status(500)
+        .json(errorResponse("DB_ERROR", recipeError?.message ?? "Failed to fetch recipe."));
+      return;
+    }
+
+    if (!(recipe as any).is_published) {
+      let viewerProfileId: string | null = null;
+      if (token) {
+        const { data: userData } = await supabase.auth.getUser(token);
+        if (userData?.user) {
+          const { data: profile } = await supabase
+            .from("profiles")
+            .select("id")
+            .eq("user_id", userData.user.id)
+            .maybeSingle();
+          viewerProfileId = (profile as any)?.id ?? null;
+        }
+      }
+      if (viewerProfileId !== (recipe as any).creator_id) {
+        res
+          .status(403)
+          .json(errorResponse("FORBIDDEN", "This recipe is a draft."));
+        return;
+      }
+    }
+
+    const { data, error } = await supabase
+      .from("video_annotations")
+      .select("id, recipe_id, start_time, end_time, note, technique, created_at")
+      .eq("recipe_id", recipeId)
+      .order("start_time", { ascending: true });
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res
+      .status(200)
+      .json(successResponse((data ?? []).map(toApiAnnotation)));
+  }
+);
+
+// ─── PATCH /annotations/:annotationId ─────────────────────────────────────────
+
+/**
+ * Update a single video annotation.
+ * Auth required: only the recipe creator may edit.
+ */
+router.patch(
+  "/annotations/:annotationId",
+  requireAuth,
+  validate(updateAnnotationSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const annotationId = (req.params["annotationId"] ?? "") as string;
+    const body = req.body as z.infer<typeof updateAnnotationSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    // 1. Fetch annotation + parent recipe creator for ownership check.
+    // Also pull current start/end so we can validate the post-update range
+    // when the caller only sends one side of it.
+    const { data: existing, error: fetchError } = await userClient
+      .from("video_annotations")
+      .select(
+        "id, recipe_id, start_time, end_time, recipe:recipes!video_annotations_recipe_id_fkey(creator_id)"
+      )
+      .eq("id", annotationId)
+      .single();
+
+    if (fetchError || !existing) {
+      if (fetchError?.code === "PGRST116") {
+        res.status(404).json(errorResponse("NOT_FOUND", "Annotation not found."));
+        return;
+      }
+      res
+        .status(500)
+        .json(errorResponse("DB_ERROR", fetchError?.message ?? "Failed to fetch annotation."));
+      return;
+    }
+
+    const creatorId = (existing as any).recipe?.creator_id;
+    if (creatorId !== user.profileId) {
+      res
+        .status(403)
+        .json(errorResponse("FORBIDDEN", "You can only edit annotations on your own recipes."));
+      return;
+    }
+
+    // 2. Range invariant check against the merged (existing + patched) values.
+    const nextStart =
+      body.startTime !== undefined ? body.startTime : Number((existing as any).start_time);
+    const nextEnd =
+      body.endTime !== undefined ? body.endTime : Number((existing as any).end_time);
+    if (nextEnd < nextStart) {
+      res
+        .status(400)
+        .json(
+          errorResponse(
+            "VALIDATION_ERROR",
+            "endTime must be greater than or equal to startTime."
+          )
+        );
+      return;
+    }
+
+    // 3. Update — only set provided fields
+    const update: Record<string, unknown> = {};
+    if (body.startTime !== undefined) update["start_time"] = body.startTime;
+    if (body.endTime !== undefined) update["end_time"] = body.endTime;
+    if (body.note !== undefined) {
+      update["note"] = normalizeText(body.note) ?? body.note;
+    }
+    if (body.technique !== undefined) {
+      update["technique"] =
+        body.technique == null ? null : normalizeText(body.technique);
+    }
+
+    const { data: updated, error: updateError } = await userClient
+      .from("video_annotations")
+      .update(update)
+      .eq("id", annotationId)
+      .select("id, recipe_id, start_time, end_time, note, technique, created_at")
+      .single();
+
+    if (updateError || !updated) {
+      res
+        .status(500)
+        .json(errorResponse("DB_ERROR", updateError?.message ?? "Failed to update annotation."));
+      return;
+    }
+
+    res.status(200).json(successResponse(toApiAnnotation(updated)));
+  }
+);
+
+// ─── DELETE /annotations/:annotationId ────────────────────────────────────────
+
+/**
+ * Delete a single video annotation.
+ * Auth required: only the recipe creator may delete.
+ */
+router.delete(
+  "/annotations/:annotationId",
+  requireAuth,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const annotationId = (req.params["annotationId"] ?? "") as string;
+    const userClient = createUserClient(user.accessToken);
+
+    const { data: existing, error: fetchError } = await userClient
+      .from("video_annotations")
+      .select("id, recipe_id, recipe:recipes!video_annotations_recipe_id_fkey(creator_id)")
+      .eq("id", annotationId)
+      .single();
+
+    if (fetchError || !existing) {
+      if (fetchError?.code === "PGRST116") {
+        res.status(404).json(errorResponse("NOT_FOUND", "Annotation not found."));
+        return;
+      }
+      res
+        .status(500)
+        .json(errorResponse("DB_ERROR", fetchError?.message ?? "Failed to fetch annotation."));
+      return;
+    }
+
+    const creatorId = (existing as any).recipe?.creator_id;
+    if (creatorId !== user.profileId) {
+      res
+        .status(403)
+        .json(errorResponse("FORBIDDEN", "You can only delete annotations on your own recipes."));
+      return;
+    }
+
+    const { error: deleteError } = await userClient
+      .from("video_annotations")
+      .delete()
+      .eq("id", annotationId);
+
+    if (deleteError) {
+      res.status(500).json(errorResponse("DB_ERROR", deleteError.message));
+      return;
+    }
+
+    res.status(204).send();
+  }
+);
+
+export default router;


### PR DESCRIPTION
This pull request introduces a new feature for manual video timestamp annotations on recipe videos, allowing recipe creators (cooks/experts) to add, edit, and delete time-ranged notes over recipe videos. It updates the backend API, OpenAPI documentation, and response formats to support this functionality, and ensures that video annotations are included in recipe details for frontend consumption.
Closes #422 , Closes #491 