### PR TITLE
Add admin role and expert request workflow

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -68,6 +68,7 @@ backend/
 │   │   ├── units.ts             # Unit search/autocomplete
 │   │   ├── comments.ts          # Recipe comments (create, list, delete)
 │   │   ├── video-annotations.ts # Manual timestamp annotations on recipe videos
+│   │   ├── admin.ts             # Admin-only: expert-request review, user/recipe/comment moderation
 │   │   └── parse.ts             # Free-text recipe parser endpoint
 │   ├── types/
 │   │   └── index.ts             # TypeScript interfaces (roles, auth, response, SupportedLanguage, LanguageRequest)
@@ -104,7 +105,8 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 
 ### Core Tables
 
-- **profiles** — `id`, `user_id` (FK auth.users), `username` (unique), `role`
+- **profiles** — `id`, `user_id` (FK auth.users), `username` (unique), `role` (`learner` | `cook` | `expert` | `admin`). A partial unique index `profiles_one_admin_only` (`WHERE role='admin'`) enforces that **at most one admin** can exist at any time. The first admin is seeded manually via SQL/Supabase dashboard — `admin` is intentionally absent from the registration enum so it cannot be created from the public API.
+- **expert_requests** — `id`, `user_id` (FK profiles, ON DELETE CASCADE), `reason` (TEXT, nullable — applicant's justification), `status` (`pending` | `approved` | `rejected`), `decision_note` (TEXT, nullable — admin's note), `decided_by` (FK profiles, ON DELETE SET NULL), `created_at`, `decided_at`. A partial unique index `expert_requests_one_pending_per_user` (`WHERE status='pending'`) ensures each user has at most one open request; previously rejected requests do not block new submissions.
 - **recipes** — `id`, `creator_id` (FK profiles), `dish_variety_id` (FK), `title`, `story`, `video_url`, `serving_size`, `type` (community|cultural), `is_published`, `average_rating`, `rating_count`, `created_at`, `updated_at`
 - **recipe_ingredients** — `id`, `recipe_id` (FK), `ingredient_id` (FK), `quantity`, `unit`
 - **recipe_steps** — `id`, `recipe_id` (FK), `step_order`, `description`, `video_timestamp` (numeric, nullable — seconds into the recipe video)
@@ -144,12 +146,27 @@ Migration `002_en_tr_language_fields.sql` adds these columns and seeds `_en` fro
 - `GET /health` — Health check
 
 ### Auth (`/auth`)
-- `POST /auth/register` — Register (email, password, username, role)
+- `POST /auth/register` — Register (email, password, username, role, optional `expertRequestReason`)
+  - **Option-A expert flow:** if `role === "expert"` is requested, the profile is created with `role='cook'` (interim — applicants can already publish community recipes while waiting) and a pending `expert_requests` row is opened (seeded with `expertRequestReason` if provided). Response includes `pendingExpertRequest: true`. The user must wait for admin approval to actually become an expert.
+  - `role='admin'` is rejected at the schema level (admin cannot be self-registered).
 - `POST /auth/login` — Login (returns access_token, refresh_token)
 - `POST /auth/logout` — Logout (auth required)
 - `POST /auth/refresh` — Refresh access token
 - `GET /auth/me` — Current user info (auth required)
 - `PATCH /auth/profile` — Update profile fields (auth required, all fields optional: `username`, `bio`, `avatar_url`, `preferred_language`, `region`); returns 409 if username taken
+- `POST /auth/expert-requests` — Submit an expert-account request (learner/cook only; body `{ reason: string }`). Returns 409 `EXPERT_REQUEST_PENDING` if a pending request already exists, 409 `CONFLICT` if caller is already expert, 403 if caller is admin.
+- `GET /auth/expert-requests/me` — Returns the caller's most recent request (any status) or `null`.
+
+### Admin (`/admin`) — single-admin moderation surface
+All endpoints require `requireAuth + requireAdmin`. **Admin writes go through a privileged service-role Supabase client** (`supabaseAdmin` in `src/config/supabase.ts`). This is required because the `profiles` table has RLS enabled with `UPDATE/INSERT` policies scoped to `(user_id = auth.uid())` — a plain anon client silently no-ops when an admin tries to mutate someone else's row, leaving requests as "approved" while the role never flips. Reads continue to use the regular anon client (the `SELECT` policy is `USING: true`). When `SUPABASE_SERVICE_ROLE_KEY` is missing the admin write endpoints return 503 `ADMIN_NOT_CONFIGURED` rather than failing silently.
+- `GET /admin/expert-requests` — List requests (default `status=pending`); query: `status`, `page`, `limit`. Includes nested `applicant` (id/username/role).
+- `POST /admin/expert-requests/:id/approve` — Approve and promote applicant to `expert` (idempotent — does not touch admin profiles via `.neq('role','admin')`). Body: optional `decisionNote`. Returns 409 `REQUEST_ALREADY_DECIDED` if not pending.
+- `POST /admin/expert-requests/:id/reject` — Reject without changing the applicant's role. Body: optional `decisionNote`.
+- `GET /admin/users` — List profiles; query: `search` (username ilike), `role`, `page`, `limit`.
+- `PATCH /admin/users/:id` — Update another user's profile fields (`username`, `role`, `bio`, `region`, `preferred_language`). `role` is restricted to non-admin values; the admin profile itself cannot be modified through this endpoint (returns 403). Username uniqueness is re-checked.
+- `DELETE /admin/users/:id` — Delete a profile (every FK referencing profiles cascades). Cannot delete the admin profile or self. The matching `auth.users` row is preserved (only the Supabase service role can remove it); the deleted profile is enough to lock the account out of every API endpoint.
+- `DELETE /admin/recipes/:id` — Delete any recipe (all `recipe_*` child rows cascade via existing FKs).
+- `DELETE /admin/comments/:id` — Moderator-style delete of any comment, even when the admin is not its author (distinct from `DELETE /comments/:id` which is author-only).
 
 ### Recipes (`/recipes`)
 - `GET /recipes/:id` — Recipe detail (public if published, creator-only if draft)
@@ -320,6 +337,16 @@ Manual timestamp **ranges** a cook/expert places on the recipe's uploaded video 
 | `learner` | View recipes, rate, browse/discover |
 | `cook` | + Create **community** recipes, upload media |
 | `expert` | + Create **cultural** recipes (in addition to community) |
+| `admin` | Single account. Reviews expert requests, edits/deletes any user/recipe/comment. Not registerable; seeded manually. |
+
+### Becoming an expert (approval workflow)
+
+`expert` is the only gated role. Two paths exist for landing on it; both end up writing to `expert_requests`:
+
+1. **At registration** — picking `role='expert'` on `POST /auth/register` creates the profile as `cook` (interim, so the applicant can immediately publish community recipes) and opens a pending request seeded with the optional `expertRequestReason`. Response carries `pendingExpertRequest: true`.
+2. **Post-registration promotion** — an existing learner or cook calls `POST /auth/expert-requests` with a `reason`. Same `expert_requests` row, just opened later.
+
+Either way, the single admin reviews the request via `GET /admin/expert-requests` and decides with `POST /admin/expert-requests/:id/approve` (which sets `profiles.role='expert'` on the applicant) or `.../reject`. The DB enforces "one pending request per user" via a partial unique index, so the user surface returns 409 `EXPERT_REQUEST_PENDING` rather than silently stacking duplicates.
 
 ## Authentication Flow
 
@@ -348,6 +375,10 @@ Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/r
 - `CONFLICT` (409) — Duplicate username/email, already published
 - `RATING_REQUIRED` (400) — Comment attempted without a rating on the recipe
 - `COMMENT_ALREADY_EXISTS` (409) — User attempted to post a second comment on the same recipe (must edit instead)
+- `EXPERT_REQUEST_PENDING` (409) — User submitted a second expert request while one is still pending
+- `REQUEST_ALREADY_DECIDED` (409) — Admin tried to approve/reject a request that is no longer pending
+- `PROMOTION_FAILED` (409) — Admin approved a request but the applicant's profile could not be promoted (deleted, or already an admin)
+- `ADMIN_NOT_CONFIGURED` (503) — `SUPABASE_SERVICE_ROLE_KEY` is missing on the backend, so admin writes are disabled
 - `INCOMPLETE_RECIPE` (400) — Missing fields for publish
 - `PARSE_FAILED` (500) — AI parsing of recipe text failed
 - `STANDARDIZATION_FAILED` (500) — AI unit standardization failed
@@ -494,11 +525,14 @@ Required in `.env`:
 PORT=3000
 SUPABASE_URL=<supabase-project-url>
 SUPABASE_ANON_KEY=<supabase-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<supabase-service-role-key>   # required for /admin/* writes — bypasses RLS, must NEVER be exposed to the frontend
 DATABASE_URL=<postgres-connection-string>
 DIRECT_URL=<postgres-direct-connection-string>
 GEMINI_API_KEY=<google-gemini-api-key>
 ELEVENLABS_API_KEY=<elevenlabs-api-key>   # Speech-to-Text (Scribe v1) for /parse/recipe-audio
 ```
+
+**Where to get `SUPABASE_SERVICE_ROLE_KEY`:** Supabase Dashboard → Project Settings → API → "Project API keys" → `service_role` (labeled "secret"). Treat this key like a database superuser password — it bypasses every RLS policy, so keep it server-side only.
 
 ## Docker
 

--- a/backend/migrations/003_admin_role_and_expert_requests.sql
+++ b/backend/migrations/003_admin_role_and_expert_requests.sql
@@ -1,0 +1,64 @@
+-- Migration: Add admin role + expert approval workflow
+-- Adds:
+--   1. 'admin' as a valid value in profiles.role
+--   2. Partial unique index ensuring at most one admin can exist
+--   3. expert_requests table for the expert-account approval workflow
+--
+-- The matching rollback lives in 003_admin_role_and_expert_requests_rollback.sql.
+
+BEGIN;
+
+-- ─── 1. profiles.role: allow 'admin' ──────────────────────────────────────────
+-- Drop whichever role-check constraint currently exists (name varies across
+-- environments) and recreate it with 'admin' included.
+DO $$
+DECLARE
+  cons RECORD;
+BEGIN
+  FOR cons IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'public.profiles'::regclass
+      AND contype  = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%role%'
+  LOOP
+    EXECUTE format('ALTER TABLE public.profiles DROP CONSTRAINT %I', cons.conname);
+  END LOOP;
+END $$;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_role_check
+  CHECK (role IN ('learner', 'cook', 'expert', 'admin'));
+
+-- ─── 2. Single-admin invariant ────────────────────────────────────────────────
+-- Partial unique index: enforce that at most one row may have role='admin'.
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_one_admin_only
+  ON public.profiles ((role))
+  WHERE role = 'admin';
+
+-- ─── 3. expert_requests table ─────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.expert_requests (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reason        text        NULL,
+  status        text        NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending', 'approved', 'rejected')),
+  decision_note text        NULL,
+  decided_by    uuid        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  decided_at    timestamptz NULL
+);
+
+-- One pending request per user (a user with a pending request may not open another)
+CREATE UNIQUE INDEX IF NOT EXISTS expert_requests_one_pending_per_user
+  ON public.expert_requests (user_id)
+  WHERE status = 'pending';
+
+-- Helpful indexes
+CREATE INDEX IF NOT EXISTS expert_requests_status_created_at_idx
+  ON public.expert_requests (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS expert_requests_user_id_idx
+  ON public.expert_requests (user_id);
+
+COMMIT;

--- a/backend/migrations/003_admin_role_and_expert_requests_rollback.sql
+++ b/backend/migrations/003_admin_role_and_expert_requests_rollback.sql
@@ -1,0 +1,39 @@
+-- Rollback for 003_admin_role_and_expert_requests.sql
+--
+-- WARNING: this drops the expert_requests table (all data lost) and the
+-- single-admin index, then narrows profiles.role back to the legacy three
+-- roles. If any profile already has role='admin' the role-check recreation
+-- step below will fail; promote/demote that profile first.
+
+BEGIN;
+
+-- ─── 3. Drop expert_requests ──────────────────────────────────────────────────
+DROP INDEX IF EXISTS public.expert_requests_user_id_idx;
+DROP INDEX IF EXISTS public.expert_requests_status_created_at_idx;
+DROP INDEX IF EXISTS public.expert_requests_one_pending_per_user;
+DROP TABLE  IF EXISTS public.expert_requests;
+
+-- ─── 2. Drop single-admin index ───────────────────────────────────────────────
+DROP INDEX IF EXISTS public.profiles_one_admin_only;
+
+-- ─── 1. profiles.role: revert to legacy three-role check ──────────────────────
+DO $$
+DECLARE
+  cons RECORD;
+BEGIN
+  FOR cons IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'public.profiles'::regclass
+      AND contype  = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%role%'
+  LOOP
+    EXECUTE format('ALTER TABLE public.profiles DROP CONSTRAINT %I', cons.conname);
+  END LOOP;
+END $$;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_role_check
+  CHECK (role IN ('learner', 'cook', 'expert'));
+
+COMMIT;

--- a/backend/scripts/inspect-fks.js
+++ b/backend/scripts/inspect-fks.js
@@ -1,0 +1,48 @@
+require("dotenv").config();
+const { Client } = require("pg");
+
+(async () => {
+  const client = new Client({
+    connectionString: process.env.DIRECT_URL || process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+  await client.connect();
+
+  // For every FK that references recipes(id) or profiles(id), show the
+  // ON DELETE rule so we know what cascades when an admin deletes them.
+  const q = `
+    SELECT
+      con.conname,
+      cl_src.relname  AS src_table,
+      a_src.attname   AS src_column,
+      cl_tgt.relname  AS tgt_table,
+      a_tgt.attname   AS tgt_column,
+      CASE con.confdeltype
+        WHEN 'a' THEN 'NO ACTION'
+        WHEN 'r' THEN 'RESTRICT'
+        WHEN 'c' THEN 'CASCADE'
+        WHEN 'n' THEN 'SET NULL'
+        WHEN 'd' THEN 'SET DEFAULT'
+      END AS on_delete
+    FROM pg_constraint con
+    JOIN pg_class cl_src ON cl_src.oid = con.conrelid
+    JOIN pg_class cl_tgt ON cl_tgt.oid = con.confrelid
+    JOIN pg_namespace n ON n.oid = cl_src.relnamespace
+    JOIN unnest(con.conkey)  WITH ORDINALITY AS u_src(attnum, ord) ON TRUE
+    JOIN unnest(con.confkey) WITH ORDINALITY AS u_tgt(attnum, ord) ON u_src.ord = u_tgt.ord
+    JOIN pg_attribute a_src ON a_src.attrelid = con.conrelid  AND a_src.attnum = u_src.attnum
+    JOIN pg_attribute a_tgt ON a_tgt.attrelid = con.confrelid AND a_tgt.attnum = u_tgt.attnum
+    WHERE con.contype = 'f'
+      AND n.nspname = 'public'
+      AND cl_tgt.relname IN ('recipes', 'profiles')
+    ORDER BY tgt_table, src_table, src_column;
+  `;
+  const { rows } = await client.query(q);
+  console.log("FKs referencing recipes/profiles:");
+  for (const r of rows) {
+    console.log(
+      `  ${r.src_table}.${r.src_column} → ${r.tgt_table}.${r.tgt_column}  ON DELETE ${r.on_delete}  (${r.conname})`
+    );
+  }
+  await client.end();
+})();

--- a/backend/scripts/inspect-profiles.js
+++ b/backend/scripts/inspect-profiles.js
@@ -1,0 +1,42 @@
+require("dotenv").config();
+const { Client } = require("pg");
+
+(async () => {
+  const client = new Client({
+    connectionString: process.env.DIRECT_URL || process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+  await client.connect();
+
+  const constraints = await client.query(`
+    SELECT conname, pg_get_constraintdef(oid) AS def
+    FROM pg_constraint
+    WHERE conrelid = 'public.profiles'::regclass
+    ORDER BY conname;
+  `);
+  console.log("--- profiles constraints ---");
+  for (const r of constraints.rows) console.log(r.conname, "::", r.def);
+
+  const cols = await client.query(`
+    SELECT column_name, data_type, is_nullable, column_default
+    FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='profiles'
+    ORDER BY ordinal_position;
+  `);
+  console.log("\n--- profiles columns ---");
+  for (const r of cols.rows) console.log(r.column_name, r.data_type, r.is_nullable, r.column_default);
+
+  const roleCounts = await client.query(`
+    SELECT role, count(*) AS n FROM public.profiles GROUP BY role ORDER BY role;
+  `);
+  console.log("\n--- existing role counts ---");
+  for (const r of roleCounts.rows) console.log(r.role, r.n);
+
+  const expertReqExists = await client.query(`
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='expert_requests';
+  `);
+  console.log("\nexpert_requests table exists?", expertReqExists.rowCount > 0);
+
+  await client.end();
+})();

--- a/backend/scripts/inspect-rls.js
+++ b/backend/scripts/inspect-rls.js
@@ -1,0 +1,64 @@
+require("dotenv").config();
+const { Client } = require("pg");
+
+(async () => {
+  const client = new Client({
+    connectionString: process.env.DIRECT_URL || process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+  await client.connect();
+
+  // Tables to inspect.
+  const tables = ["profiles", "expert_requests", "recipes", "comments"];
+
+  for (const tbl of tables) {
+    const meta = await client.query(
+      `SELECT relname, relrowsecurity, relforcerowsecurity
+       FROM pg_class
+       WHERE relname = $1 AND relnamespace = 'public'::regnamespace`,
+      [tbl]
+    );
+    console.log(`\n--- ${tbl} ---`);
+    for (const r of meta.rows) {
+      console.log(
+        `  rowsecurity=${r.relrowsecurity}  forced=${r.relforcerowsecurity}`
+      );
+    }
+    const policies = await client.query(
+      `SELECT polname, polcmd, polroles::regrole[] AS roles,
+              pg_get_expr(polqual,  polrelid) AS using_expr,
+              pg_get_expr(polwithcheck, polrelid) AS with_check_expr,
+              polpermissive
+       FROM pg_policy
+       WHERE polrelid = ('public.' || $1)::regclass
+       ORDER BY polname`,
+      [tbl]
+    );
+    if (policies.rowCount === 0) {
+      console.log("  (no policies)");
+    }
+    for (const p of policies.rows) {
+      console.log(
+        `  policy ${p.polname} cmd=${p.polcmd} permissive=${p.polpermissive} roles=${p.roles}`
+      );
+      console.log(`    USING: ${p.using_expr ?? "—"}`);
+      console.log(`    WITH CHECK: ${p.with_check_expr ?? "—"}`);
+    }
+  }
+
+  // Look for the freshly-created learner that wasn't promoted.
+  const stuck = await client.query(`
+    SELECT p.id AS profile_id, p.username, p.role, p.updated_at,
+           er.id AS request_id, er.status, er.decided_at, er.decided_by
+    FROM expert_requests er
+    JOIN profiles p ON p.id = er.user_id
+    WHERE p.username ILIKE 'expertdeneme%'
+    ORDER BY er.created_at DESC;
+  `);
+  console.log("\n--- expertdeneme_* state ---");
+  for (const r of stuck.rows) {
+    console.log(r);
+  }
+
+  await client.end();
+})();

--- a/backend/scripts/promote-stuck-user.js
+++ b/backend/scripts/promote-stuck-user.js
@@ -1,0 +1,51 @@
+// One-off: promote profiles whose latest expert_request is 'approved' but
+// whose role is still 'learner'/'cook' — i.e. rows that were silently skipped
+// by the prior anon-client UPDATE under RLS.
+
+require("dotenv").config();
+const { Client } = require("pg");
+
+(async () => {
+  const client = new Client({
+    connectionString: process.env.DIRECT_URL || process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+  await client.connect();
+
+  const before = await client.query(`
+    SELECT p.id, p.username, p.role
+    FROM profiles p
+    JOIN expert_requests er ON er.user_id = p.id
+    WHERE er.status = 'approved'
+      AND p.role <> 'expert'
+      AND p.role <> 'admin'
+    ORDER BY er.decided_at DESC NULLS LAST;
+  `);
+  console.log("Profiles to fix:");
+  for (const r of before.rows) console.log(" ", r);
+
+  if (before.rowCount === 0) {
+    console.log("Nothing to do.");
+    await client.end();
+    return;
+  }
+
+  const ids = before.rows.map((r) => r.id);
+  const { rowCount } = await client.query(
+    `UPDATE profiles
+       SET role = 'expert', updated_at = now()
+     WHERE id = ANY($1::uuid[])
+       AND role <> 'admin'`,
+    [ids]
+  );
+  console.log(`Promoted ${rowCount} profile(s).`);
+
+  const after = await client.query(
+    `SELECT id, username, role FROM profiles WHERE id = ANY($1::uuid[])`,
+    [ids]
+  );
+  console.log("After:");
+  for (const r of after.rows) console.log(" ", r);
+
+  await client.end();
+})();

--- a/backend/scripts/run-migration.js
+++ b/backend/scripts/run-migration.js
@@ -1,0 +1,55 @@
+// One-off migration runner.
+// Usage:  node scripts/run-migration.js <relative-or-absolute-path-to-sql>
+//
+// Reads DIRECT_URL from backend/.env and applies the SQL file as a single
+// query (the file is expected to wrap itself in BEGIN/COMMIT).
+
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+async function main() {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error("Usage: node scripts/run-migration.js <path-to-sql>");
+    process.exit(2);
+  }
+  const sqlPath = path.isAbsolute(arg) ? arg : path.resolve(process.cwd(), arg);
+  if (!fs.existsSync(sqlPath)) {
+    console.error(`SQL file not found: ${sqlPath}`);
+    process.exit(2);
+  }
+  const sql = fs.readFileSync(sqlPath, "utf8");
+
+  const connectionString = process.env.DIRECT_URL || process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DIRECT_URL (or DATABASE_URL) not set in environment.");
+    process.exit(2);
+  }
+
+  const client = new Client({
+    connectionString,
+    ssl: { rejectUnauthorized: false },
+  });
+
+  console.log(`→ Connecting to database…`);
+  await client.connect();
+
+  try {
+    console.log(`→ Applying migration: ${path.relative(process.cwd(), sqlPath)}`);
+    await client.query(sql);
+    console.log("✓ Migration applied successfully.");
+  } catch (err) {
+    console.error("✗ Migration failed:");
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/backend/src/__tests__/admin.test.ts
+++ b/backend/src/__tests__/admin.test.ts
@@ -1,0 +1,315 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+    from: jest.fn(),
+  },
+  // Admin write paths use this client (service-role bypasses RLS).
+  supabaseAdmin: {
+    from: jest.fn(),
+  },
+  createUserClient: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { supabaseAdmin } = require("../config/supabase.js") as {
+  supabaseAdmin: { from: jest.Mock };
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Mock the auth lookup that requireAuth performs (auth.getUser + profiles select). */
+function mockAuthAs(role: "learner" | "cook" | "expert" | "admin", profileId = "admin-prof") {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "auth-user-1", email: "x@y.com" } },
+    error: null,
+  });
+
+  // First .from("profiles") in requireAuth: profile lookup.
+  // Subsequent .from() calls in the route are configured per-test.
+  const profileLookup = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest
+          .fn()
+          .mockResolvedValue({ data: { id: profileId, username: "u", role }, error: null }),
+      }),
+    }),
+  };
+  return profileLookup;
+}
+
+// ─── /admin guard ─────────────────────────────────────────────────────────────
+
+describe("Admin guard", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 403 for a non-admin caller", async () => {
+    const profileLookup = mockAuthAs("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/admin/expert-requests")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 401 without a Bearer token", async () => {
+    const res = await request(app).get("/admin/expert-requests");
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── Expert request approve / reject ──────────────────────────────────────────
+
+describe("Admin expert-requests approve/reject", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("approves a pending request and promotes the applicant to expert", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    // expert_requests select for status check (anon client — only reads use it).
+    const mockReqSelectSingle = jest.fn().mockResolvedValue({
+      data: { id: "req-1", user_id: "applicant-1", status: "pending" },
+      error: null,
+    });
+    const mockReqSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({ maybeSingle: mockReqSelectSingle }),
+    });
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") {
+        return profileLookup; // requireAuth
+      }
+      if (table === "expert_requests") {
+        return { select: mockReqSelect };
+      }
+      return {};
+    });
+
+    // Admin client: profile promotion (.update().eq().neq().select().maybeSingle())
+    // returns the promoted row, then expert_requests .update().eq() succeeds.
+    const mockPromoteMaybeSingle = jest
+      .fn()
+      .mockResolvedValue({ data: { id: "applicant-1", role: "expert" }, error: null });
+    const mockPromoteSelect = jest.fn().mockReturnValue({ maybeSingle: mockPromoteMaybeSingle });
+    const mockPromoteNeq = jest.fn().mockReturnValue({ select: mockPromoteSelect });
+    const mockPromoteEq = jest.fn().mockReturnValue({ neq: mockPromoteNeq });
+    const mockProfileUpdate = jest.fn().mockReturnValue({ eq: mockPromoteEq });
+
+    const mockReqUpdate = jest
+      .fn()
+      .mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return { update: mockProfileUpdate };
+      if (table === "expert_requests") return { update: mockReqUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/expert-requests/req-1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("approved");
+    expect(mockProfileUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "expert" })
+    );
+    expect(mockReqUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 409 PROMOTION_FAILED when the applicant profile no longer exists", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqSelectSingle = jest.fn().mockResolvedValue({
+      data: { id: "req-x", user_id: "ghost", status: "pending" },
+      error: null,
+    });
+    const mockReqSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({ maybeSingle: mockReqSelectSingle }),
+    });
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "expert_requests") return { select: mockReqSelect };
+      return {};
+    });
+
+    const mockPromoteMaybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+    const mockPromoteSelect = jest.fn().mockReturnValue({ maybeSingle: mockPromoteMaybeSingle });
+    const mockPromoteNeq = jest.fn().mockReturnValue({ select: mockPromoteSelect });
+    const mockPromoteEq = jest.fn().mockReturnValue({ neq: mockPromoteNeq });
+    const mockProfileUpdate = jest.fn().mockReturnValue({ eq: mockPromoteEq });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return { update: mockProfileUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/expert-requests/req-x/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("PROMOTION_FAILED");
+  });
+
+  it("rejects a pending request with a decision note", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqSelectSingle = jest.fn().mockResolvedValue({
+      data: { id: "req-2", user_id: "applicant-2", status: "pending" },
+      error: null,
+    });
+    const mockReqSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({ maybeSingle: mockReqSelectSingle }),
+    });
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "expert_requests") return { select: mockReqSelect };
+      return {};
+    });
+
+    const mockReqUpdate = jest
+      .fn()
+      .mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "expert_requests") return { update: mockReqUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/expert-requests/req-2/reject")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Insufficient evidence." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("rejected");
+    expect(mockReqUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "rejected",
+        decision_note: "Insufficient evidence.",
+      })
+    );
+  });
+
+  it("returns 409 when approving an already-decided request", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqSelectSingle = jest.fn().mockResolvedValue({
+      data: { id: "req-3", user_id: "applicant-3", status: "approved" },
+      error: null,
+    });
+    const mockReqSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({ maybeSingle: mockReqSelectSingle }),
+    });
+
+    let profilesCalls = 0;
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") {
+        profilesCalls++;
+        if (profilesCalls === 1) return profileLookup;
+        return {};
+      }
+      if (table === "expert_requests") {
+        return { select: mockReqSelect };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/expert-requests/req-3/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+});
+
+// ─── User-side POST /auth/expert-requests ─────────────────────────────────────
+
+describe("POST /auth/expert-requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects an already-expert caller with 409", async () => {
+    const profileLookup = mockAuthAs("expert", "p-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/auth/expert-requests")
+      .set("Authorization", "Bearer t")
+      .send({ reason: "I want to upgrade" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.message).toMatch(/already an expert/i);
+  });
+
+  it("creates a new pending request for a learner", async () => {
+    const profileLookup = mockAuthAs("learner", "p-2");
+
+    // No existing pending request.
+    const mockReqExistsMaybeSingle = jest.fn().mockResolvedValue({ data: null });
+    const mockReqExistsEq2 = jest
+      .fn()
+      .mockReturnValue({ maybeSingle: mockReqExistsMaybeSingle });
+    const mockReqExistsEq1 = jest.fn().mockReturnValue({ eq: mockReqExistsEq2 });
+    const mockReqExistsSelect = jest.fn().mockReturnValue({ eq: mockReqExistsEq1 });
+
+    // Insert returns the row.
+    const mockInsertSingle = jest.fn().mockResolvedValue({
+      data: {
+        id: "new-req",
+        user_id: "p-2",
+        reason: "I cooked for 20 years",
+        status: "pending",
+        created_at: "2026-05-09T00:00:00Z",
+      },
+      error: null,
+    });
+    const mockInsertSelect = jest.fn().mockReturnValue({ single: mockInsertSingle });
+    const mockReqInsert = jest.fn().mockReturnValue({ select: mockInsertSelect });
+
+    let profilesCalls = 0;
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") {
+        profilesCalls++;
+        if (profilesCalls === 1) return profileLookup;
+        return {};
+      }
+      if (table === "expert_requests") {
+        return { select: mockReqExistsSelect, insert: mockReqInsert };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/auth/expert-requests")
+      .set("Authorization", "Bearer t")
+      .send({ reason: "I cooked for 20 years" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.status).toBe("pending");
+    expect(res.body.data.userId).toBe("p-2");
+  });
+});

--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -55,22 +55,29 @@ describe("Auth Routes", () => {
     });
 
     it("should return 201 on successful registration", async () => {
-      // Mock existing profile check
-      const mockSingle = jest.fn().mockResolvedValue({ data: null });
-      const mockEq = jest.fn().mockReturnValue({ maybeSingle: mockSingle });
-      const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
-      
-      // Mock profile insert
-      const mockInsert = jest.fn().mockResolvedValue({ error: null });
-      
+      // Username uniqueness check returns no row.
+      const mockExistingProfileMaybeSingle = jest.fn().mockResolvedValue({ data: null });
+      const mockExistingProfileEq = jest
+        .fn()
+        .mockReturnValue({ maybeSingle: mockExistingProfileMaybeSingle });
+      const mockExistingProfileSelect = jest
+        .fn()
+        .mockReturnValue({ eq: mockExistingProfileEq });
+
+      // Profile insert + select id chain.
+      const mockInsertSingle = jest
+        .fn()
+        .mockResolvedValue({ data: { id: "profile-1" }, error: null });
+      const mockInsertSelect = jest.fn().mockReturnValue({ single: mockInsertSingle });
+      const mockInsert = jest.fn().mockReturnValue({ select: mockInsertSelect });
+
       (supabase.from as jest.Mock).mockImplementation((table) => {
         if (table === "profiles") {
-          return { select: mockSelect, insert: mockInsert };
+          return { select: mockExistingProfileSelect, insert: mockInsert };
         }
         return {};
       });
 
-      // Mock auth.signUp
       (supabase.auth.signUp as jest.Mock).mockResolvedValue({
         data: {
           user: { id: "user-123", email: validPayload.email },
@@ -84,6 +91,82 @@ describe("Auth Routes", () => {
       expect(response.body.success).toBe(true);
       expect(response.body.data.username).toBe(validPayload.username);
       expect(response.body.data.role).toBe(validPayload.role);
+      expect(response.body.data.pendingExpertRequest).toBe(false);
+    });
+
+    it("registers as cook with a pending expert request when role=expert is requested", async () => {
+      // Username check — free.
+      const mockExistingProfileMaybeSingle = jest.fn().mockResolvedValue({ data: null });
+      const mockExistingProfileEq = jest
+        .fn()
+        .mockReturnValue({ maybeSingle: mockExistingProfileMaybeSingle });
+      const mockExistingProfileSelect = jest
+        .fn()
+        .mockReturnValue({ eq: mockExistingProfileEq });
+
+      // Profile insert returns the new id.
+      const mockInsertSingle = jest
+        .fn()
+        .mockResolvedValue({ data: { id: "profile-new" }, error: null });
+      const mockInsertSelect = jest.fn().mockReturnValue({ single: mockInsertSingle });
+      const mockProfilesInsert = jest.fn().mockReturnValue({ select: mockInsertSelect });
+
+      // expert_requests insert succeeds.
+      const mockExpertRequestsInsert = jest.fn().mockResolvedValue({ error: null });
+
+      (supabase.from as jest.Mock).mockImplementation((table) => {
+        if (table === "profiles") {
+          return { select: mockExistingProfileSelect, insert: mockProfilesInsert };
+        }
+        if (table === "expert_requests") {
+          return { insert: mockExpertRequestsInsert };
+        }
+        return {};
+      });
+
+      (supabase.auth.signUp as jest.Mock).mockResolvedValue({
+        data: {
+          user: { id: "user-xyz", email: "expert@example.com" },
+          session: { access_token: "access", refresh_token: "refresh" },
+        },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/auth/register")
+        .send({
+          email: "expert@example.com",
+          password: "password123",
+          username: "wannabe_expert",
+          role: "expert",
+          expertRequestReason: "10 years of cooking",
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      // Role is downgraded to cook (interim) regardless of the form selection.
+      expect(res.body.data.role).toBe("cook");
+      expect(res.body.data.pendingExpertRequest).toBe(true);
+
+      // Verify the expert_requests insert ran with the new profile id + reason.
+      expect(mockExpertRequestsInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: "profile-new",
+          reason: "10 years of cooking",
+          status: "pending",
+        })
+      );
+    });
+
+    it("rejects role=admin at registration via VALIDATION_ERROR", async () => {
+      const res = await request(app).post("/auth/register").send({
+        email: "test@example.com",
+        password: "password123",
+        username: "wannabe_admin",
+        role: "admin",
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("VALIDATION_ERROR");
     });
   });
 

--- a/backend/src/config/supabase.ts
+++ b/backend/src/config/supabase.ts
@@ -1,10 +1,11 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import dotenv from "dotenv";
 
 dotenv.config();
 
 const supabaseUrl = process.env["SUPABASE_URL"];
 const supabaseAnonKey = process.env["SUPABASE_ANON_KEY"];
+const supabaseServiceRoleKey = process.env["SUPABASE_SERVICE_ROLE_KEY"];
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error(
@@ -39,3 +40,28 @@ export const createUserClient = (accessToken: string) =>
       persistSession: false,
     },
   });
+
+/**
+ * Privileged Supabase client used only by `/admin/*` routes for cross-profile
+ * writes. Uses the service-role key, which bypasses RLS — anything done through
+ * this client is unconstrained by row-level policies, so callers MUST gate
+ * access with `requireAdmin` first.
+ *
+ * `null` when SUPABASE_SERVICE_ROLE_KEY is not configured. Admin routes detect
+ * this and return a clear error instead of silently no-op'ing under RLS.
+ */
+export const supabaseAdmin: SupabaseClient | null = supabaseServiceRoleKey
+  ? createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    })
+  : null;
+
+if (!supabaseAdmin && process.env["NODE_ENV"] !== "test") {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[supabase] SUPABASE_SERVICE_ROLE_KEY is not set. /admin/* writes will fail with ADMIN_NOT_CONFIGURED until it is provided."
+  );
+}

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -243,16 +243,227 @@ export const openApiSpec = {
                   email: { type: "string", format: "email" },
                   password: { type: "string", minLength: 6 },
                   username: { type: "string" },
-                  role: { type: "string", enum: ["learner", "cook", "expert"] },
+                  role: { type: "string", enum: ["learner", "cook", "expert"], description: "Choosing 'expert' creates the profile as 'cook' (interim) and opens a pending expert_requests row that must be approved by the admin." },
+                  expertRequestReason: { type: "string", description: "Optional justification, only stored when role='expert' is requested." },
                 },
               },
             },
           },
         },
         responses: {
-          "201": { description: "User registered successfully" },
+          "201": {
+            description: "User registered successfully. When role='expert' was requested, the response carries `pendingExpertRequest: true` and the user's role is 'cook' (interim) until an admin approves the request.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    data: {
+                      type: "object",
+                      properties: {
+                        userId: { type: "string" },
+                        email: { type: "string" },
+                        username: { type: "string" },
+                        role: { type: "string", enum: ["learner", "cook", "expert"] },
+                        accessToken: { type: "string" },
+                        refreshToken: { type: "string" },
+                        pendingExpertRequest: { type: "boolean" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
           "400": { description: "Validation error", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
           "409": { description: "Email or username already taken", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Expert account requests (user-side) ─────────────────────────────────
+    "/auth/expert-requests": {
+      post: {
+        summary: "Submit an expert-account request",
+        description:
+          "Open a pending expert_requests row. Only one pending request per user. Caller must currently be a learner or cook.",
+        tags: ["Auth"],
+        security: [bearerAuth],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["reason"],
+                properties: {
+                  reason: { type: "string", maxLength: 2000 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": { description: "Pending request created" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "403": { description: "Caller is admin (admins cannot apply)", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+          "409": { description: "Already an expert OR a pending request already exists", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+    "/auth/expert-requests/me": {
+      get: {
+        summary: "Get my latest expert-account request (or null)",
+        tags: ["Auth"],
+        security: [bearerAuth],
+        responses: {
+          "200": { description: "Latest request or null" },
+          "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ApiError" } } } },
+        },
+      },
+    },
+
+    // ── Admin (admin-only) ──────────────────────────────────────────────────
+    "/admin/expert-requests": {
+      get: {
+        summary: "List expert-account requests",
+        description: "Defaults to only pending requests. Admin only.",
+        tags: ["Admin"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "status", in: "query", schema: { type: "string", enum: ["pending", "approved", "rejected"] } },
+          { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 20, maximum: 100 } },
+        ],
+        responses: {
+          "200": { description: "Paginated list" },
+          "401": { description: "Unauthorized" },
+          "403": { description: "Caller is not the admin" },
+        },
+      },
+    },
+    "/admin/expert-requests/{id}/approve": {
+      post: {
+        summary: "Approve a pending expert request",
+        description: "Promotes the applicant's profile.role to 'expert' and marks the request approved.",
+        tags: ["Admin"],
+        security: [bearerAuth],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        requestBody: {
+          required: false,
+          content: { "application/json": { schema: { type: "object", properties: { decisionNote: { type: "string" } } } } },
+        },
+        responses: {
+          "200": { description: "Approved" },
+          "404": { description: "Request not found" },
+          "409": { description: "Request already decided" },
+        },
+      },
+    },
+    "/admin/expert-requests/{id}/reject": {
+      post: {
+        summary: "Reject a pending expert request",
+        tags: ["Admin"],
+        security: [bearerAuth],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        requestBody: {
+          required: false,
+          content: { "application/json": { schema: { type: "object", properties: { decisionNote: { type: "string" } } } } },
+        },
+        responses: {
+          "200": { description: "Rejected" },
+          "404": { description: "Request not found" },
+          "409": { description: "Request already decided" },
+        },
+      },
+    },
+    "/admin/users": {
+      get: {
+        summary: "List users",
+        tags: ["Admin"],
+        security: [bearerAuth],
+        parameters: [
+          { name: "search", in: "query", schema: { type: "string" } },
+          { name: "role", in: "query", schema: { type: "string", enum: ["learner", "cook", "expert", "admin"] } },
+          { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 20, maximum: 100 } },
+        ],
+        responses: {
+          "200": { description: "Paginated list" },
+          "401": { description: "Unauthorized" },
+          "403": { description: "Caller is not the admin" },
+        },
+      },
+    },
+    "/admin/users/{id}": {
+      patch: {
+        summary: "Update a user's profile",
+        description:
+          "Admin can modify role/username/bio/region/preferred_language. The admin profile itself cannot be modified through this endpoint, and roles cannot be set to 'admin'.",
+        tags: ["Admin"],
+        security: [bearerAuth],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  username: { type: "string" },
+                  role: { type: "string", enum: ["learner", "cook", "expert"] },
+                  bio: { type: "string" },
+                  region: { type: "string" },
+                  preferred_language: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Updated" },
+          "403": { description: "Target is the admin profile" },
+          "404": { description: "User not found" },
+          "409": { description: "Username already taken" },
+        },
+      },
+      delete: {
+        summary: "Delete a user profile",
+        description:
+          "Removes the profile row. All FKs referencing profiles cascade. The auth.users row is preserved (only the Supabase service role can remove it); the deleted profile is enough to lock the account out of the API.",
+        tags: ["Admin"],
+        security: [bearerAuth],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "204": { description: "Deleted" },
+          "403": { description: "Target is the admin profile or self" },
+          "404": { description: "User not found" },
+        },
+      },
+    },
+    "/admin/recipes/{id}": {
+      delete: {
+        summary: "Delete any recipe",
+        description: "Deletes a recipe regardless of who created it. All recipe_* child rows cascade.",
+        tags: ["Admin"],
+        security: [bearerAuth],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "204": { description: "Deleted" },
+          "404": { description: "Recipe not found" },
+        },
+      },
+    },
+    "/admin/comments/{id}": {
+      delete: {
+        summary: "Delete any comment (moderator action)",
+        tags: ["Admin"],
+        security: [bearerAuth],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
+        responses: {
+          "204": { description: "Deleted" },
+          "404": { description: "Comment not found" },
         },
       },
     },
@@ -1711,5 +1922,6 @@ export const openApiSpec = {
     { name: "Media", description: "File upload" },
     { name: "Tools & Units", description: "Cooking tool and measurement unit lookup" },
     { name: "Users", description: "Favorites and drafts" },
+    { name: "Admin", description: "Single-admin moderation surface: expert request review, user/recipe/comment moderation" },
   ],
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import commentsRouter from "./routes/comments.js";
 import usersRouter from "./routes/users.js";
 import allergensRouter from "./routes/allergens.js";
 import videoAnnotationsRouter from "./routes/video-annotations.js";
+import adminRouter from "./routes/admin.js";
 
 const app = express();
 const PORT = process.env["PORT"] ?? 3000;
@@ -57,6 +58,7 @@ app.use("/", commentsRouter);
 app.use("/", videoAnnotationsRouter);
 app.use("/users", usersRouter);
 app.use("/allergens", allergensRouter);
+app.use("/admin", adminRouter);
 
 // ─── 404 Handler ─────────────────────────────────────────────────────────────
 app.use((_req, res) => {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -84,3 +84,11 @@ export const requireRole =
     }
     next();
   };
+
+// ─── requireAdmin ────────────────────────────────────────────────────────────
+
+/**
+ * Shorthand for `requireRole("admin")`. Intentionally a separate export so the
+ * intent is obvious at call sites in admin-only routes.
+ */
+export const requireAdmin = requireRole("admin");

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,553 @@
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { supabase, supabaseAdmin } from "../config/supabase.js";
+import { requireAuth, requireAdmin } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest, UserRole } from "../types/index.js";
+import { errorResponse, successResponse } from "../utils/response.js";
+
+const router = Router();
+
+// All routes in this file are admin-only.
+router.use(requireAuth, requireAdmin);
+
+/**
+ * Returns the privileged service-role Supabase client, or sends a 503 to the
+ * caller and returns null when the key is not configured. Reads from
+ * `profiles` (e.g. listing users) work through the regular `supabase` anon
+ * client because the SELECT policy is `USING: true`; writes to other users'
+ * rows do NOT, because the RLS UPDATE policy on profiles is restricted to
+ * `(user_id = auth.uid())`. So we use this helper only for cross-row writes.
+ */
+function getAdminClient(res: Response): typeof supabaseAdmin {
+  if (!supabaseAdmin) {
+    res
+      .status(503)
+      .json(
+        errorResponse(
+          "ADMIN_NOT_CONFIGURED",
+          "SUPABASE_SERVICE_ROLE_KEY is not set on the backend; admin writes are disabled."
+        )
+      );
+    return null;
+  }
+  return supabaseAdmin;
+}
+
+// ─── Expert Requests ─────────────────────────────────────────────────────────
+
+const listExpertRequestsQuery = z.object({
+  status: z.enum(["pending", "approved", "rejected"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+/**
+ * GET /admin/expert-requests
+ * List expert account requests, newest first. Default: only pending.
+ */
+router.get("/expert-requests", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listExpertRequestsQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid query."));
+    return;
+  }
+  const { status, page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("expert_requests")
+    .select(
+      `id, user_id, reason, status, decision_note, decided_by, created_at, decided_at,
+       applicant:profiles!expert_requests_user_id_fkey(id, username, role)`,
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  if (status) {
+    query = query.eq("status", status);
+  } else {
+    query = query.eq("status", "pending");
+  }
+
+  const { data, error, count } = await query;
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  const items = (data ?? []).map((r: any) => ({
+    id: r.id,
+    userId: r.user_id,
+    reason: r.reason,
+    status: r.status,
+    decisionNote: r.decision_note,
+    decidedBy: r.decided_by,
+    createdAt: r.created_at,
+    decidedAt: r.decided_at,
+    applicant: r.applicant
+      ? { id: r.applicant.id, username: r.applicant.username, role: r.applicant.role }
+      : null,
+  }));
+
+  res.status(200).json(
+    successResponse({
+      requests: items,
+      pagination: { page, limit, total: count ?? 0 },
+    })
+  );
+});
+
+const decisionSchema = z.object({
+  decisionNote: z
+    .string()
+    .trim()
+    .max(2000, "Decision note must be at most 2000 characters.")
+    .optional(),
+});
+
+/**
+ * Loads a request by id and ensures it is in 'pending' state. Returns the
+ * row, or sends an error response and returns null.
+ */
+async function loadPendingRequest(
+  id: string,
+  res: Response
+): Promise<{ id: string; user_id: string } | null> {
+  const { data: request, error } = await supabase
+    .from("expert_requests")
+    .select("id, user_id, status")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return null;
+  }
+  if (!request) {
+    res.status(404).json(errorResponse("NOT_FOUND", "Expert request not found."));
+    return null;
+  }
+  if ((request as any).status !== "pending") {
+    res
+      .status(409)
+      .json(
+        errorResponse(
+          "REQUEST_ALREADY_DECIDED",
+          `This request has already been ${(request as any).status}.`
+        )
+      );
+    return null;
+  }
+  return request as { id: string; user_id: string };
+}
+
+/**
+ * POST /admin/expert-requests/:id/approve
+ * Promotes the applicant to "expert" and marks the request approved.
+ */
+router.post(
+  "/expert-requests/:id/approve",
+  validate(decisionSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const id = req.params["id"] as string;
+    const { decisionNote } = req.body as z.infer<typeof decisionSchema>;
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const request = await loadPendingRequest(id, res);
+    if (!request) return;
+
+    // 1) Promote the applicant first. We do this before flipping the request
+    //    state so that a failure here leaves the request as 'pending' and the
+    //    admin can simply retry. Verifying with `.select().single()` makes a
+    //    silent 0-row update (e.g. RLS misconfig) surface as an error instead
+    //    of pretending the promotion succeeded.
+    const decidedAt = new Date().toISOString();
+    const { data: promoted, error: roleErr } = await adminClient
+      .from("profiles")
+      .update({ role: "expert", updated_at: decidedAt })
+      .eq("id", request.user_id)
+      .neq("role", "admin")
+      .select("id, role")
+      .maybeSingle();
+
+    if (roleErr) {
+      res.status(500).json(errorResponse("DB_ERROR", roleErr.message));
+      return;
+    }
+    if (!promoted) {
+      // Either the profile vanished, or it was already an admin — both should
+      // be treated as a hard error here so the admin sees what happened.
+      res
+        .status(409)
+        .json(
+          errorResponse(
+            "PROMOTION_FAILED",
+            "Could not promote the applicant. Their profile may have been deleted or already be an admin."
+          )
+        );
+      return;
+    }
+
+    // 2) Mark the request approved using the same admin client (RLS isn't
+    //    set on expert_requests today, but using the privileged client keeps
+    //    the contract uniform if policies are added later).
+    const { error: updateErr } = await adminClient
+      .from("expert_requests")
+      .update({
+        status: "approved",
+        decision_note: decisionNote ?? null,
+        decided_by: admin.profileId,
+        decided_at: decidedAt,
+      })
+      .eq("id", request.id);
+
+    if (updateErr) {
+      res.status(500).json(errorResponse("DB_ERROR", updateErr.message));
+      return;
+    }
+
+    res.status(200).json(
+      successResponse({
+        id: request.id,
+        userId: request.user_id,
+        status: "approved",
+        decisionNote: decisionNote ?? null,
+        decidedAt,
+      })
+    );
+  }
+);
+
+/**
+ * POST /admin/expert-requests/:id/reject
+ * Marks the request rejected. Profile role is unchanged.
+ */
+router.post(
+  "/expert-requests/:id/reject",
+  validate(decisionSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const id = req.params["id"] as string;
+    const { decisionNote } = req.body as z.infer<typeof decisionSchema>;
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const request = await loadPendingRequest(id, res);
+    if (!request) return;
+
+    const decidedAt = new Date().toISOString();
+    const { error } = await adminClient
+      .from("expert_requests")
+      .update({
+        status: "rejected",
+        decision_note: decisionNote ?? null,
+        decided_by: admin.profileId,
+        decided_at: decidedAt,
+      })
+      .eq("id", request.id);
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res.status(200).json(
+      successResponse({
+        id: request.id,
+        userId: request.user_id,
+        status: "rejected",
+        decisionNote: decisionNote ?? null,
+        decidedAt,
+      })
+    );
+  }
+);
+
+// ─── Users ───────────────────────────────────────────────────────────────────
+
+const listUsersQuery = z.object({
+  search: z.string().trim().min(1).optional(),
+  role: z.enum(["learner", "cook", "expert", "admin"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+/**
+ * GET /admin/users
+ * List profiles with optional username search and role filter.
+ */
+router.get("/users", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listUsersQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid query."));
+    return;
+  }
+  const { search, role, page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("profiles")
+    .select(
+      "id, user_id, username, role, region, preferred_language, bio, avatar_url, created_at, updated_at",
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  if (search) {
+    query = query.ilike("username", `%${search}%`);
+  }
+  if (role) {
+    query = query.eq("role", role);
+  }
+
+  const { data, error, count } = await query;
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(
+    successResponse({
+      users: data ?? [],
+      pagination: { page, limit, total: count ?? 0 },
+    })
+  );
+});
+
+const updateUserSchema = z.object({
+  username: z
+    .string()
+    .min(3)
+    .max(30)
+    .regex(/^[a-zA-Z0-9_]+$/, "Username can only contain letters, numbers, and underscores.")
+    .optional(),
+  role: z.enum(["learner", "cook", "expert"]).optional(),
+  bio: z.string().max(500).optional(),
+  region: z.string().max(100).optional(),
+  preferred_language: z.string().max(10).optional(),
+});
+
+/**
+ * PATCH /admin/users/:id
+ * Update another user's profile. Role can be changed to any non-admin value;
+ * promoting/demoting the admin is intentionally not supported here (the
+ * single-admin invariant is enforced by a partial unique index in the DB).
+ */
+router.patch(
+  "/users/:id",
+  validate(updateUserSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const id = req.params["id"] as string;
+    const updates = req.body as z.infer<typeof updateUserSchema>;
+
+    if (Object.keys(updates).length === 0) {
+      res
+        .status(400)
+        .json(errorResponse("VALIDATION_ERROR", "At least one field must be provided."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    // Refuse to mutate the admin profile via this endpoint.
+    const { data: target, error: loadErr } = await supabase
+      .from("profiles")
+      .select("id, role, username")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (loadErr) {
+      res.status(500).json(errorResponse("DB_ERROR", loadErr.message));
+      return;
+    }
+    if (!target) {
+      res.status(404).json(errorResponse("NOT_FOUND", "User not found."));
+      return;
+    }
+    if ((target as any).role === "admin") {
+      res
+        .status(403)
+        .json(errorResponse("FORBIDDEN", "The admin profile cannot be modified via this endpoint."));
+      return;
+    }
+
+    if (updates.username && updates.username !== (target as any).username) {
+      const { data: clash } = await supabase
+        .from("profiles")
+        .select("id")
+        .eq("username", updates.username)
+        .maybeSingle();
+      if (clash) {
+        res.status(409).json(errorResponse("CONFLICT", "Username is already taken."));
+        return;
+      }
+    }
+
+    const { data: updated, error } = await adminClient
+      .from("profiles")
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .select(
+        "id, user_id, username, role, region, preferred_language, bio, avatar_url, created_at, updated_at"
+      )
+      .single();
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res.status(200).json(successResponse(updated));
+  }
+);
+
+/**
+ * DELETE /admin/users/:id
+ * Removes the profile row. All recipes/comments/ratings/etc. cascade away
+ * via the existing FKs. The matching auth.users row remains (it can only be
+ * removed via the Supabase service role); the deleted profile is enough to
+ * lock the account out of every API endpoint.
+ */
+router.delete("/users/:id", async (req: Request, res: Response): Promise<void> => {
+  const admin = (req as AuthenticatedRequest).user;
+  const id = req.params["id"] as string;
+
+  if (id === admin.profileId) {
+    res
+      .status(403)
+      .json(errorResponse("FORBIDDEN", "You cannot delete your own admin profile."));
+    return;
+  }
+
+  const adminClient = getAdminClient(res);
+  if (!adminClient) return;
+
+  const { data: target, error: loadErr } = await supabase
+    .from("profiles")
+    .select("id, role")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (loadErr) {
+    res.status(500).json(errorResponse("DB_ERROR", loadErr.message));
+    return;
+  }
+  if (!target) {
+    res.status(404).json(errorResponse("NOT_FOUND", "User not found."));
+    return;
+  }
+  if ((target as any).role === "admin") {
+    res
+      .status(403)
+      .json(errorResponse("FORBIDDEN", "The admin profile cannot be deleted via this endpoint."));
+    return;
+  }
+
+  const { error } = await adminClient.from("profiles").delete().eq("id", id);
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(204).send();
+});
+
+// ─── Recipes ─────────────────────────────────────────────────────────────────
+
+/**
+ * DELETE /admin/recipes/:id
+ * Removes a recipe regardless of who created it. All recipe_* child rows,
+ * ratings, comments, video_annotations, etc. cascade away via FKs.
+ */
+router.delete("/recipes/:id", async (req: Request, res: Response): Promise<void> => {
+  const id = req.params["id"] as string;
+
+  const adminClient = getAdminClient(res);
+  if (!adminClient) return;
+
+  const { data: recipe, error: loadErr } = await supabase
+    .from("recipes")
+    .select("id")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (loadErr) {
+    res.status(500).json(errorResponse("DB_ERROR", loadErr.message));
+    return;
+  }
+  if (!recipe) {
+    res.status(404).json(errorResponse("NOT_FOUND", "Recipe not found."));
+    return;
+  }
+
+  const { error } = await adminClient.from("recipes").delete().eq("id", id);
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(204).send();
+});
+
+// ─── Comments ────────────────────────────────────────────────────────────────
+
+/**
+ * DELETE /admin/comments/:id
+ * Moderator-style deletion: removes any comment, even if the admin is not its
+ * author. Distinct from `DELETE /comments/:id` which is author-only.
+ */
+router.delete("/comments/:id", async (req: Request, res: Response): Promise<void> => {
+  const id = req.params["id"] as string;
+
+  const idNum = Number.parseInt(id, 10);
+  if (!Number.isFinite(idNum)) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", "Comment id must be an integer."));
+    return;
+  }
+
+  const adminClient = getAdminClient(res);
+  if (!adminClient) return;
+
+  const { data: existing, error: loadErr } = await supabase
+    .from("comments")
+    .select("id")
+    .eq("id", idNum)
+    .maybeSingle();
+
+  if (loadErr) {
+    res.status(500).json(errorResponse("DB_ERROR", loadErr.message));
+    return;
+  }
+  if (!existing) {
+    res.status(404).json(errorResponse("NOT_FOUND", "Comment not found."));
+    return;
+  }
+
+  const { error } = await adminClient.from("comments").delete().eq("id", idNum);
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(204).send();
+});
+
+// Lint hint: silence unused-import warnings in environments where UserRole is
+// shaken out by the bundler.
+export type _Unused = UserRole;
+
+export default router;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -4,6 +4,7 @@ import { supabase } from "../config/supabase.js";
 import { requireAuth } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import type { AuthenticatedRequest, UserRole } from "../types/index.js";
+import { REGISTRABLE_ROLES } from "../types/index.js";
 import { errorResponse, successResponse } from "../utils/response.js";
 
 const router = Router();
@@ -18,9 +19,16 @@ const registerSchema = z.object({
     .min(3, "Username must be at least 3 characters.")
     .max(30, "Username must be at most 30 characters.")
     .regex(/^[a-zA-Z0-9_]+$/, "Username can only contain letters, numbers, and underscores."),
-  role: z.enum(["learner", "cook", "expert"], {
+  role: z.enum(REGISTRABLE_ROLES, {
     message: "Role must be one of: learner, cook, expert.",
   }),
+  // Optional justification — used only when `role === "expert"` to seed the
+  // expert_requests row that a single admin will later review/approve.
+  expertRequestReason: z
+    .string()
+    .trim()
+    .max(2000, "Expert request reason must be at most 2000 characters.")
+    .optional(),
 });
 
 const loginSchema = z.object({
@@ -39,7 +47,21 @@ const refreshSchema = z.object({
  * Creates a Supabase Auth user and a corresponding profile row.
  */
 router.post("/register", validate(registerSchema), async (req, res): Promise<void> => {
-  const { email, password, username, role } = req.body as z.infer<typeof registerSchema>;
+  const {
+    email,
+    password,
+    username,
+    role: requestedRole,
+    expertRequestReason,
+  } = req.body as z.infer<typeof registerSchema>;
+
+  // Option-A expert flow: choosing "expert" at registration does NOT make the
+  // user an expert. The profile is created with role="cook" (so the applicant
+  // can already publish community recipes while waiting) and a pending
+  // expert_requests row is opened. The single admin reviews it, and if
+  // approved, the user's role is promoted to "expert".
+  const isExpertRequest = requestedRole === "expert";
+  const role: UserRole = isExpertRequest ? "cook" : requestedRole;
 
   // Check if username already taken (before creating auth user)
   const { data: existingProfile } = await supabase
@@ -86,19 +108,38 @@ router.post("/register", validate(registerSchema), async (req, res): Promise<voi
   }
 
   // Insert profile row
-  const { error: profileError } = await supabase.from("profiles").insert({
-    user_id: authData.user.id,
-    username,
-    role,
-  });
+  const { data: insertedProfile, error: profileError } = await supabase
+    .from("profiles")
+    .insert({
+      user_id: authData.user.id,
+      username,
+      role,
+    })
+    .select("id")
+    .single();
 
-  if (profileError) {
+  if (profileError || !insertedProfile) {
     // Profile insertion failed — attempt to clean up the auth user
     await supabase.auth.admin?.deleteUser(authData.user.id).catch(() => null);
     res
       .status(500)
       .json(errorResponse("PROFILE_CREATION_FAILED", "Could not create user profile."));
     return;
+  }
+
+  // If the caller asked for the "expert" role, open a pending expert_requests
+  // row tied to their fresh profile. Failure here is non-fatal — the account
+  // is created either way; the user can re-submit via POST /auth/expert-requests.
+  let pendingExpertRequest = false;
+  if (isExpertRequest) {
+    const { error: reqError } = await supabase.from("expert_requests").insert({
+      user_id: (insertedProfile as { id: string }).id,
+      reason: expertRequestReason ?? null,
+      status: "pending",
+    });
+    if (!reqError) {
+      pendingExpertRequest = true;
+    }
   }
 
   res.status(201).json(
@@ -109,6 +150,7 @@ router.post("/register", validate(registerSchema), async (req, res): Promise<voi
       role,
       accessToken: authData.session.access_token,
       refreshToken: authData.session.refresh_token,
+      pendingExpertRequest,
     })
   );
 });
@@ -266,6 +308,145 @@ router.patch("/profile", requireAuth, validate(updateProfileSchema), async (req,
   }
 
   res.status(200).json(successResponse(updated));
+});
+
+// ─── Expert Account Requests ─────────────────────────────────────────────────
+//
+// Open-to-self endpoints used by learner/cook profiles to apply for promotion
+// to "expert". The matching admin-side review endpoints live under
+// `/admin/expert-requests/*` (see src/routes/admin.ts).
+
+const expertRequestSchema = z.object({
+  reason: z
+    .string()
+    .trim()
+    .min(1, "Please provide a short reason for your request.")
+    .max(2000, "Reason must be at most 2000 characters."),
+});
+
+/**
+ * Submit an expert-account request. The caller must currently be a learner or
+ * cook (already-experts and the admin cannot apply). Only one pending request
+ * per user is allowed; a previously rejected request does not block a new one.
+ */
+router.post(
+  "/expert-requests",
+  requireAuth,
+  validate(expertRequestSchema),
+  async (req, res): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const { reason } = req.body as z.infer<typeof expertRequestSchema>;
+
+    if (user.role === "expert") {
+      res
+        .status(409)
+        .json(errorResponse("CONFLICT", "You are already an expert."));
+      return;
+    }
+    if (user.role === "admin") {
+      res
+        .status(403)
+        .json(errorResponse("FORBIDDEN", "Admins cannot request the expert role."));
+      return;
+    }
+
+    // Reject if a pending request already exists.
+    const { data: existing } = await supabase
+      .from("expert_requests")
+      .select("id, status")
+      .eq("user_id", user.profileId)
+      .eq("status", "pending")
+      .maybeSingle();
+
+    if (existing) {
+      res
+        .status(409)
+        .json(
+          errorResponse(
+            "EXPERT_REQUEST_PENDING",
+            "You already have a pending expert request."
+          )
+        );
+      return;
+    }
+
+    const { data: inserted, error } = await supabase
+      .from("expert_requests")
+      .insert({
+        user_id: user.profileId,
+        reason,
+        status: "pending",
+      })
+      .select("id, user_id, reason, status, created_at")
+      .single();
+
+    if (error || !inserted) {
+      // Map the partial-unique-index race to the same 409 path.
+      if ((error as { code?: string } | null)?.code === "23505") {
+        res
+          .status(409)
+          .json(
+            errorResponse(
+              "EXPERT_REQUEST_PENDING",
+              "You already have a pending expert request."
+            )
+          );
+        return;
+      }
+      res.status(500).json(errorResponse("DB_ERROR", error?.message ?? "Insert failed."));
+      return;
+    }
+
+    res.status(201).json(
+      successResponse({
+        id: (inserted as any).id,
+        userId: (inserted as any).user_id,
+        reason: (inserted as any).reason,
+        status: (inserted as any).status,
+        createdAt: (inserted as any).created_at,
+      })
+    );
+  }
+);
+
+/**
+ * Returns the most recent expert request belonging to the caller, or null if
+ * none exists. Useful for the frontend to render "your request is pending /
+ * approved / rejected" badges.
+ */
+router.get("/expert-requests/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+
+  const { data, error } = await supabase
+    .from("expert_requests")
+    .select("id, user_id, reason, status, decision_note, decided_by, created_at, decided_at")
+    .eq("user_id", user.profileId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  if (!data) {
+    res.status(200).json(successResponse(null));
+    return;
+  }
+
+  res.status(200).json(
+    successResponse({
+      id: (data as any).id,
+      userId: (data as any).user_id,
+      reason: (data as any).reason,
+      status: (data as any).status,
+      decisionNote: (data as any).decision_note,
+      decidedBy: (data as any).decided_by,
+      createdAt: (data as any).created_at,
+      decidedAt: (data as any).decided_at,
+    })
+  );
 });
 
 export default router;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -12,9 +12,13 @@ export interface LanguageRequest extends Request {
 
 // ─── User Roles ────────────────────────────────────────────────────────────────
 
-export type UserRole = "learner" | "cook" | "expert";
+export type UserRole = "learner" | "cook" | "expert" | "admin";
 
-export const USER_ROLES: UserRole[] = ["learner", "cook", "expert"];
+export const USER_ROLES: UserRole[] = ["learner", "cook", "expert", "admin"];
+
+/** Roles selectable at registration. `admin` is intentionally excluded. */
+export const REGISTRABLE_ROLES = ["learner", "cook", "expert"] as const;
+export type RegistrableRole = (typeof REGISTRABLE_ROLES)[number];
 
 // ─── Authenticated User ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
This pull request introduces a robust admin role and an expert account approval workflow to the backend, along with supporting database migrations, documentation updates, and utility scripts. The changes enforce a single-admin invariant, add moderation endpoints, and implement a formal process for users to request and be granted "expert" status, all while ensuring data integrity and auditability.

**Database schema and role management:**

- Added `admin` as a valid value in `profiles.role`, enforced by a new partial unique index to guarantee only one admin exists at a time. (`003_admin_role_and_expert_requests.sql`)
- Created the `expert_requests` table to track expert account applications, with unique constraints to prevent duplicate pending requests and indexes for efficient querying. (`003_admin_role_and_expert_requests.sql`)
- Provided a rollback migration to safely revert these schema changes if needed. (`003_admin_role_and_expert_requests_rollback.sql`)

**API and workflow enhancements:**

- Documented new admin-only moderation endpoints in `CLAUDE.md`, including user/recipe/comment management and expert request review, all requiring a secure service-role Supabase key. [[1]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR71) [[2]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eL147-R169) [[3]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR528-R536)
- Detailed the expert approval workflow, including registration and post-registration flows, admin review process, and error handling for edge cases. [[1]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eL107-R109) [[2]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR340-R349) [[3]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR378-R381)

**Operational and developer tooling:**

- Added scripts for inspecting foreign keys, profile constraints, row-level security policies, and for promoting users whose expert requests were approved but not reflected in their profile due to earlier RLS issues. (`inspect-fks.js`, `inspect-profiles.js`, `inspect-rls.js`, `promote-stuck-user.js`) [[1]](diffhunk://#diff-0a1597adf31ed9b8aeabd237069adfb9191a0e9ad7d566fe110a144f327fbcf4R1-R48) [[2]](diffhunk://#diff-d69298ab6d9a3766c67267251ac0a39d3b76fcb3326cf6bfc06dfd0954aa585eR1-R42) [[3]](diffhunk://#diff-f849d6c2a69accf16c6ff95a69dc58b8ab538ebdf7b701be63fa5163963ead5bR1-R64) [[4]](diffhunk://#diff-dfc6a2df47e7d2ea6bb0a0aba0ffa3fdb91ae9a4e3b6dc5007511017f118c09bR1-R51)
- Added a migration runner script for applying SQL migrations using environment-configured database URLs. (`run-migration.js`)

**Documentation and configuration:**

- Updated `CLAUDE.md` to describe the new roles, expert approval process, admin API endpoints, error codes, and required environment variables, including secure handling of the Supabase service role key. [[1]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR71) [[2]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eL107-R109) [[3]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eL147-R169) [[4]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR340-R349) [[5]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR378-R381) [[6]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR528-R536)

These changes collectively enable secure, auditable admin moderation and a formalized expert user workflow, while providing the tools and documentation necessary for ongoing maintenance and troubleshooting.…,

Closes #493  , Closes #494 