### PR TITLE
Add cultural tags migration, endpoint, and recipe integration

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -60,6 +60,7 @@ backend/
 │   │   ├── media.ts             # File upload (images/videos)
 │   │   ├── discovery.ts         # Recipe discovery with filters
 │   │   ├── dietary-tags.ts      # Dietary/allergen tag listing
+│   │   ├── cultural-tags.ts     # Cultural-event tag listing (region-scoped)
 │   │   ├── dish-genres.ts       # Cuisine genre listing
 │   │   ├── dish-varieties.ts    # Dish variety listing, search, recipes
 │   │   ├── ingredients.ts       # Ingredient search/autocomplete
@@ -92,6 +93,7 @@ backend/
 │       ├── tools.test.ts
 │       ├── units.test.ts
 │       ├── comments.test.ts
+│       ├── cultural-tags.test.ts # GET /cultural-tags, culturalTags in recipe detail, discovery filter
 │       └── health.test.ts
 ├── Dockerfile
 ├── jest.config.js
@@ -114,6 +116,7 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - **recipe_media** — `id`, `recipe_id` (FK), `url`, `type` (image|video), `created_at`
 - **ratings** — `id`, `recipe_id` (FK), `user_id` (FK profiles), `score` (1-5), `created_at`, `updated_at` — unique constraint on (recipe_id, user_id)
 - **recipe_dietary_tags** — `recipe_id` (FK recipes), `tag_id` (FK dietary_tags) — composite PK
+- **recipe_cultural_tags** — `recipe_id` (FK recipes ON DELETE CASCADE), `tag_id` (FK cultural_tags ON DELETE CASCADE) — composite PK
 - **comments** — `id` (serial PK), `recipe_id` (FK recipes ON DELETE CASCADE), `user_id` (FK profiles ON DELETE CASCADE), `text` (1–2000 chars, CHECK), `created_at`, `updated_at` (nullable). Indexed on `recipe_id`, `user_id`, and `(recipe_id, created_at DESC)`. **Unique constraint on `(recipe_id, user_id)`** — one comment per user per recipe; the API enforces this with a pre-insert existence check and also maps Postgres `unique_violation` (23505) on insert to 409 `COMMENT_ALREADY_EXISTS` to handle the race window. The API exposes the column as `body`; the route maps `body` ↔ `text` at the DB boundary.
 - **video_annotations** — `id` (serial PK), `recipe_id` (FK recipes), `start_time` / `end_time` (numeric seconds into the video, both `>= 0`, `end_time >= start_time` enforced both at the DB CHECK level and in the route), `note` (1–500 chars, CHECK), `technique` (text, nullable — short label like "Searing"), `created_at`. Used for manual timestamp **ranges** placed by the recipe creator (cook/expert) on top of an uploaded video — e.g. "putting the chicken in the oven" from 42.5s to 56.78s. Two complementary surfaces, both creator-only: per-step start markers via `recipe_steps.video_timestamp` (single point — when the step begins), and standalone time-range annotations via this table.
 
@@ -124,6 +127,7 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 - **ingredient_allergens** — `ingredient_id` (FK), `allergen_id` (FK)
 - **ingredient_substitutions** — `id`, `ingredient_id` (FK ingredients), `substitute_id` (FK ingredients), `source_amount` NUMERIC(10,3), `source_unit` TEXT, `sub_amount` NUMERIC(10,3), `sub_unit` TEXT, `confidence` NUMERIC(3,2), `description` TEXT — unique on (ingredient_id, substitute_id), no self-substitution
 - **dietary_tags** — `id`, `name`, `name_en`, `name_tr`, `category` (dietary|allergen)
+- **cultural_tags** — `id`, `key` (unique slug e.g. `"social-gathering"`), `label_en`, `label_tr`, `country` (nullable — NULL = global, otherwise country-scoped e.g. `"Turkey"`). Seeded with 10 curated tags: 7 global (`social-gathering`, `religious-feast`, `wedding`, `funeral`, `birth`, `new-year`, `harvest`) + 3 region-specific (`sira-gecesi`/Turkey, `iftar`/Turkey, `mochitsuki`/Japan). Migration: `migrations/004_cultural_tags.sql`.
 - **dish_genres** — `id`, `name`, `name_en`, `name_tr`, `description`, `description_en`, `description_tr`
 - **dish_varieties** — `id`, `name`, `name_en`, `name_tr`, `description`, `description_en`, `description_tr`, `genre_id` (FK dish_genres)
 
@@ -169,12 +173,12 @@ All endpoints require `requireAuth + requireAdmin`. **Admin writes go through a 
 - `DELETE /admin/comments/:id` — Moderator-style delete of any comment, even when the admin is not its author (distinct from `DELETE /comments/:id` which is author-only).
 
 ### Recipes (`/recipes`)
-- `GET /recipes/:id` — Recipe detail (public if published, creator-only if draft)
+- `GET /recipes/:id` — Recipe detail (public if published, creator-only if draft); response includes `culturalTags[]` (`{ id, key, labelEn, labelTr, country }`) alongside existing `tags[]`
 - `GET /recipes` — List published recipes with pagination
   - Query params: `creatorId` (optional UUID — filter by creator's profile ID to view a specific user's published recipes), `page`, `limit`
   - Response recipe objects include `coverImageUrl` (first image from `recipe_media`, or `null`)
-- `POST /recipes` — Create recipe (cook/expert only, accepts `tagIds`, optional `country`, `city`, `district`)
-- `PATCH /recipes/:id` — Update draft (creator only, cook/expert, accepts `tagIds`, optional `country`, `city`, `district`)
+- `POST /recipes` — Create recipe (cook/expert only, accepts `tagIds`, `culturalTagIds`, optional `country`, `city`, `district`)
+- `PATCH /recipes/:id` — Update draft (creator only, cook/expert, accepts `tagIds`, `culturalTagIds`, optional `country`, `city`, `district`)
 - `POST /recipes/:id/publish` — Publish draft (validates completeness)
 - `POST /recipes/:id/ratings` — Rate recipe 1-5 (cannot self-rate, upsert)
 - `GET /recipes/:id/ratings/me` — Get own rating
@@ -225,9 +229,16 @@ All endpoints require `requireAuth + requireAdmin`. **Admin writes go through a 
   - Query params: `lang` (optional — "en" or "tr")
   - Without `lang`: response includes `name`, `name_en`, `name_tr`, `category`
 
+### Cultural Tags (`/cultural-tags`)
+- `GET /cultural-tags` — List curated cultural-event tags
+  - Query params: `country` (optional — when provided returns global tags + country-scoped tags; omitting returns all 10 tags)
+  - Response shape: `{ id, key, labelEn, labelTr, country }[]` — mirrors mobile `CulturalTagItem` interface
+  - 10 seeded tags: 7 global (`social-gathering`, `religious-feast`, `wedding`, `funeral`, `birth`, `new-year`, `harvest`) + Turkey-scoped (`sira-gecesi`, `iftar`) + Japan-scoped (`mochitsuki`)
+  - `GET /cultural-tags?country=Turkey` → 9 tags (global + sira-gecesi + iftar, excludes mochitsuki)
+
 ### Discovery (`/discovery`)
 - `GET /discovery/recipes` — Filtered recipe discovery
-  - Query params: `genreId`, `varietyId`, `excludeAllergens` (comma-separated IDs), `tagIds` (comma-separated dietary tag IDs — only recipes with ALL specified tags), `search` (case-insensitive partial match on recipe title), `country`, `city`, `district` (case-insensitive, whitespace-/diacritic-tolerant; country also resolves common aliases — `"tr"`/`"Türkiye"`/`"TUR"` all match recipes stored as `"Turkey"`. See Location Normalization below), `page`, `limit`
+  - Query params: `genreId`, `varietyId`, `excludeAllergens` (comma-separated IDs), `tagIds` (comma-separated dietary tag IDs — only recipes with ALL specified tags), `culturalTagIds` (comma-separated cultural tag IDs — recipes matching ANY of them; OR logic), `search` (case-insensitive partial match on recipe title), `country`, `city`, `district` (case-insensitive, whitespace-/diacritic-tolerant; country also resolves common aliases — `"tr"`/`"Türkiye"`/`"TUR"` all match recipes stored as `"Turkey"`. See Location Normalization below), `page`, `limit`
   - Response recipe objects include `country`, `city`, `district` fields (nullable)
   - Response also includes `varieties[]` and `genres[]` cascade arrays — distinct varieties and genres derived from **every** recipe matching the active filters (not just the current page), so callers can use them as cross-page-stable filter dropdowns. Implementation runs the cascade aggregation as a separate query in parallel with the paginated list (issue #463).
 - `GET /discovery/recipes/by-ingredients` — Recipes fully makeable with provided ingredients

--- a/backend/migrations/004_cultural_tags.sql
+++ b/backend/migrations/004_cultural_tags.sql
@@ -1,0 +1,53 @@
+-- Migration: Create cultural_tags and recipe_cultural_tags tables
+-- Run this in the Supabase SQL Editor
+
+-- 1. cultural_tags — curated flat taxonomy with optional region-scope
+CREATE TABLE public.cultural_tags (
+  id       serial PRIMARY KEY,
+  key      text   NOT NULL UNIQUE,
+  label_en text   NOT NULL,
+  label_tr text   NOT NULL,
+  country  text   NULL
+);
+
+-- 2. recipe_cultural_tags — junction (many-to-many)
+CREATE TABLE public.recipe_cultural_tags (
+  recipe_id uuid    NOT NULL REFERENCES public.recipes(id) ON DELETE CASCADE,
+  tag_id    integer NOT NULL REFERENCES public.cultural_tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (recipe_id, tag_id)
+);
+
+-- 3. Seed: 10 curated tags (mirrors mobile mock taxonomy)
+INSERT INTO public.cultural_tags (key, label_en, label_tr, country) VALUES
+  ('social-gathering', 'Social Gathering',  'Sosyal Toplanma',  NULL),
+  ('religious-feast',  'Religious Feast',   'Dini Kutlama',     NULL),
+  ('wedding',          'Wedding',           'Düğün',            NULL),
+  ('funeral',          'Funeral',           'Cenaze',           NULL),
+  ('birth',            'Birth Celebration', 'Doğum Kutlaması',  NULL),
+  ('new-year',         'New Year',          'Yeni Yıl',         NULL),
+  ('harvest',          'Harvest Festival',  'Hasat Festivali',  NULL),
+  ('sira-gecesi',      'Sıra Gecesi',       'Sıra Gecesi',      'Turkey'),
+  ('iftar',            'Iftar',             'İftar',            'Turkey'),
+  ('mochitsuki',       'Mochitsuki',        'Mochitsuki',       'Japan');
+
+-- 4. Enable RLS
+ALTER TABLE public.cultural_tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.recipe_cultural_tags ENABLE ROW LEVEL SECURITY;
+
+-- 5. RLS policies for cultural_tags (read-only for everyone)
+CREATE POLICY "Anyone can read cultural_tags"
+  ON public.cultural_tags FOR SELECT
+  USING (true);
+
+-- 6. RLS policies for recipe_cultural_tags
+CREATE POLICY "Anyone can read recipe_cultural_tags"
+  ON public.recipe_cultural_tags FOR SELECT
+  USING (true);
+
+CREATE POLICY "Authenticated users can insert recipe_cultural_tags"
+  ON public.recipe_cultural_tags FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Authenticated users can delete recipe_cultural_tags"
+  ON public.recipe_cultural_tags FOR DELETE
+  USING (true);

--- a/backend/src/__tests__/cultural-tags.test.ts
+++ b/backend/src/__tests__/cultural-tags.test.ts
@@ -1,0 +1,352 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: { from: mockFrom },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+const chainable = (resolved: { data: any; error: any; count?: number | null }) => {
+  const mock: any = {};
+  const methods = [
+    "select", "eq", "neq", "in", "not", "or", "order",
+    "range", "single", "maybeSingle", "ilike", "limit", "filter",
+  ];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
+  return mock;
+};
+
+// ─── GET /cultural-tags ───────────────────────────────────────────────────────
+
+describe("GET /cultural-tags", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const allTags = [
+    { id: 1, key: "social-gathering", label_en: "Social Gathering", label_tr: "Sosyal Toplanma", country: null },
+    { id: 2, key: "wedding",          label_en: "Wedding",           label_tr: "Düğün",           country: null },
+    { id: 8, key: "sira-gecesi",      label_en: "Sıra Gecesi",       label_tr: "Sıra Gecesi",      country: "Turkey" },
+    { id: 9, key: "iftar",            label_en: "Iftar",             label_tr: "İftar",            country: "Turkey" },
+    { id: 10, key: "mochitsuki",      label_en: "Mochitsuki",        label_tr: "Mochitsuki",       country: "Japan" },
+  ];
+
+  it("returns all tags with 200 when no country filter", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(chainable({ data: allTags, error: null }));
+
+    const res = await request(app).get("/cultural-tags");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(5);
+    expect(res.body.data[0].key).toBe("social-gathering");
+    expect(res.body.data[0].labelEn).toBe("Social Gathering");
+    expect(res.body.data[0].labelTr).toBe("Sosyal Toplanma");
+    expect(res.body.data[0].country).toBeNull();
+  });
+
+  it("camelCases the response fields correctly", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(chainable({ data: [allTags[0]], error: null }));
+
+    const res = await request(app).get("/cultural-tags");
+
+    expect(res.status).toBe(200);
+    const tag = res.body.data[0];
+    expect(tag).toHaveProperty("id");
+    expect(tag).toHaveProperty("key");
+    expect(tag).toHaveProperty("labelEn");
+    expect(tag).toHaveProperty("labelTr");
+    expect(tag).toHaveProperty("country");
+    expect(tag).not.toHaveProperty("label_en");
+    expect(tag).not.toHaveProperty("label_tr");
+  });
+
+  it("applies country filter when ?country= is provided", async () => {
+    const turkeyTags = allTags.filter((t) => t.country === null || t.country === "Turkey");
+    (supabase.from as jest.Mock).mockReturnValue(chainable({ data: turkeyTags, error: null }));
+
+    const res = await request(app).get("/cultural-tags?country=Turkey");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(4);
+    const keys = res.body.data.map((t: any) => t.key);
+    expect(keys).toContain("social-gathering");
+    expect(keys).toContain("sira-gecesi");
+    expect(keys).toContain("iftar");
+    expect(keys).not.toContain("mochitsuki");
+  });
+
+  it("applies country filter for Japan", async () => {
+    const japanTags = allTags.filter((t) => t.country === null || t.country === "Japan");
+    (supabase.from as jest.Mock).mockReturnValue(chainable({ data: japanTags, error: null }));
+
+    const res = await request(app).get("/cultural-tags?country=Japan");
+
+    expect(res.status).toBe(200);
+    const keys = res.body.data.map((t: any) => t.key);
+    expect(keys).toContain("mochitsuki");
+    expect(keys).not.toContain("sira-gecesi");
+  });
+
+  it("returns empty array when no tags exist", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(chainable({ data: [], error: null }));
+
+    const res = await request(app).get("/cultural-tags");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it("returns 500 on database error", async () => {
+    (supabase.from as jest.Mock).mockReturnValue(
+      chainable({ data: null, error: { message: "DB connection failed" } })
+    );
+
+    const res = await request(app).get("/cultural-tags");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /recipes/:id — culturalTags in payload ───────────────────────────────
+
+describe("GET /recipes/:id — culturalTags field", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns culturalTags array in recipe detail", async () => {
+    const mockRecipe = {
+      id: "recipe-1",
+      title: "Çiğ Köfte",
+      story: "Sıra gecesi geleneği...",
+      video_url: null,
+      serving_size: 4,
+      type: "cultural",
+      is_published: true,
+      average_rating: 4.5,
+      rating_count: 10,
+      allergen_ids: [],
+      country: "Turkey",
+      city: "Şanlıurfa",
+      district: null,
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+      creator: { id: "u1", username: "cook1" },
+      dish_variety: { id: 1, name: "Çiğ Köfte", dish_genre: { id: 1, name: "Salads" } },
+      recipe_ingredients: [],
+      recipe_steps: [],
+      recipe_tools: [],
+      recipe_media: [],
+      recipe_dietary_tags: [],
+      recipe_cultural_tags: [
+        {
+          cultural_tag: {
+            id: 1,
+            key: "social-gathering",
+            label_en: "Social Gathering",
+            label_tr: "Sosyal Toplanma",
+            country: null,
+          },
+        },
+        {
+          cultural_tag: {
+            id: 8,
+            key: "sira-gecesi",
+            label_en: "Sıra Gecesi",
+            label_tr: "Sıra Gecesi",
+            country: "Turkey",
+          },
+        },
+      ],
+      video_annotations: [],
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes") return chainable({ data: mockRecipe, error: null });
+      if (table === "allergens") return chainable({ data: [], error: null });
+      if (table === "user_favorites") return chainable({ data: null, error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app).get("/recipes/recipe-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.culturalTags).toHaveLength(2);
+    expect(res.body.data.culturalTags[0].key).toBe("social-gathering");
+    expect(res.body.data.culturalTags[0].labelEn).toBe("Social Gathering");
+    expect(res.body.data.culturalTags[1].key).toBe("sira-gecesi");
+    expect(res.body.data.culturalTags[1].country).toBe("Turkey");
+  });
+
+  it("returns empty culturalTags array when recipe has none", async () => {
+    const mockRecipe = {
+      id: "recipe-2",
+      title: "Plain Recipe",
+      story: null,
+      video_url: null,
+      serving_size: null,
+      type: "community",
+      is_published: true,
+      average_rating: null,
+      rating_count: 0,
+      allergen_ids: [],
+      country: null,
+      city: null,
+      district: null,
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+      creator: { id: "u1", username: "cook1" },
+      dish_variety: null,
+      recipe_ingredients: [],
+      recipe_steps: [],
+      recipe_tools: [],
+      recipe_media: [],
+      recipe_dietary_tags: [],
+      recipe_cultural_tags: [],
+      video_annotations: [],
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes") return chainable({ data: mockRecipe, error: null });
+      if (table === "allergens") return chainable({ data: [], error: null });
+      return chainable({ data: null, error: null });
+    });
+
+    const res = await request(app).get("/recipes/recipe-2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.culturalTags).toHaveLength(0);
+  });
+});
+
+// ─── GET /discovery/recipes?culturalTagIds ────────────────────────────────────
+
+describe("GET /discovery/recipes?culturalTagIds", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockRecipes = [
+    {
+      id: "r1",
+      title: "Çiğ Köfte",
+      type: "cultural",
+      average_rating: 4.5,
+      rating_count: 5,
+      allergen_ids: [],
+      country: "Turkey",
+      city: "Şanlıurfa",
+      district: null,
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+      dish_variety: { id: 1, name: "Çiğ Köfte", dish_genre: { id: 2, name: "Salads" } },
+      profile: { id: "u1", username: "cook1" },
+      recipe_media: [],
+    },
+  ];
+
+  it("returns recipes matching the cultural tag (OR logic)", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_cultural_tags")
+        return chainable({ data: [{ recipe_id: "r1" }], error: null });
+      if (table === "recipes")
+        return chainable({ data: mockRecipes, error: null, count: 1 });
+      if (table === "allergens")
+        return chainable({ data: [], error: null });
+      return chainable({ data: [], error: null });
+    });
+
+    const res = await request(app).get("/discovery/recipes?culturalTagIds=1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(1);
+    expect(res.body.data.recipes[0].title).toBe("Çiğ Köfte");
+  });
+
+  it("returns cascade varieties and genres from matching recipes", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_cultural_tags")
+        return chainable({ data: [{ recipe_id: "r1" }], error: null });
+      if (table === "recipes")
+        return chainable({ data: mockRecipes, error: null, count: 1 });
+      if (table === "allergens")
+        return chainable({ data: [], error: null });
+      return chainable({ data: [], error: null });
+    });
+
+    const res = await request(app).get("/discovery/recipes?culturalTagIds=1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.varieties.length).toBeGreaterThanOrEqual(0);
+    expect(res.body.data.genres.length).toBeGreaterThanOrEqual(0);
+    expect(res.body.data).toHaveProperty("pagination");
+  });
+
+  it("returns empty result when no recipes match the cultural tag", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_cultural_tags")
+        return chainable({ data: [], error: null });
+      return chainable({ data: [], error: null });
+    });
+
+    const res = await request(app).get("/discovery/recipes?culturalTagIds=999");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toHaveLength(0);
+    expect(res.body.data.pagination.total).toBe(0);
+  });
+
+  it("multiple culturalTagIds uses OR — returns recipes from any matching tag", async () => {
+    // recipe r1 has tag 1, recipe r2 has tag 8 — both should appear
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_cultural_tags")
+        return chainable({
+          data: [{ recipe_id: "r1" }, { recipe_id: "r2" }],
+          error: null,
+        });
+      if (table === "recipes")
+        return chainable({ data: mockRecipes, error: null, count: 2 });
+      if (table === "allergens")
+        return chainable({ data: [], error: null });
+      return chainable({ data: [], error: null });
+    });
+
+    const res = await request(app).get("/discovery/recipes?culturalTagIds=1,8");
+
+    expect(res.status).toBe(200);
+    // Both recipe IDs were passed to the main query via .in("id", [...])
+    expect(res.body.data.pagination).toBeDefined();
+  });
+
+  it("returns 500 when recipe_cultural_tags query fails", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipe_cultural_tags")
+        return chainable({ data: null, error: { message: "DB failure" } });
+      return chainable({ data: [], error: null });
+    });
+
+    const res = await request(app).get("/discovery/recipes?culturalTagIds=1");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+
+  it("ignores culturalTagIds param when not provided — returns all recipes", async () => {
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "recipes")
+        return chainable({ data: mockRecipes, error: null, count: 1 });
+      if (table === "allergens")
+        return chainable({ data: [], error: null });
+      return chainable({ data: [], error: null });
+    });
+
+    const res = await request(app).get("/discovery/recipes");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.recipes).toBeDefined();
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,6 +23,7 @@ import usersRouter from "./routes/users.js";
 import allergensRouter from "./routes/allergens.js";
 import videoAnnotationsRouter from "./routes/video-annotations.js";
 import adminRouter from "./routes/admin.js";
+import culturalTagsRouter from "./routes/cultural-tags.js";
 
 const app = express();
 const PORT = process.env["PORT"] ?? 3000;
@@ -59,6 +60,7 @@ app.use("/", videoAnnotationsRouter);
 app.use("/users", usersRouter);
 app.use("/allergens", allergensRouter);
 app.use("/admin", adminRouter);
+app.use("/cultural-tags", culturalTagsRouter);
 
 // ─── 404 Handler ─────────────────────────────────────────────────────────────
 app.use((_req, res) => {

--- a/backend/src/routes/cultural-tags.ts
+++ b/backend/src/routes/cultural-tags.ts
@@ -1,0 +1,48 @@
+import { Router } from "express";
+import { supabase } from "../config/supabase.js";
+import { successResponse, errorResponse } from "../utils/response.js";
+
+const router = Router();
+
+// ─── GET /cultural-tags ──────────────────────────────────────────────────────
+// Returns curated cultural-event tags.
+// Query params:
+//   country — when provided, returns only global tags (country IS NULL) plus
+//              tags scoped to that country. Omitting the param returns all tags.
+//
+// Response shape mirrors the mobile mock client:
+//   { id, key, labelEn, labelTr, country }
+
+router.get("/", async (req, res) => {
+  const country = typeof req.query["country"] === "string"
+    ? req.query["country"].trim()
+    : null;
+
+  let query = supabase
+    .from("cultural_tags")
+    .select("id, key, label_en, label_tr, country")
+    .order("country", { nullsFirst: true })
+    .order("key");
+
+  if (country) {
+    query = query.or(`country.is.null,country.eq.${country}`);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return res.status(500).json(errorResponse("DB_ERROR", error.message));
+  }
+
+  const tags = (data as any[]).map((row) => ({
+    id:      row.id,
+    key:     row.key,
+    labelEn: row.label_en,
+    labelTr: row.label_tr,
+    country: row.country ?? null,
+  }));
+
+  return res.status(200).json(successResponse(tags));
+});
+
+export default router;

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -58,6 +58,8 @@ const discoveryQuerySchema = z.object({
   excludeAllergens: z.string().optional(),
   // Comma-separated dietary tag IDs to require (e.g. "1,3" for Halal + Vegan)
   tagIds: z.string().optional(),
+  // Comma-separated cultural tag IDs — recipes matching ANY of them are returned
+  culturalTagIds: z.string().optional(),
   genreId: z.coerce.number().int().positive().optional(),
   varietyId: z.coerce.number().int().positive().optional(),
   // Case-insensitive partial match on recipe title (e.g. "pasta")
@@ -86,7 +88,7 @@ router.get("/recipes", async (req, res) => {
         .join("; ");
       return res.status(400).json(errorResponse("VALIDATION_ERROR", message));
     }
-    const { excludeAllergens, tagIds, genreId, varietyId, search, country, city, district, page, limit } = parsed.data;
+    const { excludeAllergens, tagIds, culturalTagIds, genreId, varietyId, search, country, city, district, page, limit } = parsed.data;
 
     // ── Step 0: Resolve tag filter ───────────────────────────────────────────
     let tagFilteredRecipeIds: string[] | null = null;
@@ -129,6 +131,42 @@ router.get("/recipes", async (req, res) => {
           return res.status(200).json(
             successResponse({
               recipes: [],
+              pagination: { page, limit, total: 0 },
+            })
+          );
+        }
+      }
+    }
+
+    // ── Step 0b: Resolve cultural tag filter (OR — any matching tag) ─────────
+    let culturalTagFilteredRecipeIds: string[] | null = null;
+
+    if (culturalTagIds) {
+      const parsedCulturalTagIds = culturalTagIds
+        .split(",")
+        .map(Number)
+        .filter((n) => Number.isInteger(n) && n > 0);
+
+      if (parsedCulturalTagIds.length > 0) {
+        const { data: culturalTagRows, error: culturalTagErr } = await supabase
+          .from("recipe_cultural_tags")
+          .select("recipe_id")
+          .in("tag_id", parsedCulturalTagIds);
+
+        if (culturalTagErr) {
+          return res.status(500).json(errorResponse("DB_ERROR", culturalTagErr.message));
+        }
+
+        culturalTagFilteredRecipeIds = [
+          ...new Set((culturalTagRows ?? []).map((r) => r.recipe_id)),
+        ];
+
+        if (culturalTagFilteredRecipeIds.length === 0) {
+          return res.status(200).json(
+            successResponse({
+              recipes: [],
+              varieties: [],
+              genres: [],
               pagination: { page, limit, total: 0 },
             })
           );
@@ -194,6 +232,9 @@ router.get("/recipes", async (req, res) => {
       }
       if (tagFilteredRecipeIds !== null) {
         q = q.in("id", tagFilteredRecipeIds);
+      }
+      if (culturalTagFilteredRecipeIds !== null) {
+        q = q.in("id", culturalTagFilteredRecipeIds);
       }
       return q;
     };

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -69,6 +69,10 @@ const recipeSchema = z.object({
     .array(z.number().int().positive())
     .optional()
     .default([]),
+  culturalTagIds: z
+    .array(z.number().int().positive())
+    .optional()
+    .default([]),
   allergenIds: z
     .array(z.number().int().positive())
     .optional()
@@ -245,6 +249,7 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
        recipe_tools(id, name),
        recipe_media(id, url, type),
        recipe_dietary_tags(dietary_tag:dietary_tags(id, name, category)),
+       recipe_cultural_tags(cultural_tag:cultural_tags(id, key, label_en, label_tr, country)),
        video_annotations(id, start_time, end_time, note, technique, created_at)`
     )
     .eq("id", recipeId)
@@ -390,6 +395,13 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
         id: rt.dietary_tag?.id ?? null,
         name: rt.dietary_tag?.name ?? null,
         category: rt.dietary_tag?.category ?? null,
+      })),
+      culturalTags: ((data as any).recipe_cultural_tags ?? []).map((rt: any) => ({
+        id: rt.cultural_tag?.id ?? null,
+        key: rt.cultural_tag?.key ?? null,
+        labelEn: rt.cultural_tag?.label_en ?? null,
+        labelTr: rt.cultural_tag?.label_tr ?? null,
+        country: rt.cultural_tag?.country ?? null,
       })),
       videoAnnotations: [...((data as any).video_annotations ?? [])]
         .sort((a: any, b: any) => Number(a.start_time) - Number(b.start_time))
@@ -598,6 +610,17 @@ router.post(
       );
     }
 
+    if (body.culturalTagIds.length > 0) {
+      insertPromises.push(
+        userClient.from("recipe_cultural_tags").insert(
+          body.culturalTagIds.map((tagId) => ({
+            recipe_id: recipeId,
+            tag_id: tagId,
+          }))
+        ).then(r => r)
+      );
+    }
+
     // Wait for all sub-inserts to complete
     const results = await Promise.all(insertPromises);
     const subError = results.find((r) => r.error);
@@ -765,6 +788,20 @@ router.patch(
         insertPromises.push(
           userClient.from("recipe_dietary_tags").insert(
             body.tagIds.map((tagId) => ({
+              recipe_id: recipeId,
+              tag_id: tagId,
+            }))
+          ).then(r => r)
+        );
+      }
+    }
+
+    if (body.culturalTagIds) {
+      await userClient.from("recipe_cultural_tags").delete().eq("recipe_id", recipeId);
+      if (body.culturalTagIds.length > 0) {
+        insertPromises.push(
+          userClient.from("recipe_cultural_tags").insert(
+            body.culturalTagIds.map((tagId) => ({
               recipe_id: recipeId,
               tag_id: tagId,
             }))


### PR DESCRIPTION
This pull request introduces a new "cultural tags" feature to the backend, allowing recipes to be tagged with curated cultural-event labels (such as "wedding", "iftar", or "mochitsuki"). It adds new database tables, API endpoints, and comprehensive tests to support querying, filtering, and displaying these tags on recipes and in discovery filters.

**Database schema changes:**

* Added `cultural_tags` table (curated taxonomy of cultural-event tags, with optional country scope) and `recipe_cultural_tags` junction table (many-to-many between recipes and tags), seeded with 10 tags and appropriate RLS policies.
* Documented new tables and their structure in `CLAUDE.md`. 

**API and endpoint changes:**

* Added new `GET /cultural-tags` endpoint to list all cultural tags, with optional country filtering. 
* Updated recipe creation and update endpoints to accept `culturalTagIds`, and recipe detail responses to include a `culturalTags[]` field.
* Extended recipe discovery endpoint to support filtering by `culturalTagIds` (OR logic), returning recipes matching any selected cultural tag.

**Testing and documentation:**

* Added comprehensive tests for cultural tags, including endpoint tests for tag listing, recipe detail, and discovery filtering.
* Updated backend documentation to reflect new endpoints, query parameters, and test files.
**Summary of most important changes:**

**Database and schema:**
- Added `cultural_tags` and `recipe_cultural_tags` tables, seeded with 10 tags, and enabled RLS with appropriate policies.
- Documented new tables and their structure in `CLAUDE.md`.

**API endpoints and integration:**
- Introduced `GET /cultural-tags` endpoint with country filtering, and integrated the router in the backend.
**Testing and documentation:**
- Added comprehensive tests for cultural tag endpoints, recipe detail integration, and discovery filtering.
- Updated backend documentation and test file listings to cover new features and endpoints. 

closes #499 
closes #500 
closes #501