### PR TITLE
Frontend/feature language switcher

### DIFF
--- a/frontend/src/__tests__/integration/http-client-lang.test.ts
+++ b/frontend/src/__tests__/integration/http-client-lang.test.ts
@@ -1,0 +1,95 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { httpClient } from '@/lib/http-client'
+import { LANGUAGE_STORAGE_KEY } from '@/lib/language-storage'
+
+describe('httpClient lang interceptor', () => {
+  afterEach(() => {
+    localStorage.removeItem(LANGUAGE_STORAGE_KEY)
+  })
+
+  it('sends lang=en when localStorage has "en"', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en')
+    let capturedParams: URLSearchParams | null = null
+
+    server.use(
+      http.get('/api/test-endpoint', ({ request }) => {
+        capturedParams = new URL(request.url).searchParams
+        return HttpResponse.json({ success: true, data: null, error: null })
+      }),
+    )
+
+    await httpClient.get('/test-endpoint')
+
+    expect(capturedParams).not.toBeNull()
+    expect(capturedParams!.get('lang')).toBe('en')
+  })
+
+  it('sends lang=tr when localStorage has "tr"', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'tr')
+    let capturedParams: URLSearchParams | null = null
+
+    server.use(
+      http.get('/api/test-endpoint', ({ request }) => {
+        capturedParams = new URL(request.url).searchParams
+        return HttpResponse.json({ success: true, data: null, error: null })
+      }),
+    )
+
+    await httpClient.get('/test-endpoint')
+
+    expect(capturedParams).not.toBeNull()
+    expect(capturedParams!.get('lang')).toBe('tr')
+  })
+
+  it('defaults to lang=en when localStorage is empty', async () => {
+    localStorage.removeItem(LANGUAGE_STORAGE_KEY)
+    let capturedParams: URLSearchParams | null = null
+
+    server.use(
+      http.get('/api/test-endpoint', ({ request }) => {
+        capturedParams = new URL(request.url).searchParams
+        return HttpResponse.json({ success: true, data: null, error: null })
+      }),
+    )
+
+    await httpClient.get('/test-endpoint')
+
+    expect(capturedParams!.get('lang')).toBe('en')
+  })
+
+  it('does not override an explicitly passed lang param', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en')
+    let capturedParams: URLSearchParams | null = null
+
+    server.use(
+      http.get('/api/test-endpoint', ({ request }) => {
+        capturedParams = new URL(request.url).searchParams
+        return HttpResponse.json({ success: true, data: null, error: null })
+      }),
+    )
+
+    await httpClient.get('/test-endpoint', { params: { lang: 'tr' } })
+
+    // caller-supplied lang wins (spread order: { lang: stored, ...config.params })
+    expect(capturedParams!.get('lang')).toBe('tr')
+  })
+
+  it('sends lang alongside other query params', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'tr')
+    let capturedParams: URLSearchParams | null = null
+
+    server.use(
+      http.get('/api/dish-genres', ({ request }) => {
+        capturedParams = new URL(request.url).searchParams
+        return HttpResponse.json({ success: true, data: [], error: null })
+      }),
+    )
+
+    await httpClient.get('/dish-genres', { params: { page: 1, limit: 20 } })
+
+    expect(capturedParams!.get('lang')).toBe('tr')
+    expect(capturedParams!.get('page')).toBe('1')
+    expect(capturedParams!.get('limit')).toBe('20')
+  })
+})

--- a/frontend/src/__tests__/integration/http-client-lang.test.ts
+++ b/frontend/src/__tests__/integration/http-client-lang.test.ts
@@ -3,6 +3,22 @@ import { server } from '@/test/mocks/server'
 import { httpClient } from '@/lib/http-client'
 import { LANGUAGE_STORAGE_KEY } from '@/lib/language-storage'
 
+// In tests VITE_API_BASE_URL=/api (set in vite.config.ts test.env).
+// jsdom sets window.location to http://localhost, so Axios resolves
+// relative baseURL requests to http://localhost/api/<path>.
+const BASE = 'http://localhost/api'
+
+function interceptPath(path: string): Promise<URLSearchParams> {
+  return new Promise((resolve) => {
+    server.use(
+      http.get(`${BASE}${path}`, ({ request }) => {
+        resolve(new URL(request.url).searchParams)
+        return HttpResponse.json({ success: true, data: null, error: null })
+      }),
+    )
+  })
+}
+
 describe('httpClient lang interceptor', () => {
   afterEach(() => {
     localStorage.removeItem(LANGUAGE_STORAGE_KEY)
@@ -10,86 +26,44 @@ describe('httpClient lang interceptor', () => {
 
   it('sends lang=en when localStorage has "en"', async () => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en')
-    let capturedParams: URLSearchParams | null = null
-
-    server.use(
-      http.get('/api/test-endpoint', ({ request }) => {
-        capturedParams = new URL(request.url).searchParams
-        return HttpResponse.json({ success: true, data: null, error: null })
-      }),
-    )
-
-    await httpClient.get('/test-endpoint')
-
-    expect(capturedParams).not.toBeNull()
-    expect(capturedParams!.get('lang')).toBe('en')
+    const paramsPromise = interceptPath('/dish-genres')
+    await httpClient.get('/dish-genres')
+    const params = await paramsPromise
+    expect(params.get('lang')).toBe('en')
   })
 
   it('sends lang=tr when localStorage has "tr"', async () => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, 'tr')
-    let capturedParams: URLSearchParams | null = null
-
-    server.use(
-      http.get('/api/test-endpoint', ({ request }) => {
-        capturedParams = new URL(request.url).searchParams
-        return HttpResponse.json({ success: true, data: null, error: null })
-      }),
-    )
-
-    await httpClient.get('/test-endpoint')
-
-    expect(capturedParams).not.toBeNull()
-    expect(capturedParams!.get('lang')).toBe('tr')
+    const paramsPromise = interceptPath('/dish-genres')
+    await httpClient.get('/dish-genres')
+    const params = await paramsPromise
+    expect(params.get('lang')).toBe('tr')
   })
 
   it('defaults to lang=en when localStorage is empty', async () => {
     localStorage.removeItem(LANGUAGE_STORAGE_KEY)
-    let capturedParams: URLSearchParams | null = null
-
-    server.use(
-      http.get('/api/test-endpoint', ({ request }) => {
-        capturedParams = new URL(request.url).searchParams
-        return HttpResponse.json({ success: true, data: null, error: null })
-      }),
-    )
-
-    await httpClient.get('/test-endpoint')
-
-    expect(capturedParams!.get('lang')).toBe('en')
+    const paramsPromise = interceptPath('/dish-genres')
+    await httpClient.get('/dish-genres')
+    const params = await paramsPromise
+    expect(params.get('lang')).toBe('en')
   })
 
   it('does not override an explicitly passed lang param', async () => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en')
-    let capturedParams: URLSearchParams | null = null
-
-    server.use(
-      http.get('/api/test-endpoint', ({ request }) => {
-        capturedParams = new URL(request.url).searchParams
-        return HttpResponse.json({ success: true, data: null, error: null })
-      }),
-    )
-
-    await httpClient.get('/test-endpoint', { params: { lang: 'tr' } })
-
+    const paramsPromise = interceptPath('/dish-genres')
+    await httpClient.get('/dish-genres', { params: { lang: 'tr' } })
+    const params = await paramsPromise
     // caller-supplied lang wins (spread order: { lang: stored, ...config.params })
-    expect(capturedParams!.get('lang')).toBe('tr')
+    expect(params.get('lang')).toBe('tr')
   })
 
   it('sends lang alongside other query params', async () => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, 'tr')
-    let capturedParams: URLSearchParams | null = null
-
-    server.use(
-      http.get('/api/dish-genres', ({ request }) => {
-        capturedParams = new URL(request.url).searchParams
-        return HttpResponse.json({ success: true, data: [], error: null })
-      }),
-    )
-
+    const paramsPromise = interceptPath('/dish-genres')
     await httpClient.get('/dish-genres', { params: { page: 1, limit: 20 } })
-
-    expect(capturedParams!.get('lang')).toBe('tr')
-    expect(capturedParams!.get('page')).toBe('1')
-    expect(capturedParams!.get('limit')).toBe('20')
+    const params = await paramsPromise
+    expect(params.get('lang')).toBe('tr')
+    expect(params.get('page')).toBe('1')
+    expect(params.get('limit')).toBe('20')
   })
 })

--- a/frontend/src/__tests__/integration/i18n-language-switcher.test.ts
+++ b/frontend/src/__tests__/integration/i18n-language-switcher.test.ts
@@ -1,0 +1,50 @@
+import i18n from '@/i18n/i18n'
+import { LANGUAGE_STORAGE_KEY } from '@/lib/language-storage'
+
+describe('i18n language switcher', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    reloadSpy = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    })
+    localStorage.removeItem(LANGUAGE_STORAGE_KEY)
+    // reset to english before each test
+    void i18n.changeLanguage('en')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('persists the new language to localStorage on change', async () => {
+    await i18n.changeLanguage('tr')
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('tr')
+  })
+
+  it('calls window.location.reload when language actually changes', async () => {
+    await i18n.changeLanguage('en')   // start at en (no reload — same lang)
+    reloadSpy.mockClear()
+
+    await i18n.changeLanguage('tr')
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT reload when the same language is set again', async () => {
+    await i18n.changeLanguage('en')
+    reloadSpy.mockClear()
+
+    await i18n.changeLanguage('en')
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('updates document.documentElement.lang on change', async () => {
+    await i18n.changeLanguage('tr')
+    expect(document.documentElement.lang).toBe('tr')
+
+    await i18n.changeLanguage('en')
+    expect(document.documentElement.lang).toBe('en')
+  })
+})

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -19,9 +19,14 @@ void i18n.use(initReactI18next).init({
 })
 
 i18n.on('languageChanged', (lng) => {
+  const prev = getStoredLanguage()
   persistLanguage(lng)
   if (typeof document !== 'undefined') {
     document.documentElement.lang = lng.split('-')[0] || 'en'
+    const next = lng.split('-')[0]
+    if (prev !== next) {
+      window.location.reload()
+    }
   }
 })
 

--- a/frontend/src/lib/http-client.ts
+++ b/frontend/src/lib/http-client.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios'
 import { session } from '@/auth/session'
 import { refreshSession } from '@/lib/refresh-session'
+import { getStoredLanguage } from '@/lib/language-storage'
 
 /**
  * Tek HTTP istemcisi. `npm run dev`: `.env.development` → `/api` + Vite proxy (localhost:3000).
@@ -66,6 +67,7 @@ httpClient.interceptors.request.use((config) => {
       config.headers.Authorization = `Bearer ${token}`
     }
   }
+  config.params = { lang: getStoredLanguage(), ...config.params }
   return config
 })
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,23 @@
 import '@testing-library/jest-dom'
 import { server } from './mocks/server'
 
+// ── Ensure localStorage is writable (vitest 4.x + jsdom 29 passes an invalid
+//    --localstorage-file path which makes jsdom return a read-only storage).
+if (typeof localStorage === 'undefined' || typeof localStorage.setItem !== 'function') {
+  const store: Record<string, string> = {}
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => { store[k] = String(v) },
+      removeItem: (k: string) => { delete store[k] },
+      clear: () => { for (const k in store) delete store[k] },
+      get length() { return Object.keys(store).length },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+    },
+  })
+}
+
 // ── Seed localStorage so session/auth-slice sees an authenticated user ──────
 localStorage.setItem('rr_access_token', 'fake-test-token')
 localStorage.setItem('rr_refresh_token', 'fake-refresh-token')

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost',
+      },
+    },
     setupFiles: ['./src/test/setup.ts'],
     css: true,
     exclude: [

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig({
       },
     },
     setupFiles: ['./src/test/setup.ts'],
+    env: {
+      VITE_API_BASE_URL: '/api',
+    },
     css: true,
     exclude: [
       '**/node_modules/**',


### PR DESCRIPTION
[Frontend/Task] Implement language switcher and translated content display (#410)

## What

- **API language param**: Every `httpClient` request now automatically appends `?lang=en` or `?lang=tr` based on the value stored in `localStorage`. This means recipe detail (title, story, steps), genres, varieties, ingredients, and dietary tags are all returned in the selected language by the backend.
- **Page reload on language change**: When the user toggles EN ↔ TR in the header switcher, the page reloads so all already-loaded data (genres, varieties, etc.) is re-fetched in the new language. The reload is guarded — it only fires when the language actually changes, not on re-selection of the current language.
- **Root `.gitignore`**: Added a root-level `.gitignore` to exclude `.DS_Store` and personal `docs/` files from the repo.

## How to test

1. Log in and navigate to any page — open DevTools Network tab and confirm every API request carries `?lang=en`.
2. Click the **TR** toggle in the top-right header — the page should reload and all genre/variety/tag names should appear in Turkish.
3. Click **EN** — page reloads back to English content.
4. Clicking the already-active language should do nothing (no reload).
5. Open a recipe detail page in Turkish — title, story, and step descriptions should be in Turkish if a translation exists.

## Tests

- `http-client-lang.test.ts` — 5 tests verifying `?lang=` is appended to every request, defaults to `en`, respects `tr`, and does not override a caller-supplied `lang` param.
- `i18n-language-switcher.test.ts` — 4 tests verifying localStorage persistence, `window.location.reload()` is called only on an actual language change, and `document.documentElement.lang` is updated correctly.
- `vite.config.ts` + `test/setup.ts`: fixed vitest 4.x + jsdom 29 localStorage incompatibility so integration tests can run.

## Notes

- Discovery recipe list titles are **not** translated — the backend `/discovery/recipes` endpoint reads `recipes.title` directly and does not join the `recipe_translations` table. This is a known backend limitation; full coverage would require a backend change.

## Related issue

Closes #410
