### PR TITLE
Add cultural tag request review workflow and tests

### DIFF
--- a/backend/migrations/005_cultural_tag_requests.sql
+++ b/backend/migrations/005_cultural_tag_requests.sql
@@ -1,0 +1,36 @@
+-- Migration: Create cultural_tag_requests table
+-- Run this in the Supabase SQL Editor
+
+CREATE TABLE public.cultural_tag_requests (
+  id            serial      PRIMARY KEY,
+  requested_by  uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  label_en      text        NULL,
+  label_tr      text        NULL,
+  country       text        NULL,
+  status        text        NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending', 'approved', 'rejected')),
+  decision_note text        NULL,
+  decided_by    uuid        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  decided_at    timestamptz NULL
+);
+
+CREATE INDEX cultural_tag_requests_status_created_at_idx
+  ON public.cultural_tag_requests (status, created_at DESC);
+
+CREATE INDEX cultural_tag_requests_requested_by_idx
+  ON public.cultural_tag_requests (requested_by);
+
+ALTER TABLE public.cultural_tag_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can read cultural_tag_requests"
+  ON public.cultural_tag_requests FOR SELECT
+  USING (true);
+
+CREATE POLICY "Authenticated users can insert cultural_tag_requests"
+  ON public.cultural_tag_requests FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Authenticated users can update cultural_tag_requests"
+  ON public.cultural_tag_requests FOR UPDATE
+  USING (true);

--- a/backend/src/__tests__/admin.test.ts
+++ b/backend/src/__tests__/admin.test.ts
@@ -313,3 +313,322 @@ describe("POST /auth/expert-requests", () => {
     expect(res.body.data.userId).toBe("p-2");
   });
 });
+
+// ─── GET /admin/cultural-tag-requests ────────────────────────────────────────
+
+describe("GET /admin/cultural-tag-requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("lists pending requests with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const rows = [
+      {
+        id: 1,
+        label_en: "Holiday Meal",
+        label_tr: "Bayram Yemeği",
+        country: "Turkey",
+        status: "pending",
+        decision_note: null,
+        decided_by: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+        requester: { id: "p1", username: "expert_user" },
+      },
+    ];
+
+    const mockChain: any = {};
+    ["select", "order", "range", "eq"].forEach((m) => {
+      mockChain[m] = jest.fn().mockReturnValue(mockChain);
+    });
+    mockChain.then = (resolve: any) =>
+      Promise.resolve({ data: rows, error: null, count: 1 }).then(resolve);
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockChain;
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/admin/cultural-tag-requests")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.requests).toHaveLength(1);
+    expect(res.body.data.requests[0].labelEn).toBe("Holiday Meal");
+    expect(res.body.data.requests[0].requester.username).toBe("expert_user");
+    expect(res.body.data.pagination).toBeDefined();
+  });
+});
+
+// ─── POST /admin/cultural-tag-requests/:id/approve ────────────────────────────
+
+describe("POST /admin/cultural-tag-requests/:id/approve", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function mockTagRequest(status: string) {
+    return {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, label_en: "Holiday Meal", label_tr: "Bayram Yemeği", country: "Turkey", status },
+            error: null,
+          }),
+        }),
+      }),
+    };
+  }
+
+  it("approves a pending request and inserts the tag", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    // unique key check returns null (no conflict)
+    const mockKeyCheck = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockTagRequest("pending");
+      if (table === "cultural_tags") return mockKeyCheck;
+      return {};
+    });
+
+    const newTag = { id: 11, key: "holiday-meal", label_en: "Holiday Meal", label_tr: "Bayram Yemeği", country: "Turkey" };
+    const mockInsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: newTag, error: null }),
+      }),
+    });
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "cultural_tags") return { insert: mockInsert };
+      if (table === "cultural_tag_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Looks good." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("approved");
+    expect(res.body.data.createdTag.key).toBe("holiday-meal");
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "holiday-meal", label_en: "Holiday Meal" })
+    );
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 404 when request does not exist", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/999/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 409 when request is already decided", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockTagRequest("approved");
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+
+  it("returns 409 when generated key already exists", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockKeyConflict = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({ data: { id: 5 }, error: null }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockTagRequest("pending");
+      if (table === "cultural_tags") return mockKeyConflict;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("CONFLICT");
+  });
+
+  it("returns 400 when labelEn cannot be resolved", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    // Request has no label_en and admin sends no override
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 1, label_en: null, label_tr: "Test", country: null, status: "pending" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ─── POST /admin/cultural-tag-requests/:id/reject ────────────────────────────
+
+describe("POST /admin/cultural-tag-requests/:id/reject", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects a pending request with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqLoad = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, status: "pending" },
+            error: null,
+          }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockReqLoad;
+      return {};
+    });
+
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "cultural_tag_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/reject")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Not needed." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("rejected");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "rejected", decision_note: "Not needed.", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 404 when request does not exist", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/999/reject")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when request is already decided", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 1, status: "rejected" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/reject")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+});

--- a/backend/src/__tests__/cultural-tags.test.ts
+++ b/backend/src/__tests__/cultural-tags.test.ts
@@ -1,11 +1,11 @@
 import request from "supertest";
 import app from "../index.js";
-import { supabase } from "../config/supabase.js";
+import { supabase, createUserClient } from "../config/supabase.js";
 
 jest.mock("../config/supabase.js", () => {
   const mockFrom = jest.fn();
   return {
-    supabase: { from: mockFrom },
+    supabase: { auth: { getUser: jest.fn() }, from: mockFrom },
     createUserClient: jest.fn(() => ({ from: mockFrom })),
   };
 });
@@ -348,5 +348,243 @@ describe("GET /discovery/recipes?culturalTagIds", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data.recipes).toBeDefined();
+  });
+});
+
+// ─── POST /cultural-tags/requests ────────────────────────────────────────────
+
+function mockAuthAsRole(role: "expert" | "cook" | "learner", profileId = "p1") {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "u1", email: "e@e.com" } },
+    error: null,
+  });
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { id: profileId, username: "u", role },
+          error: null,
+        }),
+      }),
+    }),
+  };
+}
+
+describe("POST /cultural-tags/requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).post("/cultural-tags/requests").send({ labelEn: "Test" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-expert caller", async () => {
+    const profileLookup = mockAuthAsRole("cook");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ labelEn: "Test" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when neither labelEn nor labelTr is provided", async () => {
+    const profileLookup = mockAuthAsRole("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ country: "Turkey" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a request with 201 when both labels are provided", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const insertedRow = {
+      id: 1,
+      label_en: "Holiday Meal",
+      label_tr: "Bayram Yemeği",
+      country: "Turkey",
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ labelEn: "Holiday Meal", labelTr: "Bayram Yemeği", country: "Turkey" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.labelEn).toBe("Holiday Meal");
+    expect(res.body.data.labelTr).toBe("Bayram Yemeği");
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("accepts labelTr-only and attempts DeepL translation for labelEn", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const insertedRow = {
+      id: 2,
+      label_en: "",
+      label_tr: "Sıra Gecesi",
+      country: "Turkey",
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ labelTr: "Sıra Gecesi", country: "Turkey" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("returns 500 on DB insert error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: null, error: { message: "DB error" } }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ labelEn: "Test Tag" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /cultural-tags/requests/me ──────────────────────────────────────────
+
+describe("GET /cultural-tags/requests/me", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get("/cultural-tags/requests/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns own requests as an array", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    const rows = [
+      {
+        id: 1,
+        label_en: "Holiday Meal",
+        label_tr: "Bayram Yemeği",
+        country: "Turkey",
+        status: "pending",
+        decision_note: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+      },
+    ];
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests")
+        return chainable({ data: rows, error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/cultural-tags/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].labelEn).toBe("Holiday Meal");
+    expect(res.body.data[0].status).toBe("pending");
+    expect(res.body.data[0].decisionNote).toBeNull();
+  });
+
+  it("returns empty array when user has no requests", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests")
+        return chainable({ data: [], error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/cultural-tags/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests")
+        return chainable({ data: null, error: { message: "fail" } });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/cultural-tags/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
   });
 });

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -546,6 +546,224 @@ router.delete("/comments/:id", async (req: Request, res: Response): Promise<void
   res.status(204).send();
 });
 
+// ─── Cultural Tag Requests ────────────────────────────────────────────────────
+
+const listCulturalTagRequestsQuery = z.object({
+  status: z.enum(["pending", "approved", "rejected"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+const approveTagRequestSchema = z.object({
+  labelEn:      z.string().trim().min(2).max(100).optional(),
+  labelTr:      z.string().trim().min(2).max(100).optional(),
+  country:      z.string().trim().min(1).max(100).optional(),
+  decisionNote: z.string().trim().max(2000).optional(),
+});
+
+function slugifyTagKey(text: string): string {
+  return text
+    .replace(/[İI]/g, "i").replace(/ı/g, "i")
+    .replace(/[şŞ]/g, "s").replace(/[çÇ]/g, "c")
+    .replace(/[ğĞ]/g, "g").replace(/[üÜ]/g, "u")
+    .replace(/[öÖ]/g, "o")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+/**
+ * GET /admin/cultural-tag-requests
+ * List cultural tag requests. Defaults to pending only.
+ */
+router.get("/cultural-tag-requests", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listCulturalTagRequestsQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid query."));
+    return;
+  }
+  const { status, page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("cultural_tag_requests")
+    .select(
+      `id, label_en, label_tr, country, status, decision_note, decided_by, created_at, decided_at,
+       requester:profiles!cultural_tag_requests_requested_by_fkey(id, username)`,
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  query = status ? query.eq("status", status) : query.eq("status", "pending");
+
+  const { data, error, count } = await query;
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse({
+    requests: (data ?? []).map((r: any) => ({
+      id:           r.id,
+      labelEn:      r.label_en,
+      labelTr:      r.label_tr,
+      country:      r.country ?? null,
+      status:       r.status,
+      decisionNote: r.decision_note ?? null,
+      decidedBy:    r.decided_by ?? null,
+      createdAt:    r.created_at,
+      decidedAt:    r.decided_at ?? null,
+      requester:    r.requester ? { id: r.requester.id, username: r.requester.username } : null,
+    })),
+    pagination: { page, limit, total: count ?? 0 },
+  }));
+});
+
+/**
+ * POST /admin/cultural-tag-requests/:id/approve
+ * Approves the request and inserts the tag into cultural_tags.
+ * Admin can override labelEn, labelTr, or country before approving.
+ * label_en is required (either from the original request or admin override)
+ * because it is used to generate the unique key.
+ */
+router.post(
+  "/cultural-tag-requests/:id/approve",
+  validate(approveTagRequestSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const id = req.params["id"] as string;
+    const idNum = Number.parseInt(id, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { labelEn, labelTr, country, decisionNote } = req.body as z.infer<typeof approveTagRequestSchema>;
+
+    // 1. Load the request
+    const { data: tagRequest, error: loadErr } = await supabase
+      .from("cultural_tag_requests")
+      .select("id, label_en, label_tr, country, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!tagRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Cultural tag request not found.")); return; }
+    if ((tagRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(tagRequest as any).status}.`));
+      return;
+    }
+
+    // 2. Resolve final labels (admin override wins)
+    const finalLabelEn = labelEn ?? (tagRequest as any).label_en;
+    const finalLabelTr = labelTr ?? (tagRequest as any).label_tr;
+    const finalCountry = country !== undefined ? country : ((tagRequest as any).country ?? null);
+
+    if (!finalLabelEn) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "labelEn is required to generate the tag key. Provide it in the request body."));
+      return;
+    }
+
+    // 3. Generate key and check uniqueness
+    const key = slugifyTagKey(finalLabelEn);
+    const { data: existing } = await supabase
+      .from("cultural_tags")
+      .select("id")
+      .eq("key", key)
+      .maybeSingle();
+
+    if (existing) {
+      res.status(409).json(errorResponse("CONFLICT", `A cultural tag with key '${key}' already exists.`));
+      return;
+    }
+
+    // 4. Insert into cultural_tags
+    const { data: newTag, error: insertErr } = await adminClient
+      .from("cultural_tags")
+      .insert({ key, label_en: finalLabelEn, label_tr: finalLabelTr, country: finalCountry })
+      .select("id, key, label_en, label_tr, country")
+      .single();
+
+    if (insertErr) { res.status(500).json(errorResponse("DB_ERROR", insertErr.message)); return; }
+
+    // 5. Mark request approved
+    const decidedAt = new Date().toISOString();
+    const { error: updateErr } = await adminClient
+      .from("cultural_tag_requests")
+      .update({ status: "approved", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (updateErr) { res.status(500).json(errorResponse("DB_ERROR", updateErr.message)); return; }
+
+    res.status(200).json(successResponse({
+      requestId:  idNum,
+      status:     "approved",
+      createdTag: {
+        id:      (newTag as any).id,
+        key:     (newTag as any).key,
+        labelEn: (newTag as any).label_en,
+        labelTr: (newTag as any).label_tr,
+        country: (newTag as any).country ?? null,
+      },
+      decisionNote: decisionNote ?? null,
+      decidedAt,
+    }));
+  }
+);
+
+/**
+ * POST /admin/cultural-tag-requests/:id/reject
+ * Rejects the request. No tag is created.
+ */
+router.post(
+  "/cultural-tag-requests/:id/reject",
+  validate(decisionSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const id = req.params["id"] as string;
+    const idNum = Number.parseInt(id, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { decisionNote } = req.body as z.infer<typeof decisionSchema>;
+
+    const { data: tagRequest, error: loadErr } = await supabase
+      .from("cultural_tag_requests")
+      .select("id, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!tagRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Cultural tag request not found.")); return; }
+    if ((tagRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(tagRequest as any).status}.`));
+      return;
+    }
+
+    const decidedAt = new Date().toISOString();
+    const { error } = await adminClient
+      .from("cultural_tag_requests")
+      .update({ status: "rejected", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (error) { res.status(500).json(errorResponse("DB_ERROR", error.message)); return; }
+
+    res.status(200).json(successResponse({ requestId: idNum, status: "rejected", decisionNote: decisionNote ?? null, decidedAt }));
+  }
+);
+
 // Lint hint: silence unused-import warnings in environments where UserRole is
 // shaken out by the bundler.
 export type _Unused = UserRole;

--- a/backend/src/routes/cultural-tags.ts
+++ b/backend/src/routes/cultural-tags.ts
@@ -1,10 +1,46 @@
 import { Router } from "express";
-import { supabase } from "../config/supabase.js";
+import { z } from "zod";
+import { Translator, type TextResult } from "deepl-node";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth, requireRole } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest } from "../types/index.js";
 import { successResponse, errorResponse } from "../utils/response.js";
 
 const router = Router();
 
-// ─── GET /cultural-tags ──────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// Translates a single label via DeepL. Returns null if key is missing or call fails.
+async function translateLabel(text: string, target: "en-US" | "tr"): Promise<string | null> {
+  const apiKey = process.env["DEEPL_API_KEY"];
+  if (!apiKey) return null;
+  try {
+    const translator = new Translator(apiKey);
+    const result = (await translator.translateText(text, null, target)) as TextResult;
+    return result.text;
+  } catch {
+    return null;
+  }
+}
+
+// Produces a URL-safe key from a label, handling Turkish characters.
+function slugify(text: string): string {
+  return text
+    .replace(/[İI]/g, "i").replace(/ı/g, "i")
+    .replace(/[şŞ]/g, "s").replace(/[çÇ]/g, "c")
+    .replace(/[ğĞ]/g, "g").replace(/[üÜ]/g, "u")
+    .replace(/[öÖ]/g, "o")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+export { slugify };
+
+// ─── GET /cultural-tags ───────────────────────────────────────────────────────
 // Returns curated cultural-event tags.
 // Query params:
 //   country — when provided, returns only global tags (country IS NULL) plus
@@ -43,6 +79,98 @@ router.get("/", async (req, res) => {
   }));
 
   return res.status(200).json(successResponse(tags));
+});
+
+// ─── POST /cultural-tags/requests ─────────────────────────────────────────────
+// Expert submits a new cultural tag for admin review.
+// At least one of labelEn or labelTr must be provided.
+// The missing language is auto-translated via DeepL (falls back to null if unavailable).
+
+const tagRequestSchema = z.object({
+  labelEn: z.string().trim().min(2).max(100).optional(),
+  labelTr: z.string().trim().min(2).max(100).optional(),
+  country: z.string().trim().min(1).max(100).optional(),
+}).refine((d) => d.labelEn || d.labelTr, {
+  message: "At least one of labelEn or labelTr is required.",
+});
+
+router.post(
+  "/requests",
+  requireAuth,
+  requireRole("expert"),
+  validate(tagRequestSchema),
+  async (req, res): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const { labelEn, labelTr, country } = req.body as z.infer<typeof tagRequestSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    let resolvedEn = labelEn ?? null;
+    let resolvedTr = labelTr ?? null;
+
+    // Translate the missing language via DeepL
+    if (resolvedEn && !resolvedTr) {
+      resolvedTr = await translateLabel(resolvedEn, "tr");
+    } else if (resolvedTr && !resolvedEn) {
+      resolvedEn = await translateLabel(resolvedTr, "en-US");
+    }
+
+    const { data, error } = await userClient
+      .from("cultural_tag_requests")
+      .insert({
+        requested_by: user.profileId,
+        label_en:     resolvedEn,
+        label_tr:     resolvedTr,
+        country:      country ?? null,
+        status:       "pending",
+      })
+      .select("id, label_en, label_tr, country, status, created_at")
+      .single();
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res.status(201).json(successResponse({
+      id:        (data as any).id,
+      labelEn:   (data as any).label_en,
+      labelTr:   (data as any).label_tr,
+      country:   (data as any).country ?? null,
+      status:    (data as any).status,
+      createdAt: (data as any).created_at,
+    }));
+  }
+);
+
+// ─── GET /cultural-tags/requests/me ──────────────────────────────────────────
+// Returns the authenticated expert's own tag requests.
+
+router.get("/requests/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+
+  const { data, error } = await supabase
+    .from("cultural_tag_requests")
+    .select("id, label_en, label_tr, country, status, decision_note, created_at, decided_at")
+    .eq("requested_by", user.profileId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse(
+    (data ?? []).map((r: any) => ({
+      id:           r.id,
+      labelEn:      r.label_en,
+      labelTr:      r.label_tr,
+      country:      r.country ?? null,
+      status:       r.status,
+      decisionNote: r.decision_note ?? null,
+      createdAt:    r.created_at,
+      decidedAt:    r.decided_at ?? null,
+    }))
+  ));
 });
 
 export default router;


### PR DESCRIPTION
This pull request introduces a new feature for handling "cultural tag requests," enabling experts to request new cultural tags and providing admin endpoints to review, approve, or reject these requests. It includes a new database table with appropriate policies, as well as comprehensive API and test coverage for the new endpoints. The changes are grouped into database schema additions and API/test implementations.

**Database schema and security:**

* Added a new `cultural_tag_requests` table to store requests for new cultural tags, including fields for request metadata, status, and decision tracking.
* Defined row-level security and policies to allow anyone to read requests, authenticated users to insert, and authenticated users to update requests.

**API and test coverage:**

* Implemented and tested the `POST /cultural-tags/requests` endpoint, allowing only experts to submit new cultural tag requests, with validation for required fields and error handling for database failures.
* Implemented and tested the `GET /cultural-tags/requests/me` endpoint, allowing users to view their own submitted requests, with appropriate error handling.
* Added admin endpoints and tests for listing (`GET /admin/cultural-tag-requests`), approving (`POST /admin/cultural-tag-requests/:id/approve`), and rejecting (`POST /admin/cultural-tag-requests/:id/reject`) cultural tag requests, with handling for edge cases such as duplicate keys, missing data, and already-decided requests.
* Updated Supabase mocking in tests to support authentication and user client creation, ensuring robust test isolation for the new endpoints.

closes #504 
closes #506 