### PR TITLE
Add cultural tag request review workflow and tests

### DIFF
--- a/backend/migrations/005_cultural_tag_requests.sql
+++ b/backend/migrations/005_cultural_tag_requests.sql
@@ -1,0 +1,36 @@
+-- Migration: Create cultural_tag_requests table
+-- Run this in the Supabase SQL Editor
+
+CREATE TABLE public.cultural_tag_requests (
+  id            serial      PRIMARY KEY,
+  requested_by  uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  label_en      text        NULL,
+  label_tr      text        NULL,
+  country       text        NULL,
+  status        text        NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending', 'approved', 'rejected')),
+  decision_note text        NULL,
+  decided_by    uuid        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  decided_at    timestamptz NULL
+);
+
+CREATE INDEX cultural_tag_requests_status_created_at_idx
+  ON public.cultural_tag_requests (status, created_at DESC);
+
+CREATE INDEX cultural_tag_requests_requested_by_idx
+  ON public.cultural_tag_requests (requested_by);
+
+ALTER TABLE public.cultural_tag_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can read cultural_tag_requests"
+  ON public.cultural_tag_requests FOR SELECT
+  USING (true);
+
+CREATE POLICY "Authenticated users can insert cultural_tag_requests"
+  ON public.cultural_tag_requests FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Authenticated users can update cultural_tag_requests"
+  ON public.cultural_tag_requests FOR UPDATE
+  USING (true);

--- a/backend/src/__tests__/admin.test.ts
+++ b/backend/src/__tests__/admin.test.ts
@@ -313,3 +313,322 @@ describe("POST /auth/expert-requests", () => {
     expect(res.body.data.userId).toBe("p-2");
   });
 });
+
+// ─── GET /admin/cultural-tag-requests ────────────────────────────────────────
+
+describe("GET /admin/cultural-tag-requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("lists pending requests with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const rows = [
+      {
+        id: 1,
+        label_en: "Holiday Meal",
+        label_tr: "Bayram Yemeği",
+        country: "Turkey",
+        status: "pending",
+        decision_note: null,
+        decided_by: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+        requester: { id: "p1", username: "expert_user" },
+      },
+    ];
+
+    const mockChain: any = {};
+    ["select", "order", "range", "eq"].forEach((m) => {
+      mockChain[m] = jest.fn().mockReturnValue(mockChain);
+    });
+    mockChain.then = (resolve: any) =>
+      Promise.resolve({ data: rows, error: null, count: 1 }).then(resolve);
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockChain;
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/admin/cultural-tag-requests")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.requests).toHaveLength(1);
+    expect(res.body.data.requests[0].labelEn).toBe("Holiday Meal");
+    expect(res.body.data.requests[0].requester.username).toBe("expert_user");
+    expect(res.body.data.pagination).toBeDefined();
+  });
+});
+
+// ─── POST /admin/cultural-tag-requests/:id/approve ────────────────────────────
+
+describe("POST /admin/cultural-tag-requests/:id/approve", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function mockTagRequest(status: string) {
+    return {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, label_en: "Holiday Meal", label_tr: "Bayram Yemeği", country: "Turkey", status },
+            error: null,
+          }),
+        }),
+      }),
+    };
+  }
+
+  it("approves a pending request and inserts the tag", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    // unique key check returns null (no conflict)
+    const mockKeyCheck = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockTagRequest("pending");
+      if (table === "cultural_tags") return mockKeyCheck;
+      return {};
+    });
+
+    const newTag = { id: 11, key: "holiday-meal", label_en: "Holiday Meal", label_tr: "Bayram Yemeği", country: "Turkey" };
+    const mockInsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: newTag, error: null }),
+      }),
+    });
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "cultural_tags") return { insert: mockInsert };
+      if (table === "cultural_tag_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Looks good." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("approved");
+    expect(res.body.data.createdTag.key).toBe("holiday-meal");
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "holiday-meal", label_en: "Holiday Meal" })
+    );
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 404 when request does not exist", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/999/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 409 when request is already decided", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockTagRequest("approved");
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+
+  it("returns 409 when generated key already exists", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockKeyConflict = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({ data: { id: 5 }, error: null }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockTagRequest("pending");
+      if (table === "cultural_tags") return mockKeyConflict;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("CONFLICT");
+  });
+
+  it("returns 400 when labelEn cannot be resolved", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    // Request has no label_en and admin sends no override
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 1, label_en: null, label_tr: "Test", country: null, status: "pending" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ─── POST /admin/cultural-tag-requests/:id/reject ────────────────────────────
+
+describe("POST /admin/cultural-tag-requests/:id/reject", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects a pending request with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqLoad = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, status: "pending" },
+            error: null,
+          }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") return mockReqLoad;
+      return {};
+    });
+
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "cultural_tag_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/reject")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Not needed." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("rejected");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "rejected", decision_note: "Not needed.", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 404 when request does not exist", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/999/reject")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when request is already decided", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 1, status: "rejected" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/cultural-tag-requests/1/reject")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+});

--- a/backend/src/__tests__/cultural-tags.test.ts
+++ b/backend/src/__tests__/cultural-tags.test.ts
@@ -1,11 +1,11 @@
 import request from "supertest";
 import app from "../index.js";
-import { supabase } from "../config/supabase.js";
+import { supabase, createUserClient } from "../config/supabase.js";
 
 jest.mock("../config/supabase.js", () => {
   const mockFrom = jest.fn();
   return {
-    supabase: { from: mockFrom },
+    supabase: { auth: { getUser: jest.fn() }, from: mockFrom },
     createUserClient: jest.fn(() => ({ from: mockFrom })),
   };
 });
@@ -348,5 +348,243 @@ describe("GET /discovery/recipes?culturalTagIds", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data.recipes).toBeDefined();
+  });
+});
+
+// ─── POST /cultural-tags/requests ────────────────────────────────────────────
+
+function mockAuthAsRole(role: "expert" | "cook" | "learner", profileId = "p1") {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "u1", email: "e@e.com" } },
+    error: null,
+  });
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { id: profileId, username: "u", role },
+          error: null,
+        }),
+      }),
+    }),
+  };
+}
+
+describe("POST /cultural-tags/requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).post("/cultural-tags/requests").send({ labelEn: "Test" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-expert caller", async () => {
+    const profileLookup = mockAuthAsRole("cook");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ labelEn: "Test" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when neither labelEn nor labelTr is provided", async () => {
+    const profileLookup = mockAuthAsRole("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ country: "Turkey" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a request with 201 when both labels are provided", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const insertedRow = {
+      id: 1,
+      label_en: "Holiday Meal",
+      label_tr: "Bayram Yemeği",
+      country: "Turkey",
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ labelEn: "Holiday Meal", labelTr: "Bayram Yemeği", country: "Turkey" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.labelEn).toBe("Holiday Meal");
+    expect(res.body.data.labelTr).toBe("Bayram Yemeği");
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("accepts labelTr-only and attempts DeepL translation for labelEn", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const insertedRow = {
+      id: 2,
+      label_en: "",
+      label_tr: "Sıra Gecesi",
+      country: "Turkey",
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ labelTr: "Sıra Gecesi", country: "Turkey" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("returns 500 on DB insert error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: null, error: { message: "DB error" } }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/cultural-tags/requests")
+      .set("Authorization", "Bearer t")
+      .send({ labelEn: "Test Tag" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /cultural-tags/requests/me ──────────────────────────────────────────
+
+describe("GET /cultural-tags/requests/me", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get("/cultural-tags/requests/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns own requests as an array", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    const rows = [
+      {
+        id: 1,
+        label_en: "Holiday Meal",
+        label_tr: "Bayram Yemeği",
+        country: "Turkey",
+        status: "pending",
+        decision_note: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+      },
+    ];
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests")
+        return chainable({ data: rows, error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/cultural-tags/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].labelEn).toBe("Holiday Meal");
+    expect(res.body.data[0].status).toBe("pending");
+    expect(res.body.data[0].decisionNote).toBeNull();
+  });
+
+  it("returns empty array when user has no requests", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests")
+        return chainable({ data: [], error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/cultural-tags/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "cultural_tag_requests")
+        return chainable({ data: null, error: { message: "fail" } });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/cultural-tags/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
   });
 });

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -546,6 +546,224 @@ router.delete("/comments/:id", async (req: Request, res: Response): Promise<void
   res.status(204).send();
 });
 
+// ─── Cultural Tag Requests ────────────────────────────────────────────────────
+
+const listCulturalTagRequestsQuery = z.object({
+  status: z.enum(["pending", "approved", "rejected"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+const approveTagRequestSchema = z.object({
+  labelEn:      z.string().trim().min(2).max(100).optional(),
+  labelTr:      z.string().trim().min(2).max(100).optional(),
+  country:      z.string().trim().min(1).max(100).optional(),
+  decisionNote: z.string().trim().max(2000).optional(),
+});
+
+function slugifyTagKey(text: string): string {
+  return text
+    .replace(/[İI]/g, "i").replace(/ı/g, "i")
+    .replace(/[şŞ]/g, "s").replace(/[çÇ]/g, "c")
+    .replace(/[ğĞ]/g, "g").replace(/[üÜ]/g, "u")
+    .replace(/[öÖ]/g, "o")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+/**
+ * GET /admin/cultural-tag-requests
+ * List cultural tag requests. Defaults to pending only.
+ */
+router.get("/cultural-tag-requests", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listCulturalTagRequestsQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid query."));
+    return;
+  }
+  const { status, page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("cultural_tag_requests")
+    .select(
+      `id, label_en, label_tr, country, status, decision_note, decided_by, created_at, decided_at,
+       requester:profiles!cultural_tag_requests_requested_by_fkey(id, username)`,
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  query = status ? query.eq("status", status) : query.eq("status", "pending");
+
+  const { data, error, count } = await query;
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse({
+    requests: (data ?? []).map((r: any) => ({
+      id:           r.id,
+      labelEn:      r.label_en,
+      labelTr:      r.label_tr,
+      country:      r.country ?? null,
+      status:       r.status,
+      decisionNote: r.decision_note ?? null,
+      decidedBy:    r.decided_by ?? null,
+      createdAt:    r.created_at,
+      decidedAt:    r.decided_at ?? null,
+      requester:    r.requester ? { id: r.requester.id, username: r.requester.username } : null,
+    })),
+    pagination: { page, limit, total: count ?? 0 },
+  }));
+});
+
+/**
+ * POST /admin/cultural-tag-requests/:id/approve
+ * Approves the request and inserts the tag into cultural_tags.
+ * Admin can override labelEn, labelTr, or country before approving.
+ * label_en is required (either from the original request or admin override)
+ * because it is used to generate the unique key.
+ */
+router.post(
+  "/cultural-tag-requests/:id/approve",
+  validate(approveTagRequestSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const id = req.params["id"] as string;
+    const idNum = Number.parseInt(id, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { labelEn, labelTr, country, decisionNote } = req.body as z.infer<typeof approveTagRequestSchema>;
+
+    // 1. Load the request
+    const { data: tagRequest, error: loadErr } = await supabase
+      .from("cultural_tag_requests")
+      .select("id, label_en, label_tr, country, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!tagRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Cultural tag request not found.")); return; }
+    if ((tagRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(tagRequest as any).status}.`));
+      return;
+    }
+
+    // 2. Resolve final labels (admin override wins)
+    const finalLabelEn = labelEn ?? (tagRequest as any).label_en;
+    const finalLabelTr = labelTr ?? (tagRequest as any).label_tr;
+    const finalCountry = country !== undefined ? country : ((tagRequest as any).country ?? null);
+
+    if (!finalLabelEn) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "labelEn is required to generate the tag key. Provide it in the request body."));
+      return;
+    }
+
+    // 3. Generate key and check uniqueness
+    const key = slugifyTagKey(finalLabelEn);
+    const { data: existing } = await supabase
+      .from("cultural_tags")
+      .select("id")
+      .eq("key", key)
+      .maybeSingle();
+
+    if (existing) {
+      res.status(409).json(errorResponse("CONFLICT", `A cultural tag with key '${key}' already exists.`));
+      return;
+    }
+
+    // 4. Insert into cultural_tags
+    const { data: newTag, error: insertErr } = await adminClient
+      .from("cultural_tags")
+      .insert({ key, label_en: finalLabelEn, label_tr: finalLabelTr, country: finalCountry })
+      .select("id, key, label_en, label_tr, country")
+      .single();
+
+    if (insertErr) { res.status(500).json(errorResponse("DB_ERROR", insertErr.message)); return; }
+
+    // 5. Mark request approved
+    const decidedAt = new Date().toISOString();
+    const { error: updateErr } = await adminClient
+      .from("cultural_tag_requests")
+      .update({ status: "approved", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (updateErr) { res.status(500).json(errorResponse("DB_ERROR", updateErr.message)); return; }
+
+    res.status(200).json(successResponse({
+      requestId:  idNum,
+      status:     "approved",
+      createdTag: {
+        id:      (newTag as any).id,
+        key:     (newTag as any).key,
+        labelEn: (newTag as any).label_en,
+        labelTr: (newTag as any).label_tr,
+        country: (newTag as any).country ?? null,
+      },
+      decisionNote: decisionNote ?? null,
+      decidedAt,
+    }));
+  }
+);
+
+/**
+ * POST /admin/cultural-tag-requests/:id/reject
+ * Rejects the request. No tag is created.
+ */
+router.post(
+  "/cultural-tag-requests/:id/reject",
+  validate(decisionSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const id = req.params["id"] as string;
+    const idNum = Number.parseInt(id, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { decisionNote } = req.body as z.infer<typeof decisionSchema>;
+
+    const { data: tagRequest, error: loadErr } = await supabase
+      .from("cultural_tag_requests")
+      .select("id, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!tagRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Cultural tag request not found.")); return; }
+    if ((tagRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(tagRequest as any).status}.`));
+      return;
+    }
+
+    const decidedAt = new Date().toISOString();
+    const { error } = await adminClient
+      .from("cultural_tag_requests")
+      .update({ status: "rejected", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (error) { res.status(500).json(errorResponse("DB_ERROR", error.message)); return; }
+
+    res.status(200).json(successResponse({ requestId: idNum, status: "rejected", decisionNote: decisionNote ?? null, decidedAt }));
+  }
+);
+
 // Lint hint: silence unused-import warnings in environments where UserRole is
 // shaken out by the bundler.
 export type _Unused = UserRole;

--- a/backend/src/routes/cultural-tags.ts
+++ b/backend/src/routes/cultural-tags.ts
@@ -1,10 +1,46 @@
 import { Router } from "express";
-import { supabase } from "../config/supabase.js";
+import { z } from "zod";
+import { Translator, type TextResult } from "deepl-node";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth, requireRole } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest } from "../types/index.js";
 import { successResponse, errorResponse } from "../utils/response.js";
 
 const router = Router();
 
-// ─── GET /cultural-tags ──────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// Translates a single label via DeepL. Returns null if key is missing or call fails.
+async function translateLabel(text: string, target: "en-US" | "tr"): Promise<string | null> {
+  const apiKey = process.env["DEEPL_API_KEY"];
+  if (!apiKey) return null;
+  try {
+    const translator = new Translator(apiKey);
+    const result = (await translator.translateText(text, null, target)) as TextResult;
+    return result.text;
+  } catch {
+    return null;
+  }
+}
+
+// Produces a URL-safe key from a label, handling Turkish characters.
+function slugify(text: string): string {
+  return text
+    .replace(/[İI]/g, "i").replace(/ı/g, "i")
+    .replace(/[şŞ]/g, "s").replace(/[çÇ]/g, "c")
+    .replace(/[ğĞ]/g, "g").replace(/[üÜ]/g, "u")
+    .replace(/[öÖ]/g, "o")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+export { slugify };
+
+// ─── GET /cultural-tags ───────────────────────────────────────────────────────
 // Returns curated cultural-event tags.
 // Query params:
 //   country — when provided, returns only global tags (country IS NULL) plus
@@ -43,6 +79,98 @@ router.get("/", async (req, res) => {
   }));
 
   return res.status(200).json(successResponse(tags));
+});
+
+// ─── POST /cultural-tags/requests ─────────────────────────────────────────────
+// Expert submits a new cultural tag for admin review.
+// At least one of labelEn or labelTr must be provided.
+// The missing language is auto-translated via DeepL (falls back to null if unavailable).
+
+const tagRequestSchema = z.object({
+  labelEn: z.string().trim().min(2).max(100).optional(),
+  labelTr: z.string().trim().min(2).max(100).optional(),
+  country: z.string().trim().min(1).max(100).optional(),
+}).refine((d) => d.labelEn || d.labelTr, {
+  message: "At least one of labelEn or labelTr is required.",
+});
+
+router.post(
+  "/requests",
+  requireAuth,
+  requireRole("expert"),
+  validate(tagRequestSchema),
+  async (req, res): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const { labelEn, labelTr, country } = req.body as z.infer<typeof tagRequestSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    let resolvedEn = labelEn ?? null;
+    let resolvedTr = labelTr ?? null;
+
+    // Translate the missing language via DeepL
+    if (resolvedEn && !resolvedTr) {
+      resolvedTr = await translateLabel(resolvedEn, "tr");
+    } else if (resolvedTr && !resolvedEn) {
+      resolvedEn = await translateLabel(resolvedTr, "en-US");
+    }
+
+    const { data, error } = await userClient
+      .from("cultural_tag_requests")
+      .insert({
+        requested_by: user.profileId,
+        label_en:     resolvedEn,
+        label_tr:     resolvedTr,
+        country:      country ?? null,
+        status:       "pending",
+      })
+      .select("id, label_en, label_tr, country, status, created_at")
+      .single();
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res.status(201).json(successResponse({
+      id:        (data as any).id,
+      labelEn:   (data as any).label_en,
+      labelTr:   (data as any).label_tr,
+      country:   (data as any).country ?? null,
+      status:    (data as any).status,
+      createdAt: (data as any).created_at,
+    }));
+  }
+);
+
+// ─── GET /cultural-tags/requests/me ──────────────────────────────────────────
+// Returns the authenticated expert's own tag requests.
+
+router.get("/requests/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+
+  const { data, error } = await supabase
+    .from("cultural_tag_requests")
+    .select("id, label_en, label_tr, country, status, decision_note, created_at, decided_at")
+    .eq("requested_by", user.profileId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse(
+    (data ?? []).map((r: any) => ({
+      id:           r.id,
+      labelEn:      r.label_en,
+      labelTr:      r.label_tr,
+      country:      r.country ?? null,
+      status:       r.status,
+      decisionNote: r.decision_note ?? null,
+      createdAt:    r.created_at,
+      decidedAt:    r.decided_at ?? null,
+    }))
+  ));
 });
 
 export default router;

--- a/frontend/src/__tests__/integration/admin-cultural-tags.test.tsx
+++ b/frontend/src/__tests__/integration/admin-cultural-tags.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '@/i18n/i18n'
+import { CulturalTagRequestRow } from '@/pages/Admin/Parts/CulturalTagRequestRow'
+import { ApproveCulturalTagDialog } from '@/pages/Admin/Parts/ApproveCulturalTagDialog'
+import type { CulturalTagRequest } from '@/services/types/admin'
+
+const pendingRequest: CulturalTagRequest = {
+  id: 1,
+  labelEn: 'Holiday Meal',
+  labelTr: 'Bayram Yemeği',
+  country: 'Turkey',
+  status: 'pending',
+  decisionNote: null,
+  decidedBy: null,
+  createdAt: '2026-05-10T00:00:00Z',
+  decidedAt: null,
+  requester: { id: 'p1', username: 'expert_user' },
+}
+
+const approvedRequest: CulturalTagRequest = {
+  ...pendingRequest,
+  id: 2,
+  status: 'approved',
+  decisionNote: 'Great tag.',
+  decidedAt: '2026-05-11T00:00:00Z',
+}
+
+function wrap(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+// ─── CulturalTagRequestRow ────────────────────────────────────────────────────
+
+describe('CulturalTagRequestRow', () => {
+  it('renders requester username, labels, and country', () => {
+    wrap(
+      <CulturalTagRequestRow
+        request={pendingRequest}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('expert_user')).toBeInTheDocument()
+    expect(screen.getByText('Holiday Meal')).toBeInTheDocument()
+    expect(screen.getByText('Bayram Yemeği')).toBeInTheDocument()
+    expect(screen.getByText('Turkey')).toBeInTheDocument()
+  })
+
+  it('shows Approve and Reject buttons for pending requests', () => {
+    wrap(
+      <CulturalTagRequestRow
+        request={pendingRequest}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
+  })
+
+  it('hides action buttons for non-pending requests', () => {
+    wrap(
+      <CulturalTagRequestRow
+        request={approvedRequest}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /reject/i })).not.toBeInTheDocument()
+  })
+
+  it('shows decision note for decided requests', () => {
+    wrap(
+      <CulturalTagRequestRow
+        request={approvedRequest}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Great tag.')).toBeInTheDocument()
+  })
+
+  it('calls onApprove when Approve button is clicked', async () => {
+    const onApprove = vi.fn()
+    const user = userEvent.setup()
+
+    wrap(
+      <CulturalTagRequestRow
+        request={pendingRequest}
+        onApprove={onApprove}
+        onReject={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /approve/i }))
+    expect(onApprove).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onReject when Reject button is clicked', async () => {
+    const onReject = vi.fn()
+    const user = userEvent.setup()
+
+    wrap(
+      <CulturalTagRequestRow
+        request={pendingRequest}
+        onApprove={vi.fn()}
+        onReject={onReject}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /reject/i }))
+    expect(onReject).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── ApproveCulturalTagDialog ─────────────────────────────────────────────────
+
+describe('ApproveCulturalTagDialog', () => {
+  it('pre-fills labelEn, labelTr, and country from the request', () => {
+    wrap(
+      <ApproveCulturalTagDialog
+        request={pendingRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue('Holiday Meal')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Bayram Yemeği')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Turkey')).toBeInTheDocument()
+  })
+
+  it('disables the Approve button when labelEn is cleared', async () => {
+    const user = userEvent.setup()
+
+    wrap(
+      <ApproveCulturalTagDialog
+        request={pendingRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    const labelEnInput = screen.getByDisplayValue('Holiday Meal')
+    await user.clear(labelEnInput)
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeDisabled()
+  })
+
+  it('calls onSubmit with edited values when Approve is clicked', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+
+    wrap(
+      <ApproveCulturalTagDialog
+        request={pendingRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const labelEnInput = screen.getByDisplayValue('Holiday Meal')
+    await user.clear(labelEnInput)
+    await user.type(labelEnInput, 'Festival Meal')
+
+    await user.click(screen.getByRole('button', { name: /approve/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ labelEn: 'Festival Meal' })
+    )
+  })
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const onCancel = vi.fn()
+    const user = userEvent.setup()
+
+    wrap(
+      <ApproveCulturalTagDialog
+        request={pendingRequest}
+        busy={false}
+        onCancel={onCancel}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables both buttons when busy', () => {
+    wrap(
+      <ApproveCulturalTagDialog
+        request={pendingRequest}
+        busy={true}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    const buttons = screen.getAllByRole('button')
+    buttons.forEach((btn) => expect(btn).toBeDisabled())
+  })
+})

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -458,7 +458,8 @@
     "tabsAria": "Admin sections",
     "tabs": {
       "requests": "Expert Requests",
-      "users": "Users"
+      "users": "Users",
+      "culturalTags": "Cultural Tag Requests"
     },
     "refresh": "Refresh",
     "cancel": "Cancel",
@@ -486,7 +487,7 @@
       "rejectTitle": "Reject {{username}}'s expert request?",
       "approveConfirm": "Approve & promote",
       "rejectConfirm": "Reject request",
-      "decisionNoteLabel": "Decision note (visible to the user)",
+      "decisionNoteLabel": "Decision note",
       "decisionNotePlaceholder": "Optional — leave a short message for the applicant.",
       "decisionNoteOptional": "optional",
       "approvedToast": "{{username}} promoted to expert.",
@@ -515,10 +516,37 @@
       "updatedToast": "{{username}} updated.",
       "deletedToast": "{{username}} deleted."
     },
+    "culturalTags": {
+      "statusAria": "Filter by status",
+      "empty": "No requests in this state.",
+      "unknownRequester": "(unknown requester)",
+      "labelEn": "English label",
+      "labelTr": "Turkish label",
+      "country": "Country",
+      "global": "(global)",
+      "decisionAt": "Decision date",
+      "decisionNote": "Admin note",
+      "approve": "Approve",
+      "reject": "Reject",
+      "approveTitle": "Approve cultural tag request",
+      "rejectTitle": "Reject this tag request?",
+      "approveConfirm": "Approve & create tag",
+      "rejectConfirm": "Reject request",
+      "labelEnLabel": "English label (used to generate the tag key)",
+      "labelTrLabel": "Turkish label",
+      "countryLabel": "Country (leave blank for global)",
+      "decisionNoteLabel": "Decision note",
+      "decisionNotePlaceholder": "Optional — leave a short message.",
+      "decisionNoteOptional": "optional",
+      "approvedToast": "Cultural tag '{{labelEn}}' created and approved.",
+      "rejectedToast": "Tag request rejected."
+    },
     "errors": {
       "loadRequests": "Could not load requests.",
       "loadUsers": "Could not load users.",
+      "loadCulturalTagRequests": "Could not load cultural tag requests.",
       "decisionFailed": "Decision could not be saved.",
+      "tagDecisionFailed": "Tag decision could not be saved.",
       "updateFailed": "Could not update user.",
       "deleteFailed": "Could not delete user."
     }

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -458,7 +458,8 @@
     "tabsAria": "Yönetici bölümleri",
     "tabs": {
       "requests": "Uzman Başvuruları",
-      "users": "Kullanıcılar"
+      "users": "Kullanıcılar",
+      "culturalTags": "Kültürel Etiket Başvuruları"
     },
     "refresh": "Yenile",
     "cancel": "İptal",
@@ -486,7 +487,7 @@
       "rejectTitle": "{{username}} kişisinin uzman başvurusu reddedilsin mi?",
       "approveConfirm": "Onayla ve yükselt",
       "rejectConfirm": "Başvuruyu reddet",
-      "decisionNoteLabel": "Karar notu (kullanıcıya görünür)",
+      "decisionNoteLabel": "Karar notu",
       "decisionNotePlaceholder": "İsteğe bağlı — başvuran için kısa bir mesaj.",
       "decisionNoteOptional": "isteğe bağlı",
       "approvedToast": "{{username}} uzman olarak yükseltildi.",
@@ -515,10 +516,37 @@
       "updatedToast": "{{username}} güncellendi.",
       "deletedToast": "{{username}} silindi."
     },
+    "culturalTags": {
+      "statusAria": "Duruma göre filtrele",
+      "empty": "Bu durumda başvuru yok.",
+      "unknownRequester": "(bilinmeyen başvuran)",
+      "labelEn": "İngilizce etiket",
+      "labelTr": "Türkçe etiket",
+      "country": "Ülke",
+      "global": "(küresel)",
+      "decisionAt": "Karar tarihi",
+      "decisionNote": "Yönetici notu",
+      "approve": "Onayla",
+      "reject": "Reddet",
+      "approveTitle": "Kültürel etiket başvurusunu onayla",
+      "rejectTitle": "Bu etiket başvurusu reddedilsin mi?",
+      "approveConfirm": "Onayla ve etiket oluştur",
+      "rejectConfirm": "Başvuruyu reddet",
+      "labelEnLabel": "İngilizce etiket (anahtar oluşturmak için kullanılır)",
+      "labelTrLabel": "Türkçe etiket",
+      "countryLabel": "Ülke (küresel için boş bırakın)",
+      "decisionNoteLabel": "Karar notu",
+      "decisionNotePlaceholder": "İsteğe bağlı — kısa bir mesaj.",
+      "decisionNoteOptional": "isteğe bağlı",
+      "approvedToast": "'{{labelEn}}' kültürel etiketi oluşturuldu ve onaylandı.",
+      "rejectedToast": "Etiket başvurusu reddedildi."
+    },
     "errors": {
       "loadRequests": "Başvurular yüklenemedi.",
       "loadUsers": "Kullanıcılar yüklenemedi.",
+      "loadCulturalTagRequests": "Kültürel etiket başvuruları yüklenemedi.",
       "decisionFailed": "Karar kaydedilemedi.",
+      "tagDecisionFailed": "Etiket kararı kaydedilemedi.",
       "updateFailed": "Kullanıcı güncellenemedi.",
       "deleteFailed": "Kullanıcı silinemedi."
     }

--- a/frontend/src/pages/Admin/AdminPage.tsx
+++ b/frontend/src/pages/Admin/AdminPage.tsx
@@ -14,9 +14,12 @@ import { ExpertRequestRow } from '@/pages/Admin/Parts/ExpertRequestRow'
 import { UserRow } from '@/pages/Admin/Parts/UserRow'
 import { DecisionDialog } from '@/pages/Admin/Parts/DecisionDialog'
 import { EditUserDialog } from '@/pages/Admin/Parts/EditUserDialog'
+import { CulturalTagRequestRow } from '@/pages/Admin/Parts/CulturalTagRequestRow'
+import { ApproveCulturalTagDialog } from '@/pages/Admin/Parts/ApproveCulturalTagDialog'
+import type { CulturalTagRequest, CulturalTagRequestStatus, ApproveCulturalTagPayload } from '@/services/types/admin'
 import './AdminPage.css'
 
-type Tab = 'requests' | 'users'
+type Tab = 'requests' | 'users' | 'culturalTags'
 
 type Toast = { id: number; kind: 'success' | 'error'; message: string }
 
@@ -41,6 +44,7 @@ function extractError(err: unknown, fallback: string): string {
 }
 
 const STATUSES: ExpertRequestStatus[] = ['pending', 'approved', 'rejected']
+const TAG_STATUSES: CulturalTagRequestStatus[] = ['pending', 'approved', 'rejected']
 const ROLES_FOR_FILTER: UserRole[] = ['learner', 'cook', 'expert', 'admin']
 const PAGE_LIMIT = 20
 
@@ -190,9 +194,77 @@ export function AdminPage() {
     }
   }
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // Cultural Tag Requests tab
+  // ─────────────────────────────────────────────────────────────────────────
+  const [tagStatus, setTagStatus] = useState<CulturalTagRequestStatus>('pending')
+  const [tagPage, setTagPage] = useState(1)
+  const [tagRequests, setTagRequests] = useState<Pending<CulturalTagRequest[]>>(initial())
+  const [tagTotal, setTagTotal] = useState(0)
+
+  const [approvingTag, setApprovingTag] = useState<CulturalTagRequest | null>(null)
+  const [rejectingTag, setRejectingTag] = useState<CulturalTagRequest | null>(null)
+  const [tagDecisionBusy, setTagDecisionBusy] = useState(false)
+
+  const reloadTagRequests = useCallback(async () => {
+    setTagRequests((s) => ({ ...s, status: 'loading', error: null }))
+    try {
+      const result = await adminService.listCulturalTagRequests({
+        status: tagStatus,
+        page: tagPage,
+        limit: PAGE_LIMIT,
+      })
+      setTagRequests({ status: 'succeeded', data: result.requests, error: null })
+      setTagTotal(result.pagination.total)
+    } catch (err) {
+      setTagRequests({
+        status: 'failed',
+        data: null,
+        error: extractError(err, t('admin.errors.loadCulturalTagRequests')),
+      })
+    }
+  }, [tagStatus, tagPage, t])
+
+  useEffect(() => {
+    if (tab === 'culturalTags') {
+      void reloadTagRequests()
+    }
+  }, [tab, reloadTagRequests])
+
+  async function handleApproveTag(payload: ApproveCulturalTagPayload) {
+    if (!approvingTag) return
+    setTagDecisionBusy(true)
+    try {
+      await adminService.approveCulturalTagRequest(approvingTag.id, payload)
+      pushToast('success', t('admin.culturalTags.approvedToast', { labelEn: payload.labelEn ?? approvingTag.labelEn ?? '' }))
+      setApprovingTag(null)
+      await reloadTagRequests()
+    } catch (err) {
+      pushToast('error', extractError(err, t('admin.errors.tagDecisionFailed')))
+    } finally {
+      setTagDecisionBusy(false)
+    }
+  }
+
+  async function handleRejectTag(decisionNote: string) {
+    if (!rejectingTag) return
+    setTagDecisionBusy(true)
+    try {
+      await adminService.rejectCulturalTagRequest(rejectingTag.id, { decisionNote: decisionNote || undefined })
+      pushToast('success', t('admin.culturalTags.rejectedToast'))
+      setRejectingTag(null)
+      await reloadTagRequests()
+    } catch (err) {
+      pushToast('error', extractError(err, t('admin.errors.tagDecisionFailed')))
+    } finally {
+      setTagDecisionBusy(false)
+    }
+  }
+
   // Pagination labels are tiny enough to compute inline.
   const requestTotalPages = Math.max(1, Math.ceil(requestTotal / PAGE_LIMIT))
   const userTotalPages = Math.max(1, Math.ceil(userTotal / PAGE_LIMIT))
+  const tagTotalPages = Math.max(1, Math.ceil(tagTotal / PAGE_LIMIT))
 
   const isApproveAction = decisionFor?.action === 'approve'
   const decisionTitle = useMemo(() => {
@@ -230,6 +302,15 @@ export function AdminPage() {
           onClick={() => setTab('users')}
         >
           {t('admin.tabs.users')}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'culturalTags'}
+          className={`admin-tab ${tab === 'culturalTags' ? 'admin-tab--active' : ''}`}
+          onClick={() => setTab('culturalTags')}
+        >
+          {t('admin.tabs.culturalTags')}
         </button>
       </nav>
 
@@ -375,6 +456,72 @@ export function AdminPage() {
         </section>
       )}
 
+      {tab === 'culturalTags' && (
+        <section className="admin-section" aria-labelledby="admin-cultural-tags-h">
+          <h2 id="admin-cultural-tags-h" className="sr-only">
+            {t('admin.tabs.culturalTags')}
+          </h2>
+
+          <div className="admin-toolbar">
+            <div className="admin-chip-row" role="tablist" aria-label={t('admin.culturalTags.statusAria')}>
+              {TAG_STATUSES.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  role="tab"
+                  aria-selected={tagStatus === s}
+                  className={`admin-chip ${tagStatus === s ? 'admin-chip--active' : ''}`}
+                  onClick={() => {
+                    setTagStatus(s)
+                    setTagPage(1)
+                  }}
+                >
+                  {t(`admin.requests.status.${s}`)}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="admin-btn admin-btn--ghost"
+              onClick={() => void reloadTagRequests()}
+              disabled={tagRequests.status === 'loading'}
+            >
+              {t('admin.refresh')}
+            </button>
+          </div>
+
+          {tagRequests.status === 'loading' && (
+            <div className="admin-empty"><span className="ui-spinner" /></div>
+          )}
+          {tagRequests.status === 'failed' && (
+            <div className="admin-empty admin-empty--error">{tagRequests.error}</div>
+          )}
+          {tagRequests.status === 'succeeded' && tagRequests.data?.length === 0 && (
+            <div className="admin-empty">{t('admin.culturalTags.empty')}</div>
+          )}
+          {tagRequests.status === 'succeeded' && tagRequests.data && tagRequests.data.length > 0 && (
+            <ul className="admin-list">
+              {tagRequests.data.map((r) => (
+                <CulturalTagRequestRow
+                  key={r.id}
+                  request={r}
+                  onApprove={() => setApprovingTag(r)}
+                  onReject={() => setRejectingTag(r)}
+                />
+              ))}
+            </ul>
+          )}
+
+          <Pagination
+            page={tagPage}
+            totalPages={tagTotalPages}
+            onPrev={() => setTagPage((p) => Math.max(1, p - 1))}
+            onNext={() => setTagPage((p) => Math.min(tagTotalPages, p + 1))}
+            label={t('admin.pagination.label', { page: tagPage, total: tagTotalPages })}
+          />
+        </section>
+      )}
+
       {/* ── Modals ─────────────────────────────────────────────────────────── */}
       {decisionFor && (
         <DecisionDialog
@@ -388,6 +535,26 @@ export function AdminPage() {
           busy={decisionBusy}
           onCancel={() => (decisionBusy ? null : setDecisionFor(null))}
           onSubmit={handleDecide}
+        />
+      )}
+
+      {approvingTag && (
+        <ApproveCulturalTagDialog
+          request={approvingTag}
+          busy={tagDecisionBusy}
+          onCancel={() => (tagDecisionBusy ? null : setApprovingTag(null))}
+          onSubmit={(payload) => void handleApproveTag(payload)}
+        />
+      )}
+
+      {rejectingTag && (
+        <DecisionDialog
+          title={t('admin.culturalTags.rejectTitle')}
+          confirmLabel={t('admin.culturalTags.rejectConfirm')}
+          confirmVariant="danger"
+          busy={tagDecisionBusy}
+          onCancel={() => (tagDecisionBusy ? null : setRejectingTag(null))}
+          onSubmit={(note) => void handleRejectTag(note)}
         />
       )}
 

--- a/frontend/src/pages/Admin/Parts/ApproveCulturalTagDialog.tsx
+++ b/frontend/src/pages/Admin/Parts/ApproveCulturalTagDialog.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ApproveCulturalTagPayload, CulturalTagRequest } from '@/services/types/admin'
+
+interface Props {
+  request: CulturalTagRequest
+  busy: boolean
+  onCancel: () => void
+  onSubmit: (payload: ApproveCulturalTagPayload) => void
+}
+
+export function ApproveCulturalTagDialog({ request, busy, onCancel, onSubmit }: Props) {
+  const { t } = useTranslation('common')
+  const titleId = useId()
+
+  const [labelEn, setLabelEn] = useState(request.labelEn ?? '')
+  const [labelTr, setLabelTr] = useState(request.labelTr ?? '')
+  const [country, setCountry] = useState(request.country ?? '')
+  const [note, setNote] = useState('')
+
+  const firstInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    firstInputRef.current?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !busy) onCancel()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = prevOverflow
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [busy, onCancel])
+
+  function handleSubmit() {
+    const payload: ApproveCulturalTagPayload = {}
+    const en = labelEn.trim()
+    const tr = labelTr.trim()
+    const ct = country.trim()
+    const n = note.trim()
+    if (en) payload.labelEn = en
+    if (tr) payload.labelTr = tr
+    if (ct) payload.country = ct
+    if (n) payload.decisionNote = n
+    onSubmit(payload)
+  }
+
+  const labelEnId = useId()
+  const labelTrId = useId()
+  const countryId = useId()
+  const noteId = useId()
+
+  return (
+    <div className="admin-modal" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+      <div className="admin-modal__backdrop" onClick={() => (busy ? null : onCancel())} />
+      <div className="admin-modal__panel" role="document">
+        <h2 id={titleId} className="admin-modal__title">
+          {t('admin.culturalTags.approveTitle')}
+        </h2>
+
+        <label htmlFor={labelEnId} className="admin-field-label">
+          {t('admin.culturalTags.labelEnLabel')}
+        </label>
+        <input
+          id={labelEnId}
+          ref={firstInputRef}
+          type="text"
+          className="admin-input"
+          value={labelEn}
+          onChange={(e) => setLabelEn(e.target.value)}
+          maxLength={100}
+          disabled={busy}
+          required
+        />
+
+        <label htmlFor={labelTrId} className="admin-field-label" style={{ marginTop: '0.75rem' }}>
+          {t('admin.culturalTags.labelTrLabel')}
+        </label>
+        <input
+          id={labelTrId}
+          type="text"
+          className="admin-input"
+          value={labelTr}
+          onChange={(e) => setLabelTr(e.target.value)}
+          maxLength={100}
+          disabled={busy}
+        />
+
+        <label htmlFor={countryId} className="admin-field-label" style={{ marginTop: '0.75rem' }}>
+          {t('admin.culturalTags.countryLabel')}
+        </label>
+        <input
+          id={countryId}
+          type="text"
+          className="admin-input"
+          value={country}
+          onChange={(e) => setCountry(e.target.value)}
+          maxLength={100}
+          disabled={busy}
+          placeholder={t('admin.culturalTags.global')}
+        />
+
+        <label htmlFor={noteId} className="admin-field-label" style={{ marginTop: '0.75rem' }}>
+          {t('admin.culturalTags.decisionNoteLabel')}
+        </label>
+        <textarea
+          id={noteId}
+          className="admin-textarea"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder={t('admin.culturalTags.decisionNotePlaceholder')}
+          rows={3}
+          maxLength={2000}
+          disabled={busy}
+        />
+        <span className="admin-field-hint">
+          {note.length}/2000 — {t('admin.culturalTags.decisionNoteOptional')}
+        </span>
+
+        <div className="admin-modal__actions">
+          <button
+            type="button"
+            className="admin-btn admin-btn--ghost"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            {t('admin.cancel')}
+          </button>
+          <button
+            type="button"
+            className="admin-btn admin-btn--primary"
+            onClick={handleSubmit}
+            disabled={busy || !labelEn.trim()}
+            aria-busy={busy}
+          >
+            {busy ? <span className="ui-spinner" aria-hidden /> : t('admin.culturalTags.approveConfirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin/Parts/CulturalTagRequestRow.tsx
+++ b/frontend/src/pages/Admin/Parts/CulturalTagRequestRow.tsx
@@ -1,0 +1,81 @@
+import { useTranslation } from 'react-i18next'
+import type { CulturalTagRequest } from '@/services/types/admin'
+
+interface Props {
+  request: CulturalTagRequest
+  onApprove: () => void
+  onReject: () => void
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+export function CulturalTagRequestRow({ request, onApprove, onReject }: Props) {
+  const { t } = useTranslation('common')
+  const isPending = request.status === 'pending'
+
+  return (
+    <li className="admin-card">
+      <div className="admin-card__head">
+        <div className="admin-card__heading">
+          <strong className="admin-card__title">
+            {request.requester?.username ?? t('admin.culturalTags.unknownRequester')}
+          </strong>
+          <span
+            className={`admin-badge admin-badge--${request.status}`}
+            aria-label={t(`admin.requests.status.${request.status}`)}
+          >
+            {t(`admin.requests.status.${request.status}`)}
+          </span>
+        </div>
+        <span className="admin-card__time">{formatDate(request.createdAt)}</span>
+      </div>
+
+      <dl className="admin-card__body">
+        <div>
+          <dt>{t('admin.culturalTags.labelEn')}</dt>
+          <dd>{request.labelEn ?? '—'}</dd>
+        </div>
+        <div>
+          <dt>{t('admin.culturalTags.labelTr')}</dt>
+          <dd>{request.labelTr ?? '—'}</dd>
+        </div>
+        <div>
+          <dt>{t('admin.culturalTags.country')}</dt>
+          <dd>{request.country ?? <em>{t('admin.culturalTags.global')}</em>}</dd>
+        </div>
+        {!isPending && (
+          <>
+            <div>
+              <dt>{t('admin.culturalTags.decisionAt')}</dt>
+              <dd>{formatDate(request.decidedAt)}</dd>
+            </div>
+            {request.decisionNote && (
+              <div>
+                <dt>{t('admin.culturalTags.decisionNote')}</dt>
+                <dd className="admin-card__reason">{request.decisionNote}</dd>
+              </div>
+            )}
+          </>
+        )}
+      </dl>
+
+      {isPending && (
+        <div className="admin-card__actions">
+          <button type="button" className="admin-btn admin-btn--primary" onClick={onApprove}>
+            {t('admin.culturalTags.approve')}
+          </button>
+          <button type="button" className="admin-btn admin-btn--danger" onClick={onReject}>
+            {t('admin.culturalTags.reject')}
+          </button>
+        </div>
+      )}
+    </li>
+  )
+}

--- a/frontend/src/services/admin-service.ts
+++ b/frontend/src/services/admin-service.ts
@@ -3,6 +3,10 @@ import type {
   AdminUser,
   AdminUserList,
   AdminUserUpdate,
+  ApproveCulturalTagPayload,
+  CulturalTagRequest,
+  CulturalTagRequestList,
+  CulturalTagRequestStatus,
   ExpertRequest,
   ExpertRequestList,
   ExpertRequestStatus,
@@ -84,6 +88,40 @@ export const adminService = {
 
   async deleteUser(id: string): Promise<void> {
     await httpClient.delete(`/admin/users/${id}`)
+  },
+
+  // ── Cultural tag requests ──────────────────────────────────────────────────
+
+  async listCulturalTagRequests(
+    params: { status?: CulturalTagRequestStatus; page?: number; limit?: number } = {}
+  ): Promise<CulturalTagRequestList> {
+    const { data } = await httpClient.get<Envelope<CulturalTagRequestList>>(
+      '/admin/cultural-tag-requests',
+      { params: compact(params) }
+    )
+    return data.data
+  },
+
+  async approveCulturalTagRequest(
+    id: number,
+    payload: ApproveCulturalTagPayload = {}
+  ): Promise<CulturalTagRequest> {
+    const { data } = await httpClient.post<Envelope<CulturalTagRequest>>(
+      `/admin/cultural-tag-requests/${id}/approve`,
+      payload
+    )
+    return data.data
+  },
+
+  async rejectCulturalTagRequest(
+    id: number,
+    payload: { decisionNote?: string } = {}
+  ): Promise<CulturalTagRequest> {
+    const { data } = await httpClient.post<Envelope<CulturalTagRequest>>(
+      `/admin/cultural-tag-requests/${id}/reject`,
+      payload
+    )
+    return data.data
   },
 
   // ── Recipes / Comments (moderation) ────────────────────────────────────────

--- a/frontend/src/services/types/admin.ts
+++ b/frontend/src/services/types/admin.ts
@@ -56,3 +56,32 @@ export interface AdminUserUpdate {
   region?: string
   preferred_language?: string
 }
+
+// ── Cultural tag requests ──────────────────────────────────────────────────────
+
+export type CulturalTagRequestStatus = 'pending' | 'approved' | 'rejected'
+
+export interface CulturalTagRequest {
+  id: number
+  labelEn: string | null
+  labelTr: string | null
+  country: string | null
+  status: CulturalTagRequestStatus
+  decisionNote: string | null
+  decidedBy: string | null
+  createdAt: string
+  decidedAt: string | null
+  requester: { id: string; username: string } | null
+}
+
+export interface CulturalTagRequestList {
+  requests: CulturalTagRequest[]
+  pagination: { page: number; limit: number; total: number }
+}
+
+export interface ApproveCulturalTagPayload {
+  labelEn?: string
+  labelTr?: string
+  country?: string
+  decisionNote?: string
+}


### PR DESCRIPTION
This pull request introduces a new system for handling user-submitted cultural tag requests, including database schema changes, API endpoints for both users and admins, and comprehensive tests. The main focus is to allow "expert" users to request new cultural tags, and for admins to review, approve, or reject these requests. The changes are organized below by theme.

**Database and Security Changes**

- Added a new `cultural_tag_requests` table to store user-submitted cultural tag requests, including fields for labels, country, status, decision notes, and references to the requesting and deciding users. Indexes and row-level security policies were also established to support efficient queries and secure access.

**API Endpoint and Business Logic**

- Implemented a new POST `/cultural-tags/requests` endpoint allowing authenticated "expert" users to submit cultural tag requests, with validation for required fields and support for optional DeepL translation when only a Turkish label is provided.
- Added GET `/cultural-tags/requests/me` endpoint so users can view their own submitted requests.
- Created admin endpoints for managing requests: GET `/admin/cultural-tag-requests` (list pending requests), POST `/admin/cultural-tag-requests/:id/approve` (approve and create tag), and POST `/admin/cultural-tag-requests/:id/reject` (reject request with note). These endpoints handle various error scenarios (e.g., request not found, already decided, key conflicts, validation errors).

**Testing and Mocking**

- Added extensive tests for all new endpoints, covering success and error cases for both user and admin flows, including authentication, authorization, input validation, and database error handling.
- Updated mocks in `cultural-tags.test.ts` to support new authentication and database access patterns.

closes #505 
closes #507  