### PR TITLE
[Frontend/Fix] Fix allergen filter and add allergen step to recipe creation 

### DIFF
--- a/frontend/src/__tests__/integration/allergen-discovery-filter.test.ts
+++ b/frontend/src/__tests__/integration/allergen-discovery-filter.test.ts
@@ -1,0 +1,86 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { discoveryService } from '@/services/discovery-service'
+
+const BASE = 'http://localhost/api'
+
+describe('discoveryService allergen normalization', () => {
+  it('normalizes allergens array on recipe summaries from discovery', async () => {
+    server.use(
+      http.get(`${BASE}/discovery/recipes`, () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            recipes: [
+              {
+                id: 1,
+                title: 'Test Recipe',
+                type: 'community',
+                profile: { username: 'chef1' },
+                dish_variety: null,
+                allergens: [
+                  { id: 1, name: 'Gluten' },
+                  { id: 2, name: 'Dairy' },
+                ],
+              },
+            ],
+            pagination: { page: 1, limit: 20, total: 1 },
+          },
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await discoveryService.getRecipeResults()
+
+    expect(result.recipes[0].allergens).toHaveLength(2)
+    expect(result.recipes[0].allergens![0]).toEqual({ id: 1, name: 'Gluten' })
+    expect(result.recipes[0].allergens![1]).toEqual({ id: 2, name: 'Dairy' })
+  })
+
+  it('sets allergens to undefined when not present in response', async () => {
+    server.use(
+      http.get(`${BASE}/discovery/recipes`, () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            recipes: [
+              {
+                id: 2,
+                title: 'No Allergen Recipe',
+                type: 'community',
+                profile: { username: 'chef2' },
+                dish_variety: null,
+              },
+            ],
+            pagination: { page: 1, limit: 20, total: 1 },
+          },
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await discoveryService.getRecipeResults()
+
+    expect(result.recipes[0].allergens).toBeUndefined()
+  })
+
+  it('sends excludeAllergens param with numeric allergen IDs', async () => {
+    let capturedParams: URLSearchParams | null = null
+
+    server.use(
+      http.get(`${BASE}/discovery/recipes`, ({ request }) => {
+        capturedParams = new URL(request.url).searchParams
+        return HttpResponse.json({
+          success: true,
+          data: { recipes: [], pagination: { page: 1, limit: 20, total: 0 } },
+          error: null,
+        })
+      }),
+    )
+
+    await discoveryService.getRecipeResults({ excludeAllergens: '1,3' })
+
+    expect(capturedParams!.get('excludeAllergens')).toBe('1,3')
+  })
+})

--- a/frontend/src/__tests__/integration/allergen-service.test.ts
+++ b/frontend/src/__tests__/integration/allergen-service.test.ts
@@ -1,0 +1,110 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { allergenService } from '@/services/allergen-service'
+
+const BASE = 'http://localhost/api'
+
+describe('allergenService', () => {
+  describe('list()', () => {
+    it('returns normalized allergens from GET /allergens', async () => {
+      server.use(
+        http.get(`${BASE}/allergens`, () =>
+          HttpResponse.json({
+            success: true,
+            data: [
+              { id: 1, name: 'Gluten' },
+              { id: 2, name: 'Dairy' },
+              { id: 3, name: 'Nuts' },
+            ],
+            error: null,
+          }),
+        ),
+      )
+
+      const result = await allergenService.list()
+
+      expect(result).toHaveLength(3)
+      expect(result[0]).toEqual({ id: 1, name: 'Gluten' })
+      expect(result[1]).toEqual({ id: 2, name: 'Dairy' })
+      expect(result[2]).toEqual({ id: 3, name: 'Nuts' })
+    })
+
+    it('returns empty array when no allergens exist', async () => {
+      server.use(
+        http.get(`${BASE}/allergens`, () =>
+          HttpResponse.json({ success: true, data: [], error: null }),
+        ),
+      )
+
+      const result = await allergenService.list()
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('detect()', () => {
+    it('returns empty array without calling API when ingredientIds is empty', async () => {
+      let called = false
+      server.use(
+        http.post(`${BASE}/allergens/detect`, () => {
+          called = true
+          return HttpResponse.json({ success: true, data: [], error: null })
+        }),
+      )
+
+      const result = await allergenService.detect([])
+
+      expect(called).toBe(false)
+      expect(result).toEqual([])
+    })
+
+    it('sends ingredientIds and returns detected allergens', async () => {
+      let capturedBody: unknown = null
+
+      server.use(
+        http.post(`${BASE}/allergens/detect`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({
+            success: true,
+            data: [{ id: 1, name: 'Gluten' }],
+            error: null,
+          })
+        }),
+      )
+
+      const result = await allergenService.detect([10, 20, 30])
+
+      expect(capturedBody).toEqual({ ingredientIds: [10, 20, 30] })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({ id: 1, name: 'Gluten' })
+    })
+
+    it('deduplicates allergens returned for multiple ingredients', async () => {
+      server.use(
+        http.post(`${BASE}/allergens/detect`, () =>
+          HttpResponse.json({
+            success: true,
+            data: [
+              { id: 1, name: 'Gluten' },
+              { id: 2, name: 'Dairy' },
+            ],
+            error: null,
+          }),
+        ),
+      )
+
+      const result = await allergenService.detect([5, 6])
+      expect(result).toHaveLength(2)
+    })
+
+    it('returns empty array when no allergens found for given ingredients', async () => {
+      server.use(
+        http.post(`${BASE}/allergens/detect`, () =>
+          HttpResponse.json({ success: true, data: [], error: null }),
+        ),
+      )
+
+      const result = await allergenService.detect([99])
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/frontend/src/__tests__/integration/ingredient-service-create.test.ts
+++ b/frontend/src/__tests__/integration/ingredient-service-create.test.ts
@@ -1,0 +1,44 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { ingredientService } from '@/services/ingredient-service'
+
+const BASE = 'http://localhost/api'
+
+describe('ingredientService.create()', () => {
+  it('sends name_en and name_tr (not name) to POST /ingredients', async () => {
+    let capturedBody: unknown = null
+
+    server.use(
+      http.post(`${BASE}/ingredients`, async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({
+          success: true,
+          data: { id: 42, name: 'Tahini' },
+          error: null,
+        })
+      }),
+    )
+
+    await ingredientService.create('Tahini')
+
+    expect(capturedBody).toEqual({ name_en: 'Tahini', name_tr: 'Tahini' })
+    expect((capturedBody as any).name).toBeUndefined()
+  })
+
+  it('returns the created ingredient with id and name', async () => {
+    server.use(
+      http.post(`${BASE}/ingredients`, () =>
+        HttpResponse.json({
+          success: true,
+          data: { id: 7, name: 'Sumac' },
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await ingredientService.create('Sumac')
+
+    expect(result.id).toBe(7)
+    expect(result.name).toBe('Sumac')
+  })
+})

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -317,8 +317,9 @@
     "steps": {
       "1": "Basic Information",
       "2": "Ingredients & Tools",
-      "3": "Instructions",
-      "4": "Review & Publish"
+      "3": "Allergens",
+      "4": "Instructions",
+      "5": "Review & Publish"
     },
     "fields": {
       "recipeTitle": "Recipe Title",
@@ -345,7 +346,9 @@
       "districtPlaceholder": "District",
       "dietaryTags": "Dietary preferences (optional)",
       "allergenTags": "Allergens in this recipe",
-      "allergenTagsHint": "Select all allergens present in the ingredients."
+      "allergenTagsHint": "Select all allergens present in the ingredients.",
+      "detectedAllergens": "Detected Allergens",
+      "detectedAllergensHint": "Automatically detected from your ingredients."
     },
     "parse": {
       "label": "Free-text recipe input",
@@ -432,6 +435,16 @@
       "errorMediaAfterCreate": "Recipe saved, but uploading media failed. You can try adding files again later.",
       "uploading": "Uploading media…",
       "chooseAria": "Select photos or MP4 video files from your device"
+    },
+    "allergens": {
+      "title": "Allergens",
+      "hint": "These allergens were detected from your ingredients. Remove any that do not apply, or add missing ones.",
+      "none": "No allergens detected from your ingredients.",
+      "manualAdd": "Add Allergen",
+      "searchPlaceholder": "Search allergens...",
+      "removeAria": "Remove {{name}}",
+      "addAria": "Add {{name}}",
+      "detecting": "Detecting allergens..."
     }
   },
   "comments": {

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -317,8 +317,9 @@
     "steps": {
       "1": "Temel Bilgiler",
       "2": "Malzemeler ve Araçlar",
-      "3": "Talimatlar",
-      "4": "İncele ve Yayınla"
+      "3": "Alerjenler",
+      "4": "Talimatlar",
+      "5": "İncele ve Yayınla"
     },
     "fields": {
       "recipeTitle": "Tarif Adı",
@@ -345,7 +346,9 @@
       "districtPlaceholder": "İlçe",
       "dietaryTags": "Diyet tercihleri (isteğe bağlı)",
       "allergenTags": "Bu tarifte bulunan alerjenler",
-      "allergenTagsHint": "Malzemelerde bulunan tüm alerjenleri seçin."
+      "allergenTagsHint": "Malzemelerde bulunan tüm alerjenleri seçin.",
+      "detectedAllergens": "Tespit Edilen Alerjenler",
+      "detectedAllergensHint": "Malzemelerinizden otomatik olarak tespit edildi."
     },
     "parse": {
       "label": "Serbest metin tarif girişi",
@@ -432,6 +435,16 @@
       "errorMediaAfterCreate": "Tarif kaydedildi ancak medya yüklenemedi. Daha sonra tekrar deneyebilirsiniz.",
       "uploading": "Medyalar yükleniyor…",
       "chooseAria": "Cihazınızdan fotoğraf veya MP4 video dosyası seçin"
+    },
+    "allergens": {
+      "title": "Alerjenler",
+      "hint": "Bu alerjenler malzemelerinizden otomatik tespit edildi. Geçerli olmayanları kaldırın veya eksik olanları ekleyin.",
+      "none": "Malzemelerinizden herhangi bir alerjen tespit edilmedi.",
+      "manualAdd": "Alerjen Ekle",
+      "searchPlaceholder": "Alerjen ara...",
+      "removeAria": "{{name}} kaldır",
+      "addAria": "{{name}} ekle",
+      "detecting": "Alerjenler tespit ediliyor..."
     }
   },
   "comments": {

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { isAxiosError } from 'axios'
 import { discoveryService, type DishVariety, type Genre, type DietaryTag } from '@/services/discovery-service'
+import { allergenService, type Allergen } from '@/services/allergen-service'
 import { recipeService, type CreateRecipeIngredient } from '@/services/recipe-service'
 import { ingredientService, type IngredientOption } from '@/services/ingredient-service'
 import { parseService, type ParsedRecipeOutput } from '@/services/parse-service'
@@ -125,6 +126,8 @@ interface RecipeDraft {
   dietaryTagIds: number[]
   /** Numeric IDs from GET /dietary-tags where category === 'allergen' */
   allergenTagIds: number[]
+  /** Allergen IDs from GET /allergens — auto-detected via POST /allergens/detect */
+  allergenIds: number[]
 }
 
 const INITIAL_DRAFT: RecipeDraft = {
@@ -142,6 +145,7 @@ const INITIAL_DRAFT: RecipeDraft = {
   steps: [{ text: '' }],
   dietaryTagIds: [],
   allergenTagIds: [],
+  allergenIds: [],
 }
 
 // ── Inline SVG icons (no lucide-react in frontend) ─────────────────────────────
@@ -182,11 +186,11 @@ function CheckIcon() {
 
 // ── Progress bar ───────────────────────────────────────────────────────────────
 
-function ProgressBar({ step, label }: { step: number; label: string }) {
+function ProgressBar({ step, total, label }: { step: number; total: number; label: string }) {
   return (
     <div className="cr-progress">
       <div className="cr-progress__bars">
-        {[1, 2, 3, 4].map((n) => (
+        {Array.from({ length: total }, (_, i) => i + 1).map((n) => (
           <div
             key={n}
             className={`cr-progress__bar${n <= step ? ' cr-progress__bar--filled' : ''}`}
@@ -205,7 +209,9 @@ export function CreateRecipePage() {
   const navigate = useNavigate()
   const role = useUserRole()
 
-  const [step, setStep] = useState<1 | 2 | 3 | 4>(1)
+  const [step, setStep] = useState<1 | 2 | 3 | 4 | 5>(1)
+  const [allAllergens, setAllAllergens] = useState<Allergen[]>([])
+  const [allergenSearch, setAllergenSearch] = useState('')
   const [draft, setDraft] = useState<RecipeDraft>(INITIAL_DRAFT)
   const [genres, setGenres] = useState<Genre[]>([])
   const [varieties, setVarieties] = useState<DishVariety[]>([])
@@ -228,7 +234,10 @@ export function CreateRecipePage() {
   useEffect(() => {
     discoveryService.getGenres().then(setGenres).catch(() => setGenres([]))
     discoveryService.getDietaryTags().then(setAllTags).catch(() => setAllTags([]))
+    allergenService.list().then(setAllAllergens).catch(() => setAllAllergens([]))
   }, [])
+
+  const [detectingAllergens, setDetectingAllergens] = useState(false)
 
   useEffect(() => {
     if (!draft.genreId) {
@@ -364,6 +373,7 @@ export function CreateRecipePage() {
           .map((t) => ({ name: t.trim() })),
         isPublished: publish,
         tagIds: [...draft.dietaryTagIds, ...draft.allergenTagIds],
+        allergenIds: draft.allergenIds,
       })
       recipeCreated = true
 
@@ -473,11 +483,26 @@ export function CreateRecipePage() {
 
   const canContinueStep1 = draft.title.trim().length >= 3
   const canContinueStep2 = ingredientsStepValid(draft.ingredients)
-  const canContinueStep3 = draft.steps.some((s) => s.text.trim().length > 0)
+  // step 3 (allergens) is always skippable — no required field
+  const canContinueStep4 = draft.steps.some((s) => s.text.trim().length > 0)
 
-  const goNext = () => {
-    if (step === 2 && !ingredientsStepValid(draft.ingredients)) return
-    if (step < 4) setStep((s) => (s + 1) as typeof step)
+  const goNext = async () => {
+    if (step === 2) {
+      if (!ingredientsStepValid(draft.ingredients)) return
+      const ingredientIds = draft.ingredients
+        .map((r) => r.ingredientId)
+        .filter((id): id is number => id !== null)
+      setDetectingAllergens(true)
+      try {
+        const found = await allergenService.detect(ingredientIds)
+        setDraft((d) => ({ ...d, allergenIds: found.map((a) => a.id) }))
+      } catch {
+        // ignore — step 3 will show empty list
+      } finally {
+        setDetectingAllergens(false)
+      }
+    }
+    if (step < 5) setStep((s) => (s + 1) as typeof step)
   }
   const goBack = () => {
     if (step > 1) setStep((s) => (s - 1) as typeof step)
@@ -497,11 +522,27 @@ export function CreateRecipePage() {
 
   // ── Step labels ───────────────────────────────────────────────────────────────
 
-  const stepLabels: Record<1 | 2 | 3 | 4, string> = {
+  const stepLabels: Record<1 | 2 | 3 | 4 | 5, string> = {
     1: t('create.stepLabel', { step: 1, label: t('create.steps.1') }),
     2: t('create.stepLabel', { step: 2, label: t('create.steps.2') }),
     3: t('create.stepLabel', { step: 3, label: t('create.steps.3') }),
     4: t('create.stepLabel', { step: 4, label: t('create.steps.4') }),
+    5: t('create.stepLabel', { step: 5, label: t('create.steps.5') }),
+  }
+
+  // allergen helpers for step 3
+  const filteredAvailableAllergens = allAllergens.filter(
+    (a) =>
+      !draft.allergenIds.includes(a.id) &&
+      a.name.toLowerCase().includes(allergenSearch.toLowerCase()),
+  )
+  const addAllergen = (a: Allergen) => {
+    setDraft((d) =>
+      d.allergenIds.includes(a.id) ? d : { ...d, allergenIds: [...d.allergenIds, a.id] },
+    )
+  }
+  const removeAllergen = (id: number) => {
+    setDraft((d) => ({ ...d, allergenIds: d.allergenIds.filter((x) => x !== id) }))
   }
 
   // ── Render ────────────────────────────────────────────────────────────────────
@@ -515,7 +556,7 @@ export function CreateRecipePage() {
           <ChevronLeftIcon />
         </button>
         <h2 className="cr-header__title">
-          {step === 4 ? t('create.review.title') : t('create.title')}
+          {step === 5 ? t('create.review.title') : t('create.title')}
         </h2>
         <button
           type="button"
@@ -528,7 +569,7 @@ export function CreateRecipePage() {
       </div>
 
       {/* ── Progress ─────────────────────────────────────────────────────── */}
-      <ProgressBar step={step} label={stepLabels[step]} />
+      <ProgressBar step={step} total={5} label={stepLabels[step]} />
 
       {/* ── Step content ─────────────────────────────────────────────────── */}
       <div className="cr-body">
@@ -791,6 +832,7 @@ export function CreateRecipePage() {
               </div>
             )}
 
+
             {/* Photos & video (upload after recipe is created) */}
             <div className="cr-field cr-media">
               <span className="cr-label">{t('create.media.title')}</span>
@@ -933,8 +975,77 @@ export function CreateRecipePage() {
           </div>
         )}
 
-        {/* ── STEP 3: Instructions ──────────────────────────────────────────── */}
+        {/* ── STEP 3: Allergens ────────────────────────────────────────────── */}
         {step === 3 && (
+          <div className="cr-section">
+            <div className="cr-block">
+              <div className="cr-block__header">
+                <h3 className="cr-block__title">{t('create.allergens.title')}</h3>
+              </div>
+              <p className="cr-info-note">{t('create.allergens.hint')}</p>
+
+              {/* Detected allergens */}
+              {detectingAllergens ? (
+                <div className="cr-allergen-loading" role="status" aria-live="polite">
+                  <span className="ui-spinner" aria-hidden />
+                  <span>{t('create.allergens.detecting')}</span>
+                </div>
+              ) : draft.allergenIds.length === 0 ? (
+                <p className="cr-info-note cr-info-note--muted">{t('create.allergens.none')}</p>
+              ) : (
+                <div className="cr-tag-grid cr-tag-grid--allergens">
+                  {allAllergens
+                    .filter((a) => draft.allergenIds.includes(a.id))
+                    .map((a) => (
+                      <span key={a.id} className="cr-tag-chip cr-tag-chip--allergen cr-tag-chip--active">
+                        ⚠ {a.name}
+                        <button
+                          type="button"
+                          className="cr-tag-chip__remove"
+                          onClick={() => removeAllergen(a.id)}
+                          aria-label={t('create.allergens.removeAria', { name: a.name })}
+                        >
+                          ×
+                        </button>
+                      </span>
+                    ))}
+                </div>
+              )}
+            </div>
+
+            {/* Manual add from full allergen list */}
+            <div className="cr-block">
+              <div className="cr-block__header">
+                <h3 className="cr-block__title">{t('create.allergens.manualAdd')}</h3>
+              </div>
+              <input
+                type="search"
+                className="cr-input"
+                value={allergenSearch}
+                onChange={(e) => setAllergenSearch(e.target.value)}
+                placeholder={t('create.allergens.searchPlaceholder')}
+              />
+              {filteredAvailableAllergens.length > 0 && (
+                <div className="cr-tag-grid cr-tag-grid--allergens">
+                  {filteredAvailableAllergens.map((a) => (
+                    <button
+                      key={a.id}
+                      type="button"
+                      className="cr-tag-chip"
+                      onClick={() => addAllergen(a)}
+                      aria-label={t('create.allergens.addAria', { name: a.name })}
+                    >
+                      + {a.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* ── STEP 4: Instructions ──────────────────────────────────────────── */}
+        {step === 4 && (
           <div className="cr-section">
             <div className="cr-block">
               <div className="cr-block__header">
@@ -973,8 +1084,8 @@ export function CreateRecipePage() {
           </div>
         )}
 
-        {/* ── STEP 4: Review & Publish ──────────────────────────────────────── */}
-        {step === 4 && (
+        {/* ── STEP 5: Review & Publish ──────────────────────────────────────── */}
+        {step === 5 && (
           <div className="cr-section">
             {/* Preview card */}
             <div className="cr-review-card">
@@ -1009,7 +1120,7 @@ export function CreateRecipePage() {
                 )}
               </div>
 
-              {(draft.dietaryTagIds.length > 0 || draft.allergenTagIds.length > 0) && (
+              {(draft.dietaryTagIds.length > 0 || draft.allergenTagIds.length > 0 || draft.allergenIds.length > 0) && (
                 <div className="cr-review-card__tags">
                   {draft.dietaryTagIds.map((id) => {
                     const tag = allTags.find((t) => Number(t.id) === id)
@@ -1021,6 +1132,12 @@ export function CreateRecipePage() {
                     const tag = allTags.find((t) => Number(t.id) === id)
                     return tag ? (
                       <span key={id} className="cr-review-tag cr-review-tag--allergen">⚠ {tag.name}</span>
+                    ) : null
+                  })}
+                  {draft.allergenIds.map((id) => {
+                    const allergen = allAllergens.find((a) => a.id === id)
+                    return allergen ? (
+                      <span key={`al-${id}`} className="cr-review-tag cr-review-tag--allergen">⚠ {allergen.name}</span>
                     ) : null
                   })}
                 </div>
@@ -1080,18 +1197,22 @@ export function CreateRecipePage() {
 
       {/* ── Fixed bottom action bar ───────────────────────────────────────── */}
       <div className="cr-actions">
-        {step < 4 ? (
+        {step < 5 ? (
           <button
             type="button"
             className="cr-btn cr-btn--primary"
-            onClick={goNext}
+            onClick={() => void goNext()}
             disabled={
+              detectingAllergens ||
               (step === 1 && !canContinueStep1) ||
               (step === 2 && !canContinueStep2) ||
-              (step === 3 && !canContinueStep3)
+              (step === 4 && !canContinueStep4)
             }
+            aria-busy={detectingAllergens}
           >
-            {t('create.continue')}
+            {detectingAllergens
+              ? <span className="ui-spinner" aria-hidden />
+              : t('create.continue')}
           </button>
         ) : (
           <>
@@ -1099,7 +1220,7 @@ export function CreateRecipePage() {
               type="button"
               className="cr-btn cr-btn--primary"
               onClick={() => handleSubmit(true)}
-              disabled={submitting || !canContinueStep3}
+              disabled={submitting || !canContinueStep4}
               aria-busy={submitting}
             >
               {submitting ? <span className="ui-spinner" aria-hidden /> : t('create.review.publish')}

--- a/frontend/src/pages/Discovery/DiscoveryPage.tsx
+++ b/frontend/src/pages/Discovery/DiscoveryPage.tsx
@@ -12,6 +12,7 @@ import {
   type LocationOptions,
   type RecipeSummary,
 } from '@/services/discovery-service'
+import { allergenService, type Allergen } from '@/services/allergen-service'
 import './DiscoveryPage.css'
 
 const SEARCH_DEBOUNCE_MS = 300
@@ -45,6 +46,7 @@ export function DiscoveryPage() {
 
   // Recipe filters (only apply to recipe section)
   const [allTags, setAllTags] = useState<DietaryTag[]>([])
+  const [allergens, setAllergens] = useState<Allergen[]>([])
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([])
   const [excludedAllergenIds, setExcludedAllergenIds] = useState<string[]>([])
   const [filtersOpen, setFiltersOpen] = useState(false)
@@ -68,13 +70,15 @@ export function DiscoveryPage() {
       discoveryService.getVarieties(),
       discoveryService.getDietaryTags(),
       discoveryService.getLocations(),
+      allergenService.list(),
     ])
-      .then(([genreData, varietyData, tagData, locationData]) => {
+      .then(([genreData, varietyData, tagData, locationData, allergenData]) => {
         if (!cancelled) {
           setGenres(genreData)
           setAllVarieties(varietyData)
           setAllTags(tagData)
           setLocationOptions(locationData)
+          setAllergens(allergenData)
         }
       })
       .catch(() => {
@@ -201,7 +205,6 @@ export function DiscoveryPage() {
   }
 
   const dietaryTags = useMemo(() => allTags.filter((t) => t.category === 'dietary'), [allTags])
-  const allergenTags = useMemo(() => allTags.filter((t) => t.category === 'allergen'), [allTags])
   const activeFilterCount =
     selectedTagIds.length +
     excludedAllergenIds.length +
@@ -343,21 +346,24 @@ export function DiscoveryPage() {
               </div>
             </div>
           )}
-          {allergenTags.length > 0 && (
+          {allergens.length > 0 && (
             <div className="discovery-page__filter-group">
               <p className="discovery-page__filter-group-label">{t('discovery.allergens')}</p>
               <div className="discovery-page__filter-chips">
-                {allergenTags.map((tag) => (
-                  <button
-                    key={tag.id}
-                    type="button"
-                    className={`discovery-page__filter-chip${excludedAllergenIds.includes(tag.id) ? ' discovery-page__filter-chip--active' : ''}`}
-                    data-testid="allergen-chip"
-                    onClick={() => toggleAllergen(tag.id)}
-                  >
-                    {tag.name}
-                  </button>
-                ))}
+                {allergens.map((allergen) => {
+                  const id = String(allergen.id)
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      className={`discovery-page__filter-chip${excludedAllergenIds.includes(id) ? ' discovery-page__filter-chip--active' : ''}`}
+                      data-testid="allergen-chip"
+                      onClick={() => toggleAllergen(id)}
+                    >
+                      {allergen.name}
+                    </button>
+                  )
+                })}
               </div>
             </div>
           )}

--- a/frontend/src/services/allergen-service.ts
+++ b/frontend/src/services/allergen-service.ts
@@ -1,0 +1,26 @@
+import { httpClient } from '@/lib/http-client'
+
+export interface Allergen {
+  id: number
+  name: string
+}
+
+export const allergenService = {
+  /** GET /allergens — full allergen list from the allergens table. */
+  list: async (): Promise<Allergen[]> => {
+    const res = await httpClient.get('/allergens')
+    const raw: unknown[] = Array.isArray(res.data?.data) ? res.data.data : []
+    return raw.map((a: any) => ({ id: Number(a.id), name: a.name ?? '' }))
+  },
+
+  /**
+   * POST /allergens/detect — given a list of ingredient IDs, returns the
+   * allergens present in those ingredients (via ingredient_allergens table).
+   */
+  detect: async (ingredientIds: number[]): Promise<Allergen[]> => {
+    if (ingredientIds.length === 0) return []
+    const res = await httpClient.post('/allergens/detect', { ingredientIds })
+    const raw: unknown[] = Array.isArray(res.data?.data) ? res.data.data : []
+    return raw.map((a: any) => ({ id: Number(a.id), name: a.name ?? '' }))
+  },
+}

--- a/frontend/src/services/discovery-service.ts
+++ b/frontend/src/services/discovery-service.ts
@@ -51,6 +51,7 @@ export interface RecipeSummary {
   author: { username: string; role?: string }
   variety?: { id: string; name: string }
   genre?: { id: string; name: string }
+  allergens?: { id: number; name: string }[]
 }
 
 export interface LocationOptions {
@@ -128,6 +129,9 @@ function normalizeRecipe(r: any): RecipeSummary {
       : undefined,
     genre: r.dish_variety?.dish_genre
       ? { id: String(r.dish_variety.dish_genre.id), name: r.dish_variety.dish_genre.name }
+      : undefined,
+    allergens: Array.isArray(r.allergens)
+      ? r.allergens.map((a: any) => ({ id: Number(a.id), name: a.name ?? '' }))
       : undefined,
   }
 }

--- a/frontend/src/services/ingredient-service.ts
+++ b/frontend/src/services/ingredient-service.ts
@@ -18,8 +18,9 @@ export const ingredientService = {
    * GET /ingredients — optional `search` for partial case-insensitive name match.
    */
   search: async (search?: string): Promise<IngredientOption[]> => {
-    const params = search?.trim() ? { search: search.trim() } : undefined
-    const res = await httpClient.get('/ingredients', { params })
+    const trimmed = search?.trim()
+    if (!trimmed) return []
+    const res = await httpClient.get('/ingredients', { params: { search: trimmed } })
     const raw: unknown[] = Array.isArray(res.data?.data) ? res.data.data : []
     return raw.map((row) => {
       const r = row as { id?: unknown; name?: unknown }

--- a/frontend/src/services/ingredient-service.ts
+++ b/frontend/src/services/ingredient-service.ts
@@ -57,7 +57,7 @@ export const ingredientService = {
    * Throws with code CONFLICT (409) if name already exists.
    */
   create: async (name: string): Promise<IngredientOption> => {
-    const res = await httpClient.post('/ingredients', { name })
+    const res = await httpClient.post('/ingredients', { name_en: name, name_tr: name })
     const data = res.data?.data as { id?: unknown; name?: unknown }
     return {
       id: Number(data.id),

--- a/frontend/src/services/recipe-service.ts
+++ b/frontend/src/services/recipe-service.ts
@@ -109,6 +109,8 @@ export interface CreateRecipePayload {
   district?: string
   /** Dietary + allergen tag IDs from GET /dietary-tags */
   tagIds?: number[]
+  /** Allergen IDs from GET /allergens — auto-detected from ingredients */
+  allergenIds?: number[]
 }
 
 export interface CreatedRecipe {


### PR DESCRIPTION


## What

### Faz 8 — Allergen Filter Fix (#396)
- The discovery page allergen filter was sending `dietary_tag` IDs as `excludeAllergens`, which never matched because the backend compares against the separate `allergens` table. Fixed by loading allergens from the correct `GET /allergens` endpoint via a new `allergenService`.
- `RecipeSummary` type now includes `allergens: { id, name }[]` normalized from discovery responses.

### Faz 9 — Allergen Detection in Recipe Creation (#191)
- Added a new **Step 3 — Allergens** screen to the recipe creation flow (flow is now 5 steps: Basic Info → Ingredients & Tools → Allergens → Instructions → Review).
- On "Continue" from step 2, all selected ingredient IDs are sent to `POST /allergens/detect`. The detected allergens are shown on step 3 with a loading spinner during the call.
- Step 3 lets the user remove false-positive allergens and manually add any missing ones from the full allergen list (with search filter).
- `allergenIds` is now included in the `POST /recipes` payload (separate from `tagIds` which remains for dietary-tag labels).
- Detected allergens are shown in the Review (step 5) summary card.

### Bug fixes
- `POST /ingredients` was sending `{ name }` but the backend (post-migration 002) requires `{ name_en, name_tr }`. Fixed — both fields are now set to the user-supplied name.
- `ingredientService.search()` called without a query was fetching the entire ingredients table. Fixed — empty/undefined search now returns `[]` immediately without an API call.

## How to test

1. **Allergen filter (Discovery):** Open filter panel → Allergens section — chips should now reflect real ingredient-linked allergens (from `GET /allergens`), not dietary tag labels. Selecting one and applying should exclude recipes whose ingredients contain that allergen.
2. **Recipe creation — allergen step:**
   - Create a recipe, add ingredients in step 2 (e.g. milk, wheat flour).
   - Click Continue — a spinner appears while detection runs.
   - Step 3 shows detected allergens (e.g. Dairy, Gluten). Remove one to verify, add one manually via search.
   - Proceed to Review — selected allergens appear in the summary.
3. **Add new ingredient:** In step 2, type a name not in the catalog → "Add new" modal → confirm. Should succeed (previously returned `VALIDATION_ERROR`).
4. **No stray ingredient requests:** Open DevTools Network while on the Create page — there should be no `GET /ingredients` without a `search` param.

## Tests

- `allergen-service.test.ts` — 7 tests: `list()` normalization, `detect()` payload, empty guard
- `allergen-discovery-filter.test.ts` — 3 tests: allergen normalization on recipe summaries, `excludeAllergens` param
- `ingredient-service-create.test.ts` — 2 tests: `name_en`/`name_tr` payload, returned shape

## Related issues

Closes #191, #396
