### PR TITLE
Add expert request endpoints and migrations for genres and varieties

### DIFF
--- a/backend/migrations/006_dish_genre_requests.sql
+++ b/backend/migrations/006_dish_genre_requests.sql
@@ -1,0 +1,23 @@
+-- Migration: Create dish_genre_requests table
+-- Run this in the Supabase SQL Editor
+
+CREATE TABLE public.dish_genre_requests (
+  id             serial      PRIMARY KEY,
+  requested_by   uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  name_en        text        NULL,
+  name_tr        text        NULL,
+  description_en text        NULL,
+  description_tr text        NULL,
+  status         text        NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending', 'approved', 'rejected')),
+  decision_note  text        NULL,
+  decided_by     uuid        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  decided_at     timestamptz NULL
+);
+CREATE INDEX dish_genre_requests_status_idx ON public.dish_genre_requests (status, created_at DESC);
+CREATE INDEX dish_genre_requests_requested_by_idx ON public.dish_genre_requests (requested_by);
+ALTER TABLE public.dish_genre_requests ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read dish_genre_requests" ON public.dish_genre_requests FOR SELECT USING (true);
+CREATE POLICY "Authenticated users can insert dish_genre_requests" ON public.dish_genre_requests FOR INSERT WITH CHECK (true);
+CREATE POLICY "Authenticated users can update dish_genre_requests" ON public.dish_genre_requests FOR UPDATE USING (true);

--- a/backend/migrations/007_dish_variety_requests.sql
+++ b/backend/migrations/007_dish_variety_requests.sql
@@ -1,0 +1,24 @@
+-- Migration: Create dish_variety_requests table
+-- Run this in the Supabase SQL Editor
+
+CREATE TABLE public.dish_variety_requests (
+  id             serial      PRIMARY KEY,
+  requested_by   uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  genre_id       integer     NOT NULL REFERENCES public.dish_genres(id) ON DELETE CASCADE,
+  name_en        text        NULL,
+  name_tr        text        NULL,
+  description_en text        NULL,
+  description_tr text        NULL,
+  status         text        NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending', 'approved', 'rejected')),
+  decision_note  text        NULL,
+  decided_by     uuid        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  decided_at     timestamptz NULL
+);
+CREATE INDEX dish_variety_requests_status_idx ON public.dish_variety_requests (status, created_at DESC);
+CREATE INDEX dish_variety_requests_requested_by_idx ON public.dish_variety_requests (requested_by);
+ALTER TABLE public.dish_variety_requests ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read dish_variety_requests" ON public.dish_variety_requests FOR SELECT USING (true);
+CREATE POLICY "Authenticated users can insert dish_variety_requests" ON public.dish_variety_requests FOR INSERT WITH CHECK (true);
+CREATE POLICY "Authenticated users can update dish_variety_requests" ON public.dish_variety_requests FOR UPDATE USING (true);

--- a/backend/src/__tests__/admin.test.ts
+++ b/backend/src/__tests__/admin.test.ts
@@ -632,3 +632,462 @@ describe("POST /admin/cultural-tag-requests/:id/reject", () => {
     expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
   });
 });
+
+// ─── GET /admin/dish-genre-requests ──────────────────────────────────────────
+
+describe("GET /admin/dish-genre-requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("lists pending genre requests with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const rows = [
+      {
+        id: 1,
+        name_en: "Pastries",
+        name_tr: "Börek Çeşitleri",
+        description_en: null,
+        description_tr: null,
+        status: "pending",
+        decision_note: null,
+        decided_by: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+        requester: { id: "p1", username: "expert_user" },
+      },
+    ];
+
+    const mockChain: any = {};
+    ["select", "order", "range", "eq"].forEach((m) => {
+      mockChain[m] = jest.fn().mockReturnValue(mockChain);
+    });
+    mockChain.then = (resolve: any) =>
+      Promise.resolve({ data: rows, error: null, count: 1 }).then(resolve);
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") return mockChain;
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/admin/dish-genre-requests")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.requests).toHaveLength(1);
+    expect(res.body.data.requests[0].nameEn).toBe("Pastries");
+    expect(res.body.data.requests[0].requester.username).toBe("expert_user");
+    expect(res.body.data.pagination).toBeDefined();
+  });
+});
+
+// ─── POST /admin/dish-genre-requests/:id/approve ─────────────────────────────
+
+describe("POST /admin/dish-genre-requests/:id/approve", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function mockGenreRequest(status: string) {
+    return {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, name_en: "Pastries", name_tr: "Börek Çeşitleri", description_en: null, description_tr: null, status },
+            error: null,
+          }),
+        }),
+      }),
+    };
+  }
+
+  it("approves a pending request and inserts the genre", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") return mockGenreRequest("pending");
+      return {};
+    });
+
+    const newGenre = { id: 5, name: "Pastries", name_en: "Pastries", name_tr: "Börek Çeşitleri", description_en: null, description_tr: null };
+    const mockInsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: newGenre, error: null }),
+      }),
+    });
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_genres") return { insert: mockInsert };
+      if (table === "dish_genre_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Looks good." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("approved");
+    expect(res.body.data.createdGenre.nameEn).toBe("Pastries");
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ name_en: "Pastries" })
+    );
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 404 when request does not exist", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/999/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 409 when request is already decided", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") return mockGenreRequest("approved");
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+
+  it("returns 400 when nameEn cannot be resolved", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 1, name_en: null, name_tr: "Test", description_en: null, description_tr: null, status: "pending" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ─── POST /admin/dish-genre-requests/:id/reject ───────────────────────────────
+
+describe("POST /admin/dish-genre-requests/:id/reject", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects a pending genre request with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqLoad = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, status: "pending" },
+            error: null,
+          }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") return mockReqLoad;
+      return {};
+    });
+
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_genre_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/1/reject")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Not needed." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("rejected");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "rejected", decision_note: "Not needed.", decided_by: "admin-1" })
+    );
+  });
+});
+
+// ─── GET /admin/dish-variety-requests ────────────────────────────────────────
+
+describe("GET /admin/dish-variety-requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("lists pending variety requests with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const rows = [
+      {
+        id: 1,
+        genre_id: 2,
+        name_en: "Börek",
+        name_tr: "Börek",
+        description_en: null,
+        description_tr: null,
+        status: "pending",
+        decision_note: null,
+        decided_by: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+        requester: { id: "p1", username: "expert_user" },
+      },
+    ];
+
+    const mockChain: any = {};
+    ["select", "order", "range", "eq"].forEach((m) => {
+      mockChain[m] = jest.fn().mockReturnValue(mockChain);
+    });
+    mockChain.then = (resolve: any) =>
+      Promise.resolve({ data: rows, error: null, count: 1 }).then(resolve);
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") return mockChain;
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/admin/dish-variety-requests")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.requests).toHaveLength(1);
+    expect(res.body.data.requests[0].nameEn).toBe("Börek");
+    expect(res.body.data.requests[0].genreId).toBe(2);
+    expect(res.body.data.requests[0].requester.username).toBe("expert_user");
+    expect(res.body.data.pagination).toBeDefined();
+  });
+});
+
+// ─── POST /admin/dish-variety-requests/:id/approve ───────────────────────────
+
+describe("POST /admin/dish-variety-requests/:id/approve", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function mockVarietyRequest(status: string) {
+    return {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, genre_id: 2, name_en: "Börek", name_tr: "Börek", description_en: null, description_tr: null, status },
+            error: null,
+          }),
+        }),
+      }),
+    };
+  }
+
+  it("approves a pending request and inserts the variety", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") return mockVarietyRequest("pending");
+      return {};
+    });
+
+    const newVariety = { id: 10, name: "Börek", name_en: "Börek", name_tr: "Börek", description_en: null, description_tr: null, genre_id: 2 };
+    const mockInsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: newVariety, error: null }),
+      }),
+    });
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return { insert: mockInsert };
+      if (table === "dish_variety_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Looks good." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("approved");
+    expect(res.body.data.createdVariety.nameEn).toBe("Börek");
+    expect(res.body.data.createdVariety.genreId).toBe(2);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ name_en: "Börek", genre_id: 2 })
+    );
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 404 when request does not exist", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/999/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 409 when request is already decided", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") return mockVarietyRequest("approved");
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+
+  it("returns 400 when nameEn cannot be resolved", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 1, genre_id: 2, name_en: null, name_tr: "Test", description_en: null, description_tr: null, status: "pending" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ─── POST /admin/dish-variety-requests/:id/reject ────────────────────────────
+
+describe("POST /admin/dish-variety-requests/:id/reject", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects a pending variety request with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqLoad = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, status: "pending" },
+            error: null,
+          }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") return mockReqLoad;
+      return {};
+    });
+
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_variety_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/1/reject")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Not needed." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("rejected");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "rejected", decision_note: "Not needed.", decided_by: "admin-1" })
+    );
+  });
+});

--- a/backend/src/__tests__/dish-genre-requests.test.ts
+++ b/backend/src/__tests__/dish-genre-requests.test.ts
@@ -1,0 +1,266 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase, createUserClient } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: { auth: { getUser: jest.fn() }, from: mockFrom },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+const chainable = (resolved: { data: any; error: any; count?: number | null }) => {
+  const mock: any = {};
+  const methods = [
+    "select", "eq", "neq", "in", "not", "or", "order",
+    "range", "single", "maybeSingle", "ilike", "limit", "filter",
+  ];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
+  return mock;
+};
+
+function mockAuthAsRole(role: "expert" | "cook" | "learner", profileId = "p1") {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "u1", email: "e@e.com" } },
+    error: null,
+  });
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { id: profileId, username: "u", role },
+          error: null,
+        }),
+      }),
+    }),
+  };
+}
+
+// ─── POST /dish-genres/requests ───────────────────────────────────────────────
+
+describe("POST /dish-genres/requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).post("/dish-genres/requests").send({ nameEn: "Pastries" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-expert caller", async () => {
+    const profileLookup = mockAuthAsRole("cook");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Pastries" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when neither nameEn nor nameTr is provided", async () => {
+    const profileLookup = mockAuthAsRole("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ descriptionEn: "Some description" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a request with 201 when both names are provided", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const insertedRow = {
+      id: 1,
+      name_en: "Pastries",
+      name_tr: "Börek Çeşitleri",
+      description_en: null,
+      description_tr: null,
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Pastries", nameTr: "Börek Çeşitleri" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.nameEn).toBe("Pastries");
+    expect(res.body.data.nameTr).toBe("Börek Çeşitleri");
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("accepts nameEn only and attempts DeepL translation for nameTr", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const insertedRow = {
+      id: 2,
+      name_en: "Soups",
+      name_tr: null,
+      description_en: null,
+      description_tr: null,
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Soups" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("returns 500 on DB insert error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: null, error: { message: "DB error" } }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Stews" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /dish-genres/requests/me ─────────────────────────────────────────────
+
+describe("GET /dish-genres/requests/me", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get("/dish-genres/requests/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns own requests as an array with correct fields", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    const rows = [
+      {
+        id: 1,
+        name_en: "Pastries",
+        name_tr: "Börek",
+        description_en: null,
+        description_tr: null,
+        status: "pending",
+        decision_note: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+      },
+    ];
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests")
+        return chainable({ data: rows, error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-genres/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].nameEn).toBe("Pastries");
+    expect(res.body.data[0].status).toBe("pending");
+    expect(res.body.data[0].decisionNote).toBeNull();
+  });
+
+  it("returns empty array when user has no requests", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests")
+        return chainable({ data: [], error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-genres/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests")
+        return chainable({ data: null, error: { message: "fail" } });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-genres/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});

--- a/backend/src/__tests__/dish-variety-requests.test.ts
+++ b/backend/src/__tests__/dish-variety-requests.test.ts
@@ -1,0 +1,294 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase, createUserClient } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: { auth: { getUser: jest.fn() }, from: mockFrom },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+const chainable = (resolved: { data: any; error: any; count?: number | null }) => {
+  const mock: any = {};
+  const methods = [
+    "select", "eq", "neq", "in", "not", "or", "order",
+    "range", "single", "maybeSingle", "ilike", "limit", "filter",
+  ];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
+  return mock;
+};
+
+function mockAuthAsRole(role: "expert" | "cook" | "learner", profileId = "p1") {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "u1", email: "e@e.com" } },
+    error: null,
+  });
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { id: profileId, username: "u", role },
+          error: null,
+        }),
+      }),
+    }),
+  };
+}
+
+// ─── POST /dish-varieties/requests ────────────────────────────────────────────
+
+describe("POST /dish-varieties/requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).post("/dish-varieties/requests").send({ genreId: 1, nameEn: "Börek" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-expert caller", async () => {
+    const profileLookup = mockAuthAsRole("cook");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 1, nameEn: "Börek" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when genreId is missing", async () => {
+    const profileLookup = mockAuthAsRole("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Börek" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when neither nameEn nor nameTr is provided", async () => {
+    const profileLookup = mockAuthAsRole("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 1, descriptionEn: "A pastry" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when genre does not exist", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genres") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 999, nameEn: "Börek" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("creates a request with 201 on success", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genres") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const insertedRow = {
+      id: 1,
+      genre_id: 1,
+      name_en: "Börek",
+      name_tr: "Börek",
+      description_en: null,
+      description_tr: null,
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 1, nameEn: "Börek", nameTr: "Börek" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.nameEn).toBe("Börek");
+    expect(res.body.data.genreId).toBe(1);
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("returns 500 on DB insert error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genres") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: null, error: { message: "DB error" } }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 1, nameEn: "Börek" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /dish-varieties/requests/me ──────────────────────────────────────────
+
+describe("GET /dish-varieties/requests/me", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get("/dish-varieties/requests/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns own requests as an array with genreId field", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    const rows = [
+      {
+        id: 1,
+        genre_id: 2,
+        name_en: "Börek",
+        name_tr: "Börek",
+        description_en: null,
+        description_tr: null,
+        status: "pending",
+        decision_note: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+      },
+    ];
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests")
+        return chainable({ data: rows, error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-varieties/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].nameEn).toBe("Börek");
+    expect(res.body.data[0].genreId).toBe(2);
+    expect(res.body.data[0].status).toBe("pending");
+    expect(res.body.data[0].decisionNote).toBeNull();
+  });
+
+  it("returns empty array when user has no requests", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests")
+        return chainable({ data: [], error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-varieties/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests")
+        return chainable({ data: null, error: { message: "fail" } });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-varieties/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -764,6 +764,401 @@ router.post(
   }
 );
 
+// ─── Dish Genre Requests ──────────────────────────────────────────────────────
+
+const listContentRequestsQuery = z.object({
+  status: z.enum(["pending", "approved", "rejected"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+const approveGenreRequestSchema = z.object({
+  nameEn:        z.string().trim().min(2).max(200).optional(),
+  nameTr:        z.string().trim().min(2).max(200).optional(),
+  descriptionEn: z.string().trim().max(2000).optional(),
+  descriptionTr: z.string().trim().max(2000).optional(),
+  decisionNote:  z.string().trim().max(2000).optional(),
+});
+
+/**
+ * GET /admin/dish-genre-requests
+ * List dish genre requests. Defaults to pending only.
+ */
+router.get("/dish-genre-requests", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listContentRequestsQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid query."));
+    return;
+  }
+  const { status, page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("dish_genre_requests")
+    .select(
+      `id, name_en, name_tr, description_en, description_tr, status, decision_note, decided_by, created_at, decided_at,
+       requester:profiles!dish_genre_requests_requested_by_fkey(id, username)`,
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  query = status ? query.eq("status", status) : query.eq("status", "pending");
+
+  const { data, error, count } = await query;
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse({
+    requests: (data ?? []).map((r: any) => ({
+      id:            r.id,
+      nameEn:        r.name_en,
+      nameTr:        r.name_tr,
+      descriptionEn: r.description_en ?? null,
+      descriptionTr: r.description_tr ?? null,
+      status:        r.status,
+      decisionNote:  r.decision_note ?? null,
+      decidedBy:     r.decided_by ?? null,
+      createdAt:     r.created_at,
+      decidedAt:     r.decided_at ?? null,
+      requester:     r.requester ? { id: r.requester.id, username: r.requester.username } : null,
+    })),
+    pagination: { page, limit, total: count ?? 0 },
+  }));
+});
+
+/**
+ * POST /admin/dish-genre-requests/:id/approve
+ * Approves the request and inserts the genre into dish_genres.
+ * nameEn is required (either from the original request or admin override).
+ */
+router.post(
+  "/dish-genre-requests/:id/approve",
+  validate(approveGenreRequestSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const idNum = Number.parseInt(req.params["id"] as string, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { nameEn, nameTr, descriptionEn, descriptionTr, decisionNote } = req.body as z.infer<typeof approveGenreRequestSchema>;
+
+    // 1. Load the request
+    const { data: genreRequest, error: loadErr } = await supabase
+      .from("dish_genre_requests")
+      .select("id, name_en, name_tr, description_en, description_tr, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!genreRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Dish genre request not found.")); return; }
+    if ((genreRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(genreRequest as any).status}.`));
+      return;
+    }
+
+    // 2. Resolve final values (admin override wins)
+    const finalNameEn = nameEn ?? (genreRequest as any).name_en;
+    const finalNameTr = nameTr ?? (genreRequest as any).name_tr ?? null;
+    const finalDescEn = descriptionEn ?? (genreRequest as any).description_en ?? null;
+    const finalDescTr = descriptionTr ?? (genreRequest as any).description_tr ?? null;
+
+    if (!finalNameEn) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "nameEn is required to create the genre. Provide it in the request body."));
+      return;
+    }
+
+    // 3. Insert into dish_genres
+    const { data: newGenre, error: insertErr } = await adminClient
+      .from("dish_genres")
+      .insert({
+        name:           finalNameEn,
+        name_en:        finalNameEn,
+        name_tr:        finalNameTr,
+        description:    finalDescEn ?? finalDescTr ?? null,
+        description_en: finalDescEn,
+        description_tr: finalDescTr,
+      })
+      .select("id, name, name_en, name_tr, description_en, description_tr")
+      .single();
+
+    if (insertErr) { res.status(500).json(errorResponse("DB_ERROR", insertErr.message)); return; }
+
+    // 4. Mark request approved
+    const decidedAt = new Date().toISOString();
+    const { error: updateErr } = await adminClient
+      .from("dish_genre_requests")
+      .update({ status: "approved", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (updateErr) { res.status(500).json(errorResponse("DB_ERROR", updateErr.message)); return; }
+
+    res.status(200).json(successResponse({
+      requestId:    idNum,
+      status:       "approved",
+      createdGenre: {
+        id:            (newGenre as any).id,
+        nameEn:        (newGenre as any).name_en,
+        nameTr:        (newGenre as any).name_tr,
+        descriptionEn: (newGenre as any).description_en ?? null,
+        descriptionTr: (newGenre as any).description_tr ?? null,
+      },
+      decisionNote: decisionNote ?? null,
+      decidedAt,
+    }));
+  }
+);
+
+/**
+ * POST /admin/dish-genre-requests/:id/reject
+ * Rejects the request. No genre is created.
+ */
+router.post(
+  "/dish-genre-requests/:id/reject",
+  validate(decisionSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const idNum = Number.parseInt(req.params["id"] as string, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { decisionNote } = req.body as z.infer<typeof decisionSchema>;
+
+    const { data: genreRequest, error: loadErr } = await supabase
+      .from("dish_genre_requests")
+      .select("id, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!genreRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Dish genre request not found.")); return; }
+    if ((genreRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(genreRequest as any).status}.`));
+      return;
+    }
+
+    const decidedAt = new Date().toISOString();
+    const { error } = await adminClient
+      .from("dish_genre_requests")
+      .update({ status: "rejected", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (error) { res.status(500).json(errorResponse("DB_ERROR", error.message)); return; }
+
+    res.status(200).json(successResponse({ requestId: idNum, status: "rejected", decisionNote: decisionNote ?? null, decidedAt }));
+  }
+);
+
+// ─── Dish Variety Requests ────────────────────────────────────────────────────
+
+const approveVarietyRequestSchema = z.object({
+  nameEn:        z.string().trim().min(2).max(200).optional(),
+  nameTr:        z.string().trim().min(2).max(200).optional(),
+  descriptionEn: z.string().trim().max(2000).optional(),
+  descriptionTr: z.string().trim().max(2000).optional(),
+  genreId:       z.number().int().positive().optional(),
+  decisionNote:  z.string().trim().max(2000).optional(),
+});
+
+/**
+ * GET /admin/dish-variety-requests
+ * List dish variety requests. Defaults to pending only.
+ */
+router.get("/dish-variety-requests", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listContentRequestsQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid query."));
+    return;
+  }
+  const { status, page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("dish_variety_requests")
+    .select(
+      `id, genre_id, name_en, name_tr, description_en, description_tr, status, decision_note, decided_by, created_at, decided_at,
+       requester:profiles!dish_variety_requests_requested_by_fkey(id, username)`,
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  query = status ? query.eq("status", status) : query.eq("status", "pending");
+
+  const { data, error, count } = await query;
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse({
+    requests: (data ?? []).map((r: any) => ({
+      id:            r.id,
+      genreId:       r.genre_id,
+      nameEn:        r.name_en,
+      nameTr:        r.name_tr,
+      descriptionEn: r.description_en ?? null,
+      descriptionTr: r.description_tr ?? null,
+      status:        r.status,
+      decisionNote:  r.decision_note ?? null,
+      decidedBy:     r.decided_by ?? null,
+      createdAt:     r.created_at,
+      decidedAt:     r.decided_at ?? null,
+      requester:     r.requester ? { id: r.requester.id, username: r.requester.username } : null,
+    })),
+    pagination: { page, limit, total: count ?? 0 },
+  }));
+});
+
+/**
+ * POST /admin/dish-variety-requests/:id/approve
+ * Approves the request and inserts the variety into dish_varieties.
+ * nameEn is required.
+ */
+router.post(
+  "/dish-variety-requests/:id/approve",
+  validate(approveVarietyRequestSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const idNum = Number.parseInt(req.params["id"] as string, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { nameEn, nameTr, descriptionEn, descriptionTr, genreId, decisionNote } = req.body as z.infer<typeof approveVarietyRequestSchema>;
+
+    // 1. Load the request
+    const { data: varietyRequest, error: loadErr } = await supabase
+      .from("dish_variety_requests")
+      .select("id, genre_id, name_en, name_tr, description_en, description_tr, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!varietyRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Dish variety request not found.")); return; }
+    if ((varietyRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(varietyRequest as any).status}.`));
+      return;
+    }
+
+    // 2. Resolve final values (admin override wins)
+    const finalNameEn = nameEn ?? (varietyRequest as any).name_en;
+    const finalNameTr = nameTr ?? (varietyRequest as any).name_tr ?? null;
+    const finalDescEn = descriptionEn ?? (varietyRequest as any).description_en ?? null;
+    const finalDescTr = descriptionTr ?? (varietyRequest as any).description_tr ?? null;
+    const finalGenreId = genreId ?? (varietyRequest as any).genre_id;
+
+    if (!finalNameEn) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "nameEn is required to create the variety. Provide it in the request body."));
+      return;
+    }
+
+    // 3. Insert into dish_varieties
+    const { data: newVariety, error: insertErr } = await adminClient
+      .from("dish_varieties")
+      .insert({
+        name:           finalNameEn,
+        name_en:        finalNameEn,
+        name_tr:        finalNameTr,
+        description:    finalDescEn ?? finalDescTr ?? null,
+        description_en: finalDescEn,
+        description_tr: finalDescTr,
+        genre_id:       finalGenreId,
+      })
+      .select("id, name, name_en, name_tr, description_en, description_tr, genre_id")
+      .single();
+
+    if (insertErr) { res.status(500).json(errorResponse("DB_ERROR", insertErr.message)); return; }
+
+    // 4. Mark request approved
+    const decidedAt = new Date().toISOString();
+    const { error: updateErr } = await adminClient
+      .from("dish_variety_requests")
+      .update({ status: "approved", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (updateErr) { res.status(500).json(errorResponse("DB_ERROR", updateErr.message)); return; }
+
+    res.status(200).json(successResponse({
+      requestId:      idNum,
+      status:         "approved",
+      createdVariety: {
+        id:            (newVariety as any).id,
+        genreId:       (newVariety as any).genre_id,
+        nameEn:        (newVariety as any).name_en,
+        nameTr:        (newVariety as any).name_tr,
+        descriptionEn: (newVariety as any).description_en ?? null,
+        descriptionTr: (newVariety as any).description_tr ?? null,
+      },
+      decisionNote: decisionNote ?? null,
+      decidedAt,
+    }));
+  }
+);
+
+/**
+ * POST /admin/dish-variety-requests/:id/reject
+ * Rejects the request. No variety is created.
+ */
+router.post(
+  "/dish-variety-requests/:id/reject",
+  validate(decisionSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const idNum = Number.parseInt(req.params["id"] as string, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { decisionNote } = req.body as z.infer<typeof decisionSchema>;
+
+    const { data: varietyRequest, error: loadErr } = await supabase
+      .from("dish_variety_requests")
+      .select("id, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!varietyRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Dish variety request not found.")); return; }
+    if ((varietyRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(varietyRequest as any).status}.`));
+      return;
+    }
+
+    const decidedAt = new Date().toISOString();
+    const { error } = await adminClient
+      .from("dish_variety_requests")
+      .update({ status: "rejected", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (error) { res.status(500).json(errorResponse("DB_ERROR", error.message)); return; }
+
+    res.status(200).json(successResponse({ requestId: idNum, status: "rejected", decisionNote: decisionNote ?? null, decidedAt }));
+  }
+);
+
 // Lint hint: silence unused-import warnings in environments where UserRole is
 // shaken out by the bundler.
 export type _Unused = UserRole;

--- a/backend/src/routes/cultural-tags.ts
+++ b/backend/src/routes/cultural-tags.ts
@@ -12,7 +12,7 @@ const router = Router();
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 // Translates a single label via DeepL. Returns null if key is missing or call fails.
-async function translateLabel(text: string, target: "en-US" | "tr"): Promise<string | null> {
+export async function translateLabel(text: string, target: "en-US" | "tr"): Promise<string | null> {
   const apiKey = process.env["DEEPL_API_KEY"];
   if (!apiKey) return null;
   try {

--- a/backend/src/routes/dish-genres.ts
+++ b/backend/src/routes/dish-genres.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
-import { supabase } from "../config/supabase.js";
+import { z } from "zod";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth, requireRole } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest } from "../types/index.js";
 import { successResponse, errorResponse } from "../utils/response.js";
 import { parseLangParam, resolveLang } from "../utils/i18n.js";
+import { translateLabel } from "./cultural-tags.js";
 
 const router = Router();
 
@@ -59,6 +64,102 @@ router.get("/", async (req, res) => {
   }));
 
   return res.status(200).json(successResponse(result));
+});
+
+// ─── POST /dish-genres/requests ───────────────────────────────────────────────
+// Expert submits a request for a new dish genre.
+// At least one of nameEn or nameTr must be provided.
+// The missing language is auto-translated via DeepL.
+
+const genreRequestSchema = z.object({
+  nameEn:        z.string().trim().min(2).max(200).optional(),
+  nameTr:        z.string().trim().min(2).max(200).optional(),
+  descriptionEn: z.string().trim().max(2000).optional(),
+  descriptionTr: z.string().trim().max(2000).optional(),
+}).refine((d) => d.nameEn || d.nameTr, {
+  message: "At least one of nameEn or nameTr is required.",
+});
+
+router.post(
+  "/requests",
+  requireAuth,
+  requireRole("expert"),
+  validate(genreRequestSchema),
+  async (req, res): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const { nameEn, nameTr, descriptionEn, descriptionTr } = req.body as z.infer<typeof genreRequestSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    let resolvedEn = nameEn ?? null;
+    let resolvedTr = nameTr ?? null;
+
+    // Translate the missing language via DeepL
+    if (resolvedEn && !resolvedTr) {
+      resolvedTr = await translateLabel(resolvedEn, "tr");
+    } else if (resolvedTr && !resolvedEn) {
+      resolvedEn = await translateLabel(resolvedTr, "en-US");
+    }
+
+    const { data, error } = await userClient
+      .from("dish_genre_requests")
+      .insert({
+        requested_by:   user.profileId,
+        name_en:        resolvedEn,
+        name_tr:        resolvedTr,
+        description_en: descriptionEn ?? null,
+        description_tr: descriptionTr ?? null,
+        status:         "pending",
+      })
+      .select("id, name_en, name_tr, description_en, description_tr, status, created_at")
+      .single();
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res.status(201).json(successResponse({
+      id:            (data as any).id,
+      nameEn:        (data as any).name_en,
+      nameTr:        (data as any).name_tr,
+      descriptionEn: (data as any).description_en ?? null,
+      descriptionTr: (data as any).description_tr ?? null,
+      status:        (data as any).status,
+      createdAt:     (data as any).created_at,
+    }));
+  }
+);
+
+// ─── GET /dish-genres/requests/me ─────────────────────────────────────────────
+// Returns the authenticated user's own genre requests.
+
+router.get("/requests/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+
+  const { data, error } = await supabase
+    .from("dish_genre_requests")
+    .select("id, name_en, name_tr, description_en, description_tr, status, decision_note, created_at, decided_at")
+    .eq("requested_by", user.profileId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse(
+    (data ?? []).map((r: any) => ({
+      id:            r.id,
+      nameEn:        r.name_en,
+      nameTr:        r.name_tr,
+      descriptionEn: r.description_en ?? null,
+      descriptionTr: r.description_tr ?? null,
+      status:        r.status,
+      decisionNote:  r.decision_note ?? null,
+      createdAt:     r.created_at,
+      decidedAt:     r.decided_at ?? null,
+    }))
+  ));
 });
 
 export default router;

--- a/backend/src/routes/dish-varieties.ts
+++ b/backend/src/routes/dish-varieties.ts
@@ -1,9 +1,14 @@
 import { Router } from "express";
-import { supabase } from "../config/supabase.js";
+import { z } from "zod";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth, requireRole } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest } from "../types/index.js";
 import { successResponse, errorResponse } from "../utils/response.js";
 import { parseLangParam, resolveLang } from "../utils/i18n.js";
 import { buildSearchVariants } from "../utils/text.js";
 import { escapeLikePattern } from "../utils/locations.js";
+import { translateLabel } from "./cultural-tags.js";
 
 const router = Router();
 
@@ -202,6 +207,121 @@ router.get("/:id/recipes", async (req, res) => {
   const communityRecipes = recipes.filter((r) => r.type === "community");
 
   return res.status(200).json(successResponse({ expertRecipe, communityRecipes }));
+});
+
+// ─── POST /dish-varieties/requests ────────────────────────────────────────────
+// Expert submits a request for a new dish variety within a genre.
+// At least one of nameEn or nameTr must be provided.
+
+const varietyRequestSchema = z.object({
+  genreId:       z.number().int().positive(),
+  nameEn:        z.string().trim().min(2).max(200).optional(),
+  nameTr:        z.string().trim().min(2).max(200).optional(),
+  descriptionEn: z.string().trim().max(2000).optional(),
+  descriptionTr: z.string().trim().max(2000).optional(),
+}).refine((d) => d.nameEn || d.nameTr, {
+  message: "At least one of nameEn or nameTr is required.",
+});
+
+router.post(
+  "/requests",
+  requireAuth,
+  requireRole("expert"),
+  validate(varietyRequestSchema),
+  async (req, res): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const { genreId, nameEn, nameTr, descriptionEn, descriptionTr } = req.body as z.infer<typeof varietyRequestSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    // Validate that the genre exists
+    const { data: genre, error: genreError } = await supabase
+      .from("dish_genres")
+      .select("id")
+      .eq("id", genreId)
+      .maybeSingle();
+
+    if (genreError) {
+      res.status(500).json(errorResponse("DB_ERROR", genreError.message));
+      return;
+    }
+    if (!genre) {
+      res.status(404).json(errorResponse("NOT_FOUND", "Dish genre not found."));
+      return;
+    }
+
+    let resolvedEn = nameEn ?? null;
+    let resolvedTr = nameTr ?? null;
+
+    // Translate the missing language via DeepL
+    if (resolvedEn && !resolvedTr) {
+      resolvedTr = await translateLabel(resolvedEn, "tr");
+    } else if (resolvedTr && !resolvedEn) {
+      resolvedEn = await translateLabel(resolvedTr, "en-US");
+    }
+
+    const { data, error } = await userClient
+      .from("dish_variety_requests")
+      .insert({
+        requested_by:   user.profileId,
+        genre_id:       genreId,
+        name_en:        resolvedEn,
+        name_tr:        resolvedTr,
+        description_en: descriptionEn ?? null,
+        description_tr: descriptionTr ?? null,
+        status:         "pending",
+      })
+      .select("id, genre_id, name_en, name_tr, description_en, description_tr, status, created_at")
+      .single();
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res.status(201).json(successResponse({
+      id:            (data as any).id,
+      genreId:       (data as any).genre_id,
+      nameEn:        (data as any).name_en,
+      nameTr:        (data as any).name_tr,
+      descriptionEn: (data as any).description_en ?? null,
+      descriptionTr: (data as any).description_tr ?? null,
+      status:        (data as any).status,
+      createdAt:     (data as any).created_at,
+    }));
+  }
+);
+
+// ─── GET /dish-varieties/requests/me ──────────────────────────────────────────
+// Returns the authenticated user's own variety requests.
+
+router.get("/requests/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+
+  const { data, error } = await supabase
+    .from("dish_variety_requests")
+    .select("id, genre_id, name_en, name_tr, description_en, description_tr, status, decision_note, created_at, decided_at")
+    .eq("requested_by", user.profileId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse(
+    (data ?? []).map((r: any) => ({
+      id:            r.id,
+      genreId:       r.genre_id,
+      nameEn:        r.name_en,
+      nameTr:        r.name_tr,
+      descriptionEn: r.description_en ?? null,
+      descriptionTr: r.description_tr ?? null,
+      status:        r.status,
+      decisionNote:  r.decision_note ?? null,
+      createdAt:     r.created_at,
+      decidedAt:     r.decided_at ?? null,
+    }))
+  ));
 });
 
 export default router;


### PR DESCRIPTION
This pull request introduces new infrastructure and comprehensive tests for handling user-submitted requests to add new dish genres and dish varieties. The changes include new database tables with access policies, as well as full test coverage for the corresponding API endpoints, ensuring proper authorization, validation, and error handling.

**Database schema and access control:**

* Added new table `dish_genre_requests` to store requests for new dish genres, including fields for multilingual names, descriptions, status, decision notes, and audit fields. Indexes and row-level security policies were created to control access and optimize queries.
* Added new table `dish_variety_requests` to store requests for new dish varieties, referencing both the requesting user and the related genre, with similar fields and access policies as above.

**Automated endpoint testing:**

* Added tests for the `/dish-genres/requests` endpoints, covering authentication, role-based access, input validation, translation logic, successful creation, and error handling scenarios.
* Added tests for the `/dish-varieties/requests` endpoints, verifying authentication, role checks, genre existence, input validation, successful creation, and error handling.

closes #511 
closes #512 