### PR TITLE
[Mobile/Fix] Fix filter propagation across search navigation levels

### DIFF
--- a/mobile/src/__tests__/DishVarietyDetailScreen.test.tsx
+++ b/mobile/src/__tests__/DishVarietyDetailScreen.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react-native';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
 import { DishVarietyDetailScreen } from '../screens/DishVarietyDetailScreen';
 import * as client from '../api/client';
+import * as searchApi from '../api/search';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -16,16 +17,24 @@ jest.mock('react-native-safe-area-context', () => ({
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 
+// Mutable so individual tests can inject filters via route params
+let mockRouteParams: { id: number; filters?: any } = { id: 42 };
+
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
-  useRoute: () => ({ params: { id: 42 } }),
+  useRoute: () => ({ params: mockRouteParams }),
 }));
 
 jest.mock('../api/client', () => ({
   fetchApi: jest.fn(),
 }));
 
+jest.mock('../api/search', () => ({
+  fetchDiscoveryRecipes: jest.fn(),
+}));
+
 const mockFetchApi = client.fetchApi as jest.MockedFunction<typeof client.fetchApi>;
+const mockFetchDiscoveryRecipes = searchApi.fetchDiscoveryRecipes as jest.MockedFunction<typeof searchApi.fetchDiscoveryRecipes>;
 
 // ─── Test data ────────────────────────────────────────────────────────────────
 
@@ -83,6 +92,8 @@ async function renderAndFlush() {
 describe('DishVarietyDetailScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouteParams = { id: 42 };
+    mockFetchDiscoveryRecipes.mockResolvedValue([]);
     mockFetchApi.mockImplementation((path: string) => {
       if (path === '/dish-varieties/42') return Promise.resolve(mockVariety);
       if (path === '/recipes/r-cultural') return Promise.resolve(mockCulturalRecipeDetail);
@@ -166,6 +177,81 @@ describe('DishVarietyDetailScreen', () => {
       const { getByText } = await renderAndFlush();
       fireEvent.press(getByText('Home Style Adana'));
       expect(mockNavigate).toHaveBeenCalledWith('RecipeDetail', { recipeId: 'r-community' });
+    });
+  });
+
+  // ─── Filter propagation from navigation ────────────────────────────────────
+
+  describe('filter propagation from navigation params', () => {
+    const activeFilters = {
+      excludeAllergenIds: [1],
+      excludeAllergenNames: ['Gluten'],
+      dietaryTagIds: [],
+      dietaryTagNames: [],
+      country: '',
+      city: '',
+    };
+
+    beforeEach(() => {
+      mockRouteParams = { id: 42, filters: activeFilters };
+      // Only the cultural recipe passes the filter
+      mockFetchDiscoveryRecipes.mockResolvedValue([
+        {
+          id: 'r-cultural',
+          title: 'Traditional Adana Kebap',
+          creatorUsername: 'master_chef',
+          averageRating: 4.8,
+          ratingCount: 35,
+          dishVarietyId: 42,
+          varietyName: 'Adana Kebap',
+          recipeType: 'cultural' as const,
+          imageUrl: null,
+        },
+      ]);
+    });
+
+    it('calls fetchDiscoveryRecipes with varietyId and filter params', async () => {
+      render(<DishVarietyDetailScreen />);
+      await act(async () => { await Promise.resolve(); });
+      await waitFor(() =>
+        expect(mockFetchDiscoveryRecipes).toHaveBeenCalledWith(
+          expect.objectContaining({
+            varietyId: 42,
+            excludeAllergenIds: [1],
+          })
+        )
+      );
+    });
+
+    it('shows only recipes that pass the active filter', async () => {
+      const { queryByText } = render(<DishVarietyDetailScreen />);
+      await waitFor(() => expect(mockFetchDiscoveryRecipes).toHaveBeenCalled());
+      await act(async () => { await Promise.resolve(); });
+      // Community recipe is filtered out
+      expect(queryByText('Home Style Adana')).toBeNull();
+    });
+
+    it('shows filtered recipe count in section title', async () => {
+      const { getByText } = render(<DishVarietyDetailScreen />);
+      await waitFor(() => expect(mockFetchDiscoveryRecipes).toHaveBeenCalled());
+      await act(async () => { await Promise.resolve(); });
+      // i18n uses `{{count}} Recipes` without a separate singular key
+      expect(getByText('1 Recipes')).toBeTruthy();
+    });
+  });
+
+  // ─── No filters in route ───────────────────────────────────────────────────
+
+  describe('without filters in route params', () => {
+    it('does not call fetchDiscoveryRecipes when no filters passed', async () => {
+      await renderAndFlush();
+      expect(mockFetchDiscoveryRecipes).not.toHaveBeenCalled();
+    });
+
+    it('shows all variety recipes when no filters passed', async () => {
+      const { getByText } = await renderAndFlush();
+      expect(getByText('Traditional Adana Kebap')).toBeTruthy();
+      expect(getByText('Home Style Adana')).toBeTruthy();
     });
   });
 });

--- a/mobile/src/__tests__/SearchScreen.test.tsx
+++ b/mobile/src/__tests__/SearchScreen.test.tsx
@@ -191,6 +191,50 @@ describe('SearchScreen', () => {
     });
   });
 
+  // ─── Filter tag removal ────────────────────────────────────────────────────
+
+  describe('filter tag individual removal', () => {
+    it('pressing genre filter tag clears the genre selection', async () => {
+      const { getByPlaceholderText, getAllByText } = await renderAndFlush();
+
+      // Enter search so genre chips become visible
+      fireEvent.changeText(getByPlaceholderText('Search heirloom flavors...'), 'Soups');
+      await act(async () => { await new Promise((r) => setTimeout(r, 400)); });
+
+      // Press the 'Soups' chip to select it (query is cleared, selectedGenreId is set)
+      fireEvent.press(getAllByText('Soups')[0]);
+      await act(async () => { await new Promise((r) => setTimeout(r, 400)); });
+
+      // Now the filter tag row shows 'Soups' (index 0, above ScrollView).
+      // Genre chips also show 'Soups' (index 1+).  Pressing index 0 removes genre.
+      fireEvent.press(getAllByText('Soups')[0]);
+      await act(async () => { await Promise.resolve(); });
+
+      // Genre deselected → last API call must not carry genreId
+      const lastArgs = mockFetchDiscovery.mock.calls[mockFetchDiscovery.mock.calls.length - 1][0];
+      expect(lastArgs.genreId).toBeUndefined();
+    });
+
+    it('varieties include only those from API results when filters are active via genre selection', async () => {
+      // mockFetchDiscovery returns only variety id=1 recipe
+      mockFetchDiscovery.mockResolvedValue([
+        { ...mockRecipes[0], dishVarietyId: 1 },
+      ]);
+
+      const { getByPlaceholderText, getAllByText, queryByText } = await renderAndFlush();
+
+      // Select 'Soups' genre (sets selectedGenreId without text filter)
+      fireEvent.changeText(getByPlaceholderText('Search heirloom flavors...'), 'Soups');
+      await act(async () => { await new Promise((r) => setTimeout(r, 400)); });
+      fireEvent.press(getAllByText('Soups')[0]);
+      await act(async () => { await new Promise((r) => setTimeout(r, 500)); });
+
+      // Variety id=1 (Lentil Soup) should be in filteredVarieties
+      // Variety id=3 (Pilaf, genreId=3) does NOT belong to genre 1 so not shown
+      expect(queryByText('Pilaf')).toBeNull();
+    });
+  });
+
   // ─── Navigation ────────────────────────────────────────────────────────────
 
   describe('navigation', () => {

--- a/mobile/src/__tests__/api.search.test.ts
+++ b/mobile/src/__tests__/api.search.test.ts
@@ -202,6 +202,20 @@ describe('fetchDiscoveryRecipes', () => {
     expect(call).toContain('genreId=3');
   });
 
+  it('passes varietyId param', async () => {
+    mockFetchApi.mockResolvedValueOnce({ recipes: [] });
+    await fetchDiscoveryRecipes({ varietyId: 7 });
+    const call = (mockFetchApi as jest.Mock).mock.calls[0][0] as string;
+    expect(call).toContain('varietyId=7');
+  });
+
+  it('omits varietyId when not provided', async () => {
+    mockFetchApi.mockResolvedValueOnce({ recipes: [] });
+    await fetchDiscoveryRecipes({ search: 'test' });
+    const call = (mockFetchApi as jest.Mock).mock.calls[0][0] as string;
+    expect(call).not.toContain('varietyId');
+  });
+
   it('passes country and city params', async () => {
     mockFetchApi.mockResolvedValueOnce({ recipes: [] });
     await fetchDiscoveryRecipes({ country: 'Turkey', city: 'Istanbul' });

--- a/mobile/src/api/search.ts
+++ b/mobile/src/api/search.ts
@@ -116,6 +116,7 @@ export async function fetchLocations(country?: string): Promise<string[]> {
 export async function fetchDiscoveryRecipes(params: {
   search?: string;
   genreId?: number;
+  varietyId?: number;
   excludeAllergenIds?: number[];
   dietaryTagIds?: number[];
   culturalTagIds?: number[];
@@ -126,6 +127,7 @@ export async function fetchDiscoveryRecipes(params: {
     const qs = new URLSearchParams();
     if (params.search?.trim()) qs.set('search', params.search.trim());
     if (params.genreId !== undefined) qs.set('genreId', String(params.genreId));
+    if (params.varietyId !== undefined) qs.set('varietyId', String(params.varietyId));
     if (params.excludeAllergenIds?.length) qs.set('excludeAllergens', params.excludeAllergenIds.join(','));
     if (params.dietaryTagIds?.length) qs.set('tagIds', params.dietaryTagIds.join(','));
     // Forwarded for the (not-yet-shipped) cultural-tagging endpoint; the current

--- a/mobile/src/components/search/FilterModal.tsx
+++ b/mobile/src/components/search/FilterModal.tsx
@@ -14,17 +14,9 @@ import { useTranslation } from 'react-i18next';
 import { fetchDietaryTags, fetchLocations, type DietaryTag } from '../../api/search';
 import { getCulturalTags, pickCulturalTagLabel, type CulturalTagItem } from '../../api/cultural-tags';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
+import type { ActiveFilters } from '../../navigation/types';
 
-export interface FilterState {
-  excludeAllergenIds: number[];
-  excludeAllergenNames: string[];
-  dietaryTagIds: number[];
-  dietaryTagNames: string[];
-  culturalTagIds: number[];
-  culturalTagNames: string[];
-  country: string;
-  city: string;
-}
+export type FilterState = ActiveFilters;
 
 interface FilterModalProps {
   visible: boolean;

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -18,9 +18,20 @@ export type HomeStackParamList = {
   CommentsRatings: { recipeId: string; recipeTitle: string; rating: number; ratingCount: number; creatorUsername?: string };
 };
 
+export interface ActiveFilters {
+  excludeAllergenIds: number[];
+  excludeAllergenNames: string[];
+  dietaryTagIds: number[];
+  dietaryTagNames: string[];
+  culturalTagIds: number[];
+  culturalTagNames: string[];
+  country: string;
+  city: string;
+}
+
 export type SearchStackParamList = {
   Search: { initialQuery?: string } | undefined;
-  DishVarietyDetail: { id: number };
+  DishVarietyDetail: { id: number; filters?: ActiveFilters };
   RecipeDetail: { recipeId: string };
 };
 

--- a/mobile/src/screens/DishVarietyDetailScreen.tsx
+++ b/mobile/src/screens/DishVarietyDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   ScrollView,
   StyleSheet,
@@ -16,6 +16,8 @@ import { useTranslation } from 'react-i18next';
 import { colors, fonts, fontSizes, spacing } from '../theme';
 import { RecipeCard } from '../components/search/RecipeCard';
 import { fetchApi } from '../api/client';
+import { fetchDiscoveryRecipes } from '../api/search';
+import type { ActiveFilters } from '../navigation/types';
 
 // Types
 interface DishVarietyDetail {
@@ -107,7 +109,8 @@ export function DishVarietyDetailScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<RoutePropType>();
   const { t } = useTranslation('common');
-  const varietyId = route.params?.id;
+  const varietyId: number = route.params?.id;
+  const routeFilters: ActiveFilters | undefined = route.params?.filters;
 
   const [variety, setVariety] = useState<DishVarietyDetail | null>(null);
   const [featuredDescription, setFeaturedDescription] = useState<string | null>(null);
@@ -115,6 +118,8 @@ export function DishVarietyDetailScreen() {
   const [communityImageMap, setCommunityImageMap] = useState<Record<string, string | null>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // IDs of recipes that pass the active filters; null means "show all"
+  const [filteredRecipeIds, setFilteredRecipeIds] = useState<Set<string> | null>(null);
 
   // Fetch variety details
   useEffect(() => {
@@ -125,6 +130,32 @@ export function DishVarietyDetailScreen() {
       .catch(() => setError('Failed to load dish variety'))
       .finally(() => setLoading(false));
   }, [varietyId]);
+
+  // When the caller passed active filters, fetch the matching recipe IDs from
+  // the discovery endpoint so we can intersect them with the variety's recipe list.
+  useEffect(() => {
+    if (!routeFilters || !varietyId) {
+      setFilteredRecipeIds(null);
+      return;
+    }
+    const hasActive =
+      routeFilters.excludeAllergenIds.length > 0 ||
+      routeFilters.dietaryTagIds.length > 0 ||
+      routeFilters.country !== '';
+    if (!hasActive) {
+      setFilteredRecipeIds(null);
+      return;
+    }
+    fetchDiscoveryRecipes({
+      varietyId,
+      excludeAllergenIds: routeFilters.excludeAllergenIds,
+      dietaryTagIds: routeFilters.dietaryTagIds,
+      country: routeFilters.country || undefined,
+      city: routeFilters.city || undefined,
+    }).then((recipes) => {
+      setFilteredRecipeIds(new Set(recipes.map((r) => r.id)));
+    });
+  }, [varietyId, routeFilters]);
 
   // Fetch cultural recipe details (story + image)
   useEffect(() => {
@@ -212,8 +243,12 @@ export function DishVarietyDetailScreen() {
     );
   }
 
-  const culturalRecipe = variety.recipes.find((recipe) => recipe.type === 'cultural') ?? null;
-  const communityRecipes = variety.recipes.filter((recipe) => recipe.type === 'community');
+  const displayedRecipes = filteredRecipeIds !== null
+    ? variety.recipes.filter((r) => filteredRecipeIds.has(r.id))
+    : variety.recipes;
+
+  const culturalRecipe = displayedRecipes.find((recipe) => recipe.type === 'cultural') ?? null;
+  const communityRecipes = displayedRecipes.filter((recipe) => recipe.type === 'community');
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
@@ -244,10 +279,10 @@ export function DishVarietyDetailScreen() {
         {/* Recipes Section */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>
-            {t('dishVariety.recipes', { count: variety.recipes.length })}
+            {t('dishVariety.recipes', { count: displayedRecipes.length })}
           </Text>
 
-          {variety.recipes.length === 0 ? (
+          {displayedRecipes.length === 0 ? (
             <Text style={styles.emptyText}>{t('dishVariety.noRecipes')}</Text>
           ) : (
             <>

--- a/mobile/src/screens/DishVarietyDetailScreen.tsx
+++ b/mobile/src/screens/DishVarietyDetailScreen.tsx
@@ -141,6 +141,7 @@ export function DishVarietyDetailScreen() {
     const hasActive =
       routeFilters.excludeAllergenIds.length > 0 ||
       routeFilters.dietaryTagIds.length > 0 ||
+      routeFilters.culturalTagIds.length > 0 ||
       routeFilters.country !== '';
     if (!hasActive) {
       setFilteredRecipeIds(null);
@@ -150,6 +151,7 @@ export function DishVarietyDetailScreen() {
       varietyId,
       excludeAllergenIds: routeFilters.excludeAllergenIds,
       dietaryTagIds: routeFilters.dietaryTagIds,
+      culturalTagIds: routeFilters.culturalTagIds,
       country: routeFilters.country || undefined,
       city: routeFilters.city || undefined,
     }).then((recipes) => {

--- a/mobile/src/screens/SearchScreen.tsx
+++ b/mobile/src/screens/SearchScreen.tsx
@@ -71,7 +71,6 @@ export function SearchScreen() {
 
   // ── Derived ───────────────────────────────────────────────────────────────
   const normalizedSearch = debouncedSearch.trim().toLowerCase();
-  const isSearchActive = query.trim().length > 0 || selectedGenreId !== null;
   const hasFilters =
     filters.excludeAllergenIds.length > 0 ||
     filters.dietaryTagIds.length > 0 ||
@@ -79,14 +78,46 @@ export function SearchScreen() {
     filters.country !== '' ||
     filters.city !== '';
 
-  // Client-side filtered genres (by search text)
+  // Filter modal tags count as "active search" so genre chips replace the bento grid.
+  const isSearchActive = query.trim().length > 0 || selectedGenreId !== null || hasFilters;
+
+  // When non-search filters (allergen/dietary/location) are active, derive which
+  // variety and genre IDs have at least one recipe that passed all API filters.
+  // null means "no restriction" (show everything via client-side logic).
+  const visibleVarietyIds = useMemo<Set<number> | null>(() => {
+    if (!hasFilters) return null;
+    return new Set(recipes.map((r) => r.dishVarietyId));
+  }, [hasFilters, recipes]);
+
+  const visibleGenreIds = useMemo<Set<number> | null>(() => {
+    if (visibleVarietyIds === null) return null;
+    const ids = new Set<number>();
+    for (const id of visibleVarietyIds) {
+      const variety = allVarieties.find((v) => v.id === id);
+      if (variety) ids.add(variety.genreId);
+    }
+    return ids;
+  }, [visibleVarietyIds, allVarieties]);
+
+  // Genres: when filters active, restrict to genres with matching recipes.
+  // Otherwise, client-side text filter only.
   const filteredGenres = useMemo(() => {
+    if (visibleGenreIds !== null) {
+      return allGenres.filter((g) => visibleGenreIds.has(g.id));
+    }
     if (!normalizedSearch) return allGenres;
     return allGenres.filter((g) => searchIncludes(g.name, normalizedSearch));
-  }, [allGenres, normalizedSearch]);
+  }, [allGenres, normalizedSearch, visibleGenreIds]);
 
-  // Client-side filtered varieties (by selected genre + search text)
+  // Varieties: when filters active, restrict to varieties with matching recipes.
+  // Otherwise, client-side genre + text filter.
   const filteredVarieties = useMemo(() => {
+    if (visibleVarietyIds !== null) {
+      return sortVarieties(
+        allVarieties.filter((v) => visibleVarietyIds.has(v.id)),
+        sort,
+      );
+    }
     let result = allVarieties;
     if (selectedGenreId !== null) {
       result = result.filter((v) => v.genreId === selectedGenreId);
@@ -99,7 +130,7 @@ export function SearchScreen() {
       );
     }
     return sortVarieties(result, sort);
-  }, [allVarieties, selectedGenreId, normalizedSearch, sort]);
+  }, [allVarieties, selectedGenreId, normalizedSearch, sort, visibleVarietyIds]);
 
   // ── Load genres + varieties once on mount ─────────────────────────────────
   useEffect(() => {
@@ -146,7 +177,10 @@ export function SearchScreen() {
   }, []);
 
   const handleVarietyPress = (variety: DishVarietyResult) => {
-    navigation.navigate('DishVarietyDetail', { id: variety.id });
+    navigation.navigate('DishVarietyDetail', {
+      id: variety.id,
+      ...(hasFilters ? { filters } : {}),
+    });
     setSheetVisible(false);
   };
 
@@ -201,42 +235,78 @@ export function SearchScreen() {
           onFilterPress={() => setFilterModalVisible(true)}
         />
         {(hasFilters || selectedGenreId !== null) && (
-          <TouchableOpacity
-            style={styles.filterBadge}
-            onPress={() => setFilterModalVisible(true)}
-          >
-            <View style={styles.filterBadgeContent}>
-              {selectedGenreId !== null && (
-                <View style={styles.filterTag}>
-                  <Text style={styles.filterTagText}>
-                    {allGenres.find((g) => g.id === selectedGenreId)?.name ?? ''}
-                  </Text>
-                </View>
-              )}
-              {filters.excludeAllergenNames.map((name) => (
-                <View key={name} style={styles.filterTag}>
-                  <Text style={styles.filterTagText}>{name}</Text>
-                </View>
-              ))}
-              {filters.dietaryTagNames.map((name) => (
-                <View key={name} style={styles.filterTag}>
-                  <Text style={styles.filterTagText}>{name}</Text>
-                </View>
-              ))}
-              {filters.culturalTagNames.map((name) => (
-                <View key={`cultural-${name}`} style={styles.filterTag}>
-                  <Text style={styles.filterTagText}>{name}</Text>
-                </View>
-              ))}
-              {filters.country !== '' && (
-                <View style={styles.filterTag}>
-                  <Text style={styles.filterTagText}>
-                    {filters.city ? `${filters.city}, ${filters.country}` : filters.country}
-                  </Text>
-                </View>
-              )}
-            </View>
-          </TouchableOpacity>
+          <View style={styles.filterTagsRow}>
+            {selectedGenreId !== null && (
+              <TouchableOpacity
+                style={styles.filterTag}
+                onPress={() => setSelectedGenreId(null)}
+              >
+                <Text style={styles.filterTagText}>
+                  {allGenres.find((g) => g.id === selectedGenreId)?.name ?? ''}
+                </Text>
+                <MaterialCommunityIcons name="close-circle" size={13} color={colors.white} />
+              </TouchableOpacity>
+            )}
+            {filters.excludeAllergenNames.map((name, i) => (
+              <TouchableOpacity
+                key={`allergen-${name}`}
+                style={styles.filterTag}
+                onPress={() =>
+                  setFilters((prev) => ({
+                    ...prev,
+                    excludeAllergenIds: prev.excludeAllergenIds.filter((_, idx) => idx !== i),
+                    excludeAllergenNames: prev.excludeAllergenNames.filter((_, idx) => idx !== i),
+                  }))
+                }
+              >
+                <Text style={styles.filterTagText}>{name}</Text>
+                <MaterialCommunityIcons name="close-circle" size={13} color={colors.white} />
+              </TouchableOpacity>
+            ))}
+            {filters.dietaryTagNames.map((name, i) => (
+              <TouchableOpacity
+                key={`dietary-${name}`}
+                style={styles.filterTag}
+                onPress={() =>
+                  setFilters((prev) => ({
+                    ...prev,
+                    dietaryTagIds: prev.dietaryTagIds.filter((_, idx) => idx !== i),
+                    dietaryTagNames: prev.dietaryTagNames.filter((_, idx) => idx !== i),
+                  }))
+                }
+              >
+                <Text style={styles.filterTagText}>{name}</Text>
+                <MaterialCommunityIcons name="close-circle" size={13} color={colors.white} />
+              </TouchableOpacity>
+            ))}
+            {filters.culturalTagNames.map((name, i) => (
+              <TouchableOpacity
+                key={`cultural-${name}`}
+                style={styles.filterTag}
+                onPress={() =>
+                  setFilters((prev) => ({
+                    ...prev,
+                    culturalTagIds: prev.culturalTagIds.filter((_, idx) => idx !== i),
+                    culturalTagNames: prev.culturalTagNames.filter((_, idx) => idx !== i),
+                  }))
+                }
+              >
+                <Text style={styles.filterTagText}>{name}</Text>
+                <MaterialCommunityIcons name="close-circle" size={13} color={colors.white} />
+              </TouchableOpacity>
+            ))}
+            {filters.country !== '' && (
+              <TouchableOpacity
+                style={styles.filterTag}
+                onPress={() => setFilters((prev) => ({ ...prev, country: '', city: '' }))}
+              >
+                <Text style={styles.filterTagText}>
+                  {filters.city ? `${filters.city}, ${filters.country}` : filters.country}
+                </Text>
+                <MaterialCommunityIcons name="close-circle" size={13} color={colors.white} />
+              </TouchableOpacity>
+            )}
+          </View>
         )}
       </View>
 
@@ -385,20 +455,16 @@ const styles = StyleSheet.create({
     paddingTop: spacing.md,
     paddingBottom: spacing.md,
   },
-  filterBadge: {
+  filterTagsRow: {
     marginTop: spacing.sm,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm,
-    backgroundColor: colors.primary + '15',
-    borderRadius: 8,
-    alignSelf: 'flex-start',
-  },
-  filterBadgeContent: {
     flexDirection: 'row',
-    gap: spacing.xs,
     flexWrap: 'wrap',
+    gap: spacing.xs,
   },
   filterTag: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
     backgroundColor: colors.primary,
     borderRadius: 4,
     paddingHorizontal: spacing.sm,


### PR DESCRIPTION
## What does this PR do?
Filters selected in SearchScreen (allergen, dietary, cultural tag, location) are now preserved when drilling into a Dish Variety. The variety detail screen intersects its recipe list with the discovery API results filtered by the active selection, so only matching recipes appear. The genres/varieties bento grid is also replaced by chips whenever any filter is active, ensuring only varieties with at least one matching recipe are shown.

## How to test
- Open Search, select a cultural tag filter (e.g. "Funeral / Mourning") → only varieties containing a matching recipe appear
- Tap a variety → only the recipe(s) matching the filter are shown (not all recipes of that variety)
- Tap individual filter tags in the tag row → each tag is removed independently without opening the modal
- Repeat with allergen, dietary, and location filters; combinations should also work
- Clear all filters → bento grid and full recipe lists are restored

## Related issue
Closes #397
Closes #400