### PR TITLE
Add genre and variety request endpoints and admin panel updates

### DIFF
--- a/backend/migrations/006_dish_genre_requests.sql
+++ b/backend/migrations/006_dish_genre_requests.sql
@@ -1,0 +1,23 @@
+-- Migration: Create dish_genre_requests table
+-- Run this in the Supabase SQL Editor
+
+CREATE TABLE public.dish_genre_requests (
+  id             serial      PRIMARY KEY,
+  requested_by   uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  name_en        text        NULL,
+  name_tr        text        NULL,
+  description_en text        NULL,
+  description_tr text        NULL,
+  status         text        NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending', 'approved', 'rejected')),
+  decision_note  text        NULL,
+  decided_by     uuid        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  decided_at     timestamptz NULL
+);
+CREATE INDEX dish_genre_requests_status_idx ON public.dish_genre_requests (status, created_at DESC);
+CREATE INDEX dish_genre_requests_requested_by_idx ON public.dish_genre_requests (requested_by);
+ALTER TABLE public.dish_genre_requests ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read dish_genre_requests" ON public.dish_genre_requests FOR SELECT USING (true);
+CREATE POLICY "Authenticated users can insert dish_genre_requests" ON public.dish_genre_requests FOR INSERT WITH CHECK (true);
+CREATE POLICY "Authenticated users can update dish_genre_requests" ON public.dish_genre_requests FOR UPDATE USING (true);

--- a/backend/migrations/007_dish_variety_requests.sql
+++ b/backend/migrations/007_dish_variety_requests.sql
@@ -1,0 +1,24 @@
+-- Migration: Create dish_variety_requests table
+-- Run this in the Supabase SQL Editor
+
+CREATE TABLE public.dish_variety_requests (
+  id             serial      PRIMARY KEY,
+  requested_by   uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  genre_id       integer     NOT NULL REFERENCES public.dish_genres(id) ON DELETE CASCADE,
+  name_en        text        NULL,
+  name_tr        text        NULL,
+  description_en text        NULL,
+  description_tr text        NULL,
+  status         text        NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending', 'approved', 'rejected')),
+  decision_note  text        NULL,
+  decided_by     uuid        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  decided_at     timestamptz NULL
+);
+CREATE INDEX dish_variety_requests_status_idx ON public.dish_variety_requests (status, created_at DESC);
+CREATE INDEX dish_variety_requests_requested_by_idx ON public.dish_variety_requests (requested_by);
+ALTER TABLE public.dish_variety_requests ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read dish_variety_requests" ON public.dish_variety_requests FOR SELECT USING (true);
+CREATE POLICY "Authenticated users can insert dish_variety_requests" ON public.dish_variety_requests FOR INSERT WITH CHECK (true);
+CREATE POLICY "Authenticated users can update dish_variety_requests" ON public.dish_variety_requests FOR UPDATE USING (true);

--- a/backend/src/__tests__/admin.test.ts
+++ b/backend/src/__tests__/admin.test.ts
@@ -632,3 +632,462 @@ describe("POST /admin/cultural-tag-requests/:id/reject", () => {
     expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
   });
 });
+
+// ─── GET /admin/dish-genre-requests ──────────────────────────────────────────
+
+describe("GET /admin/dish-genre-requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("lists pending genre requests with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const rows = [
+      {
+        id: 1,
+        name_en: "Pastries",
+        name_tr: "Börek Çeşitleri",
+        description_en: null,
+        description_tr: null,
+        status: "pending",
+        decision_note: null,
+        decided_by: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+        requester: { id: "p1", username: "expert_user" },
+      },
+    ];
+
+    const mockChain: any = {};
+    ["select", "order", "range", "eq"].forEach((m) => {
+      mockChain[m] = jest.fn().mockReturnValue(mockChain);
+    });
+    mockChain.then = (resolve: any) =>
+      Promise.resolve({ data: rows, error: null, count: 1 }).then(resolve);
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") return mockChain;
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/admin/dish-genre-requests")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.requests).toHaveLength(1);
+    expect(res.body.data.requests[0].nameEn).toBe("Pastries");
+    expect(res.body.data.requests[0].requester.username).toBe("expert_user");
+    expect(res.body.data.pagination).toBeDefined();
+  });
+});
+
+// ─── POST /admin/dish-genre-requests/:id/approve ─────────────────────────────
+
+describe("POST /admin/dish-genre-requests/:id/approve", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function mockGenreRequest(status: string) {
+    return {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, name_en: "Pastries", name_tr: "Börek Çeşitleri", description_en: null, description_tr: null, status },
+            error: null,
+          }),
+        }),
+      }),
+    };
+  }
+
+  it("approves a pending request and inserts the genre", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") return mockGenreRequest("pending");
+      return {};
+    });
+
+    const newGenre = { id: 5, name: "Pastries", name_en: "Pastries", name_tr: "Börek Çeşitleri", description_en: null, description_tr: null };
+    const mockInsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: newGenre, error: null }),
+      }),
+    });
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_genres") return { insert: mockInsert };
+      if (table === "dish_genre_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Looks good." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("approved");
+    expect(res.body.data.createdGenre.nameEn).toBe("Pastries");
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ name_en: "Pastries" })
+    );
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 404 when request does not exist", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/999/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 409 when request is already decided", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") return mockGenreRequest("approved");
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+
+  it("returns 400 when nameEn cannot be resolved", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 1, name_en: null, name_tr: "Test", description_en: null, description_tr: null, status: "pending" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ─── POST /admin/dish-genre-requests/:id/reject ───────────────────────────────
+
+describe("POST /admin/dish-genre-requests/:id/reject", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects a pending genre request with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqLoad = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, status: "pending" },
+            error: null,
+          }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests") return mockReqLoad;
+      return {};
+    });
+
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_genre_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-genre-requests/1/reject")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Not needed." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("rejected");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "rejected", decision_note: "Not needed.", decided_by: "admin-1" })
+    );
+  });
+});
+
+// ─── GET /admin/dish-variety-requests ────────────────────────────────────────
+
+describe("GET /admin/dish-variety-requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("lists pending variety requests with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const rows = [
+      {
+        id: 1,
+        genre_id: 2,
+        name_en: "Börek",
+        name_tr: "Börek",
+        description_en: null,
+        description_tr: null,
+        status: "pending",
+        decision_note: null,
+        decided_by: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+        requester: { id: "p1", username: "expert_user" },
+      },
+    ];
+
+    const mockChain: any = {};
+    ["select", "order", "range", "eq"].forEach((m) => {
+      mockChain[m] = jest.fn().mockReturnValue(mockChain);
+    });
+    mockChain.then = (resolve: any) =>
+      Promise.resolve({ data: rows, error: null, count: 1 }).then(resolve);
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") return mockChain;
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/admin/dish-variety-requests")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.requests).toHaveLength(1);
+    expect(res.body.data.requests[0].nameEn).toBe("Börek");
+    expect(res.body.data.requests[0].genreId).toBe(2);
+    expect(res.body.data.requests[0].requester.username).toBe("expert_user");
+    expect(res.body.data.pagination).toBeDefined();
+  });
+});
+
+// ─── POST /admin/dish-variety-requests/:id/approve ───────────────────────────
+
+describe("POST /admin/dish-variety-requests/:id/approve", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function mockVarietyRequest(status: string) {
+    return {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, genre_id: 2, name_en: "Börek", name_tr: "Börek", description_en: null, description_tr: null, status },
+            error: null,
+          }),
+        }),
+      }),
+    };
+  }
+
+  it("approves a pending request and inserts the variety", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") return mockVarietyRequest("pending");
+      return {};
+    });
+
+    const newVariety = { id: 10, name: "Börek", name_en: "Börek", name_tr: "Börek", description_en: null, description_tr: null, genre_id: 2 };
+    const mockInsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: newVariety, error: null }),
+      }),
+    });
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_varieties") return { insert: mockInsert };
+      if (table === "dish_variety_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Looks good." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("approved");
+    expect(res.body.data.createdVariety.nameEn).toBe("Börek");
+    expect(res.body.data.createdVariety.genreId).toBe(2);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ name_en: "Börek", genre_id: 2 })
+    );
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved", decided_by: "admin-1" })
+    );
+  });
+
+  it("returns 404 when request does not exist", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/999/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 409 when request is already decided", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") return mockVarietyRequest("approved");
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("REQUEST_ALREADY_DECIDED");
+  });
+
+  it("returns 400 when nameEn cannot be resolved", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 1, genre_id: 2, name_en: null, name_tr: "Test", description_en: null, description_tr: null, status: "pending" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/1/approve")
+      .set("Authorization", "Bearer t")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ─── POST /admin/dish-variety-requests/:id/reject ────────────────────────────
+
+describe("POST /admin/dish-variety-requests/:id/reject", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects a pending variety request with 200", async () => {
+    const profileLookup = mockAuthAs("admin", "admin-1");
+
+    const mockReqLoad = {
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { id: 1, status: "pending" },
+            error: null,
+          }),
+        }),
+      }),
+    };
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests") return mockReqLoad;
+      return {};
+    });
+
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+    (supabaseAdmin.from as jest.Mock).mockImplementation((table) => {
+      if (table === "dish_variety_requests") return { update: mockUpdate };
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/admin/dish-variety-requests/1/reject")
+      .set("Authorization", "Bearer t")
+      .send({ decisionNote: "Not needed." });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("rejected");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "rejected", decision_note: "Not needed.", decided_by: "admin-1" })
+    );
+  });
+});

--- a/backend/src/__tests__/dish-genre-requests.test.ts
+++ b/backend/src/__tests__/dish-genre-requests.test.ts
@@ -1,0 +1,266 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase, createUserClient } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: { auth: { getUser: jest.fn() }, from: mockFrom },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+const chainable = (resolved: { data: any; error: any; count?: number | null }) => {
+  const mock: any = {};
+  const methods = [
+    "select", "eq", "neq", "in", "not", "or", "order",
+    "range", "single", "maybeSingle", "ilike", "limit", "filter",
+  ];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
+  return mock;
+};
+
+function mockAuthAsRole(role: "expert" | "cook" | "learner", profileId = "p1") {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "u1", email: "e@e.com" } },
+    error: null,
+  });
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { id: profileId, username: "u", role },
+          error: null,
+        }),
+      }),
+    }),
+  };
+}
+
+// ─── POST /dish-genres/requests ───────────────────────────────────────────────
+
+describe("POST /dish-genres/requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).post("/dish-genres/requests").send({ nameEn: "Pastries" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-expert caller", async () => {
+    const profileLookup = mockAuthAsRole("cook");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Pastries" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when neither nameEn nor nameTr is provided", async () => {
+    const profileLookup = mockAuthAsRole("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ descriptionEn: "Some description" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a request with 201 when both names are provided", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const insertedRow = {
+      id: 1,
+      name_en: "Pastries",
+      name_tr: "Börek Çeşitleri",
+      description_en: null,
+      description_tr: null,
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Pastries", nameTr: "Börek Çeşitleri" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.nameEn).toBe("Pastries");
+    expect(res.body.data.nameTr).toBe("Börek Çeşitleri");
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("accepts nameEn only and attempts DeepL translation for nameTr", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const insertedRow = {
+      id: 2,
+      name_en: "Soups",
+      name_tr: null,
+      description_en: null,
+      description_tr: null,
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Soups" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("returns 500 on DB insert error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: null, error: { message: "DB error" } }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-genres/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Stews" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /dish-genres/requests/me ─────────────────────────────────────────────
+
+describe("GET /dish-genres/requests/me", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get("/dish-genres/requests/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns own requests as an array with correct fields", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    const rows = [
+      {
+        id: 1,
+        name_en: "Pastries",
+        name_tr: "Börek",
+        description_en: null,
+        description_tr: null,
+        status: "pending",
+        decision_note: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+      },
+    ];
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests")
+        return chainable({ data: rows, error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-genres/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].nameEn).toBe("Pastries");
+    expect(res.body.data[0].status).toBe("pending");
+    expect(res.body.data[0].decisionNote).toBeNull();
+  });
+
+  it("returns empty array when user has no requests", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests")
+        return chainable({ data: [], error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-genres/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genre_requests")
+        return chainable({ data: null, error: { message: "fail" } });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-genres/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});

--- a/backend/src/__tests__/dish-variety-requests.test.ts
+++ b/backend/src/__tests__/dish-variety-requests.test.ts
@@ -1,0 +1,294 @@
+import request from "supertest";
+import app from "../index.js";
+import { supabase, createUserClient } from "../config/supabase.js";
+
+jest.mock("../config/supabase.js", () => {
+  const mockFrom = jest.fn();
+  return {
+    supabase: { auth: { getUser: jest.fn() }, from: mockFrom },
+    createUserClient: jest.fn(() => ({ from: mockFrom })),
+  };
+});
+
+const chainable = (resolved: { data: any; error: any; count?: number | null }) => {
+  const mock: any = {};
+  const methods = [
+    "select", "eq", "neq", "in", "not", "or", "order",
+    "range", "single", "maybeSingle", "ilike", "limit", "filter",
+  ];
+  methods.forEach((m) => {
+    mock[m] = jest.fn().mockReturnValue(mock);
+  });
+  mock.then = (resolve: any) => Promise.resolve(resolved).then(resolve);
+  mock.catch = (reject: any) => Promise.resolve(resolved).catch(reject);
+  return mock;
+};
+
+function mockAuthAsRole(role: "expert" | "cook" | "learner", profileId = "p1") {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "u1", email: "e@e.com" } },
+    error: null,
+  });
+  return {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { id: profileId, username: "u", role },
+          error: null,
+        }),
+      }),
+    }),
+  };
+}
+
+// ─── POST /dish-varieties/requests ────────────────────────────────────────────
+
+describe("POST /dish-varieties/requests", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).post("/dish-varieties/requests").send({ genreId: 1, nameEn: "Börek" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-expert caller", async () => {
+    const profileLookup = mockAuthAsRole("cook");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 1, nameEn: "Börek" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when genreId is missing", async () => {
+    const profileLookup = mockAuthAsRole("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ nameEn: "Börek" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when neither nameEn nor nameTr is provided", async () => {
+    const profileLookup = mockAuthAsRole("expert");
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 1, descriptionEn: "A pastry" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when genre does not exist", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genres") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 999, nameEn: "Börek" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("creates a request with 201 on success", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genres") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const insertedRow = {
+      id: 1,
+      genre_id: 1,
+      name_en: "Börek",
+      name_tr: "Börek",
+      description_en: null,
+      description_tr: null,
+      status: "pending",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: insertedRow, error: null }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 1, nameEn: "Börek", nameTr: "Börek" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.nameEn).toBe("Börek");
+    expect(res.body.data.genreId).toBe(1);
+    expect(res.body.data.status).toBe("pending");
+  });
+
+  it("returns 500 on DB insert error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_genres") {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const mockUserClient = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: null, error: { message: "DB error" } }),
+          }),
+        }),
+      }),
+    };
+    (createUserClient as jest.Mock).mockReturnValue(mockUserClient);
+
+    const res = await request(app)
+      .post("/dish-varieties/requests")
+      .set("Authorization", "Bearer t")
+      .send({ genreId: 1, nameEn: "Börek" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});
+
+// ─── GET /dish-varieties/requests/me ──────────────────────────────────────────
+
+describe("GET /dish-varieties/requests/me", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get("/dish-varieties/requests/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns own requests as an array with genreId field", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    const rows = [
+      {
+        id: 1,
+        genre_id: 2,
+        name_en: "Börek",
+        name_tr: "Börek",
+        description_en: null,
+        description_tr: null,
+        status: "pending",
+        decision_note: null,
+        created_at: "2026-01-01T00:00:00Z",
+        decided_at: null,
+      },
+    ];
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests")
+        return chainable({ data: rows, error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-varieties/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].nameEn).toBe("Börek");
+    expect(res.body.data[0].genreId).toBe(2);
+    expect(res.body.data[0].status).toBe("pending");
+    expect(res.body.data[0].decisionNote).toBeNull();
+  });
+
+  it("returns empty array when user has no requests", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests")
+        return chainable({ data: [], error: null });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-varieties/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const profileLookup = mockAuthAsRole("expert", "expert-1");
+
+    (supabase.from as jest.Mock).mockImplementation((table) => {
+      if (table === "profiles") return profileLookup;
+      if (table === "dish_variety_requests")
+        return chainable({ data: null, error: { message: "fail" } });
+      return {};
+    });
+
+    const res = await request(app)
+      .get("/dish-varieties/requests/me")
+      .set("Authorization", "Bearer t");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("DB_ERROR");
+  });
+});

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -764,6 +764,401 @@ router.post(
   }
 );
 
+// ─── Dish Genre Requests ──────────────────────────────────────────────────────
+
+const listContentRequestsQuery = z.object({
+  status: z.enum(["pending", "approved", "rejected"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+const approveGenreRequestSchema = z.object({
+  nameEn:        z.string().trim().min(2).max(200).optional(),
+  nameTr:        z.string().trim().min(2).max(200).optional(),
+  descriptionEn: z.string().trim().max(2000).optional(),
+  descriptionTr: z.string().trim().max(2000).optional(),
+  decisionNote:  z.string().trim().max(2000).optional(),
+});
+
+/**
+ * GET /admin/dish-genre-requests
+ * List dish genre requests. Defaults to pending only.
+ */
+router.get("/dish-genre-requests", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listContentRequestsQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid query."));
+    return;
+  }
+  const { status, page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("dish_genre_requests")
+    .select(
+      `id, name_en, name_tr, description_en, description_tr, status, decision_note, decided_by, created_at, decided_at,
+       requester:profiles!dish_genre_requests_requested_by_fkey(id, username)`,
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  query = status ? query.eq("status", status) : query.eq("status", "pending");
+
+  const { data, error, count } = await query;
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse({
+    requests: (data ?? []).map((r: any) => ({
+      id:            r.id,
+      nameEn:        r.name_en,
+      nameTr:        r.name_tr,
+      descriptionEn: r.description_en ?? null,
+      descriptionTr: r.description_tr ?? null,
+      status:        r.status,
+      decisionNote:  r.decision_note ?? null,
+      decidedBy:     r.decided_by ?? null,
+      createdAt:     r.created_at,
+      decidedAt:     r.decided_at ?? null,
+      requester:     r.requester ? { id: r.requester.id, username: r.requester.username } : null,
+    })),
+    pagination: { page, limit, total: count ?? 0 },
+  }));
+});
+
+/**
+ * POST /admin/dish-genre-requests/:id/approve
+ * Approves the request and inserts the genre into dish_genres.
+ * nameEn is required (either from the original request or admin override).
+ */
+router.post(
+  "/dish-genre-requests/:id/approve",
+  validate(approveGenreRequestSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const idNum = Number.parseInt(req.params["id"] as string, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { nameEn, nameTr, descriptionEn, descriptionTr, decisionNote } = req.body as z.infer<typeof approveGenreRequestSchema>;
+
+    // 1. Load the request
+    const { data: genreRequest, error: loadErr } = await supabase
+      .from("dish_genre_requests")
+      .select("id, name_en, name_tr, description_en, description_tr, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!genreRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Dish genre request not found.")); return; }
+    if ((genreRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(genreRequest as any).status}.`));
+      return;
+    }
+
+    // 2. Resolve final values (admin override wins)
+    const finalNameEn = nameEn ?? (genreRequest as any).name_en;
+    const finalNameTr = nameTr ?? (genreRequest as any).name_tr ?? null;
+    const finalDescEn = descriptionEn ?? (genreRequest as any).description_en ?? null;
+    const finalDescTr = descriptionTr ?? (genreRequest as any).description_tr ?? null;
+
+    if (!finalNameEn) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "nameEn is required to create the genre. Provide it in the request body."));
+      return;
+    }
+
+    // 3. Insert into dish_genres
+    const { data: newGenre, error: insertErr } = await adminClient
+      .from("dish_genres")
+      .insert({
+        name:           finalNameEn,
+        name_en:        finalNameEn,
+        name_tr:        finalNameTr,
+        description:    finalDescEn ?? finalDescTr ?? null,
+        description_en: finalDescEn,
+        description_tr: finalDescTr,
+      })
+      .select("id, name, name_en, name_tr, description_en, description_tr")
+      .single();
+
+    if (insertErr) { res.status(500).json(errorResponse("DB_ERROR", insertErr.message)); return; }
+
+    // 4. Mark request approved
+    const decidedAt = new Date().toISOString();
+    const { error: updateErr } = await adminClient
+      .from("dish_genre_requests")
+      .update({ status: "approved", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (updateErr) { res.status(500).json(errorResponse("DB_ERROR", updateErr.message)); return; }
+
+    res.status(200).json(successResponse({
+      requestId:    idNum,
+      status:       "approved",
+      createdGenre: {
+        id:            (newGenre as any).id,
+        nameEn:        (newGenre as any).name_en,
+        nameTr:        (newGenre as any).name_tr,
+        descriptionEn: (newGenre as any).description_en ?? null,
+        descriptionTr: (newGenre as any).description_tr ?? null,
+      },
+      decisionNote: decisionNote ?? null,
+      decidedAt,
+    }));
+  }
+);
+
+/**
+ * POST /admin/dish-genre-requests/:id/reject
+ * Rejects the request. No genre is created.
+ */
+router.post(
+  "/dish-genre-requests/:id/reject",
+  validate(decisionSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const idNum = Number.parseInt(req.params["id"] as string, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { decisionNote } = req.body as z.infer<typeof decisionSchema>;
+
+    const { data: genreRequest, error: loadErr } = await supabase
+      .from("dish_genre_requests")
+      .select("id, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!genreRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Dish genre request not found.")); return; }
+    if ((genreRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(genreRequest as any).status}.`));
+      return;
+    }
+
+    const decidedAt = new Date().toISOString();
+    const { error } = await adminClient
+      .from("dish_genre_requests")
+      .update({ status: "rejected", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (error) { res.status(500).json(errorResponse("DB_ERROR", error.message)); return; }
+
+    res.status(200).json(successResponse({ requestId: idNum, status: "rejected", decisionNote: decisionNote ?? null, decidedAt }));
+  }
+);
+
+// ─── Dish Variety Requests ────────────────────────────────────────────────────
+
+const approveVarietyRequestSchema = z.object({
+  nameEn:        z.string().trim().min(2).max(200).optional(),
+  nameTr:        z.string().trim().min(2).max(200).optional(),
+  descriptionEn: z.string().trim().max(2000).optional(),
+  descriptionTr: z.string().trim().max(2000).optional(),
+  genreId:       z.number().int().positive().optional(),
+  decisionNote:  z.string().trim().max(2000).optional(),
+});
+
+/**
+ * GET /admin/dish-variety-requests
+ * List dish variety requests. Defaults to pending only.
+ */
+router.get("/dish-variety-requests", async (req: Request, res: Response): Promise<void> => {
+  const parsed = listContentRequestsQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid query."));
+    return;
+  }
+  const { status, page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("dish_variety_requests")
+    .select(
+      `id, genre_id, name_en, name_tr, description_en, description_tr, status, decision_note, decided_by, created_at, decided_at,
+       requester:profiles!dish_variety_requests_requested_by_fkey(id, username)`,
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  query = status ? query.eq("status", status) : query.eq("status", "pending");
+
+  const { data, error, count } = await query;
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse({
+    requests: (data ?? []).map((r: any) => ({
+      id:            r.id,
+      genreId:       r.genre_id,
+      nameEn:        r.name_en,
+      nameTr:        r.name_tr,
+      descriptionEn: r.description_en ?? null,
+      descriptionTr: r.description_tr ?? null,
+      status:        r.status,
+      decisionNote:  r.decision_note ?? null,
+      decidedBy:     r.decided_by ?? null,
+      createdAt:     r.created_at,
+      decidedAt:     r.decided_at ?? null,
+      requester:     r.requester ? { id: r.requester.id, username: r.requester.username } : null,
+    })),
+    pagination: { page, limit, total: count ?? 0 },
+  }));
+});
+
+/**
+ * POST /admin/dish-variety-requests/:id/approve
+ * Approves the request and inserts the variety into dish_varieties.
+ * nameEn is required.
+ */
+router.post(
+  "/dish-variety-requests/:id/approve",
+  validate(approveVarietyRequestSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const idNum = Number.parseInt(req.params["id"] as string, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { nameEn, nameTr, descriptionEn, descriptionTr, genreId, decisionNote } = req.body as z.infer<typeof approveVarietyRequestSchema>;
+
+    // 1. Load the request
+    const { data: varietyRequest, error: loadErr } = await supabase
+      .from("dish_variety_requests")
+      .select("id, genre_id, name_en, name_tr, description_en, description_tr, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!varietyRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Dish variety request not found.")); return; }
+    if ((varietyRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(varietyRequest as any).status}.`));
+      return;
+    }
+
+    // 2. Resolve final values (admin override wins)
+    const finalNameEn = nameEn ?? (varietyRequest as any).name_en;
+    const finalNameTr = nameTr ?? (varietyRequest as any).name_tr ?? null;
+    const finalDescEn = descriptionEn ?? (varietyRequest as any).description_en ?? null;
+    const finalDescTr = descriptionTr ?? (varietyRequest as any).description_tr ?? null;
+    const finalGenreId = genreId ?? (varietyRequest as any).genre_id;
+
+    if (!finalNameEn) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "nameEn is required to create the variety. Provide it in the request body."));
+      return;
+    }
+
+    // 3. Insert into dish_varieties
+    const { data: newVariety, error: insertErr } = await adminClient
+      .from("dish_varieties")
+      .insert({
+        name:           finalNameEn,
+        name_en:        finalNameEn,
+        name_tr:        finalNameTr,
+        description:    finalDescEn ?? finalDescTr ?? null,
+        description_en: finalDescEn,
+        description_tr: finalDescTr,
+        genre_id:       finalGenreId,
+      })
+      .select("id, name, name_en, name_tr, description_en, description_tr, genre_id")
+      .single();
+
+    if (insertErr) { res.status(500).json(errorResponse("DB_ERROR", insertErr.message)); return; }
+
+    // 4. Mark request approved
+    const decidedAt = new Date().toISOString();
+    const { error: updateErr } = await adminClient
+      .from("dish_variety_requests")
+      .update({ status: "approved", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (updateErr) { res.status(500).json(errorResponse("DB_ERROR", updateErr.message)); return; }
+
+    res.status(200).json(successResponse({
+      requestId:      idNum,
+      status:         "approved",
+      createdVariety: {
+        id:            (newVariety as any).id,
+        genreId:       (newVariety as any).genre_id,
+        nameEn:        (newVariety as any).name_en,
+        nameTr:        (newVariety as any).name_tr,
+        descriptionEn: (newVariety as any).description_en ?? null,
+        descriptionTr: (newVariety as any).description_tr ?? null,
+      },
+      decisionNote: decisionNote ?? null,
+      decidedAt,
+    }));
+  }
+);
+
+/**
+ * POST /admin/dish-variety-requests/:id/reject
+ * Rejects the request. No variety is created.
+ */
+router.post(
+  "/dish-variety-requests/:id/reject",
+  validate(decisionSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const admin = (req as AuthenticatedRequest).user;
+    const idNum = Number.parseInt(req.params["id"] as string, 10);
+    if (!Number.isFinite(idNum)) {
+      res.status(400).json(errorResponse("VALIDATION_ERROR", "Request id must be an integer."));
+      return;
+    }
+
+    const adminClient = getAdminClient(res);
+    if (!adminClient) return;
+
+    const { decisionNote } = req.body as z.infer<typeof decisionSchema>;
+
+    const { data: varietyRequest, error: loadErr } = await supabase
+      .from("dish_variety_requests")
+      .select("id, status")
+      .eq("id", idNum)
+      .maybeSingle();
+
+    if (loadErr) { res.status(500).json(errorResponse("DB_ERROR", loadErr.message)); return; }
+    if (!varietyRequest) { res.status(404).json(errorResponse("NOT_FOUND", "Dish variety request not found.")); return; }
+    if ((varietyRequest as any).status !== "pending") {
+      res.status(409).json(errorResponse("REQUEST_ALREADY_DECIDED", `This request has already been ${(varietyRequest as any).status}.`));
+      return;
+    }
+
+    const decidedAt = new Date().toISOString();
+    const { error } = await adminClient
+      .from("dish_variety_requests")
+      .update({ status: "rejected", decision_note: decisionNote ?? null, decided_by: admin.profileId, decided_at: decidedAt })
+      .eq("id", idNum);
+
+    if (error) { res.status(500).json(errorResponse("DB_ERROR", error.message)); return; }
+
+    res.status(200).json(successResponse({ requestId: idNum, status: "rejected", decisionNote: decisionNote ?? null, decidedAt }));
+  }
+);
+
 // Lint hint: silence unused-import warnings in environments where UserRole is
 // shaken out by the bundler.
 export type _Unused = UserRole;

--- a/backend/src/routes/cultural-tags.ts
+++ b/backend/src/routes/cultural-tags.ts
@@ -12,7 +12,7 @@ const router = Router();
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 // Translates a single label via DeepL. Returns null if key is missing or call fails.
-async function translateLabel(text: string, target: "en-US" | "tr"): Promise<string | null> {
+export async function translateLabel(text: string, target: "en-US" | "tr"): Promise<string | null> {
   const apiKey = process.env["DEEPL_API_KEY"];
   if (!apiKey) return null;
   try {

--- a/backend/src/routes/dish-genres.ts
+++ b/backend/src/routes/dish-genres.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
-import { supabase } from "../config/supabase.js";
+import { z } from "zod";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth, requireRole } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest } from "../types/index.js";
 import { successResponse, errorResponse } from "../utils/response.js";
 import { parseLangParam, resolveLang } from "../utils/i18n.js";
+import { translateLabel } from "./cultural-tags.js";
 
 const router = Router();
 
@@ -59,6 +64,102 @@ router.get("/", async (req, res) => {
   }));
 
   return res.status(200).json(successResponse(result));
+});
+
+// ─── POST /dish-genres/requests ───────────────────────────────────────────────
+// Expert submits a request for a new dish genre.
+// At least one of nameEn or nameTr must be provided.
+// The missing language is auto-translated via DeepL.
+
+const genreRequestSchema = z.object({
+  nameEn:        z.string().trim().min(2).max(200).optional(),
+  nameTr:        z.string().trim().min(2).max(200).optional(),
+  descriptionEn: z.string().trim().max(2000).optional(),
+  descriptionTr: z.string().trim().max(2000).optional(),
+}).refine((d) => d.nameEn || d.nameTr, {
+  message: "At least one of nameEn or nameTr is required.",
+});
+
+router.post(
+  "/requests",
+  requireAuth,
+  requireRole("expert"),
+  validate(genreRequestSchema),
+  async (req, res): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const { nameEn, nameTr, descriptionEn, descriptionTr } = req.body as z.infer<typeof genreRequestSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    let resolvedEn = nameEn ?? null;
+    let resolvedTr = nameTr ?? null;
+
+    // Translate the missing language via DeepL
+    if (resolvedEn && !resolvedTr) {
+      resolvedTr = await translateLabel(resolvedEn, "tr");
+    } else if (resolvedTr && !resolvedEn) {
+      resolvedEn = await translateLabel(resolvedTr, "en-US");
+    }
+
+    const { data, error } = await userClient
+      .from("dish_genre_requests")
+      .insert({
+        requested_by:   user.profileId,
+        name_en:        resolvedEn,
+        name_tr:        resolvedTr,
+        description_en: descriptionEn ?? null,
+        description_tr: descriptionTr ?? null,
+        status:         "pending",
+      })
+      .select("id, name_en, name_tr, description_en, description_tr, status, created_at")
+      .single();
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res.status(201).json(successResponse({
+      id:            (data as any).id,
+      nameEn:        (data as any).name_en,
+      nameTr:        (data as any).name_tr,
+      descriptionEn: (data as any).description_en ?? null,
+      descriptionTr: (data as any).description_tr ?? null,
+      status:        (data as any).status,
+      createdAt:     (data as any).created_at,
+    }));
+  }
+);
+
+// ─── GET /dish-genres/requests/me ─────────────────────────────────────────────
+// Returns the authenticated user's own genre requests.
+
+router.get("/requests/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+
+  const { data, error } = await supabase
+    .from("dish_genre_requests")
+    .select("id, name_en, name_tr, description_en, description_tr, status, decision_note, created_at, decided_at")
+    .eq("requested_by", user.profileId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse(
+    (data ?? []).map((r: any) => ({
+      id:            r.id,
+      nameEn:        r.name_en,
+      nameTr:        r.name_tr,
+      descriptionEn: r.description_en ?? null,
+      descriptionTr: r.description_tr ?? null,
+      status:        r.status,
+      decisionNote:  r.decision_note ?? null,
+      createdAt:     r.created_at,
+      decidedAt:     r.decided_at ?? null,
+    }))
+  ));
 });
 
 export default router;

--- a/backend/src/routes/dish-varieties.ts
+++ b/backend/src/routes/dish-varieties.ts
@@ -1,9 +1,14 @@
 import { Router } from "express";
-import { supabase } from "../config/supabase.js";
+import { z } from "zod";
+import { supabase, createUserClient } from "../config/supabase.js";
+import { requireAuth, requireRole } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import type { AuthenticatedRequest } from "../types/index.js";
 import { successResponse, errorResponse } from "../utils/response.js";
 import { parseLangParam, resolveLang } from "../utils/i18n.js";
 import { buildSearchVariants } from "../utils/text.js";
 import { escapeLikePattern } from "../utils/locations.js";
+import { translateLabel } from "./cultural-tags.js";
 
 const router = Router();
 
@@ -202,6 +207,121 @@ router.get("/:id/recipes", async (req, res) => {
   const communityRecipes = recipes.filter((r) => r.type === "community");
 
   return res.status(200).json(successResponse({ expertRecipe, communityRecipes }));
+});
+
+// ─── POST /dish-varieties/requests ────────────────────────────────────────────
+// Expert submits a request for a new dish variety within a genre.
+// At least one of nameEn or nameTr must be provided.
+
+const varietyRequestSchema = z.object({
+  genreId:       z.number().int().positive(),
+  nameEn:        z.string().trim().min(2).max(200).optional(),
+  nameTr:        z.string().trim().min(2).max(200).optional(),
+  descriptionEn: z.string().trim().max(2000).optional(),
+  descriptionTr: z.string().trim().max(2000).optional(),
+}).refine((d) => d.nameEn || d.nameTr, {
+  message: "At least one of nameEn or nameTr is required.",
+});
+
+router.post(
+  "/requests",
+  requireAuth,
+  requireRole("expert"),
+  validate(varietyRequestSchema),
+  async (req, res): Promise<void> => {
+    const user = (req as AuthenticatedRequest).user;
+    const { genreId, nameEn, nameTr, descriptionEn, descriptionTr } = req.body as z.infer<typeof varietyRequestSchema>;
+    const userClient = createUserClient(user.accessToken);
+
+    // Validate that the genre exists
+    const { data: genre, error: genreError } = await supabase
+      .from("dish_genres")
+      .select("id")
+      .eq("id", genreId)
+      .maybeSingle();
+
+    if (genreError) {
+      res.status(500).json(errorResponse("DB_ERROR", genreError.message));
+      return;
+    }
+    if (!genre) {
+      res.status(404).json(errorResponse("NOT_FOUND", "Dish genre not found."));
+      return;
+    }
+
+    let resolvedEn = nameEn ?? null;
+    let resolvedTr = nameTr ?? null;
+
+    // Translate the missing language via DeepL
+    if (resolvedEn && !resolvedTr) {
+      resolvedTr = await translateLabel(resolvedEn, "tr");
+    } else if (resolvedTr && !resolvedEn) {
+      resolvedEn = await translateLabel(resolvedTr, "en-US");
+    }
+
+    const { data, error } = await userClient
+      .from("dish_variety_requests")
+      .insert({
+        requested_by:   user.profileId,
+        genre_id:       genreId,
+        name_en:        resolvedEn,
+        name_tr:        resolvedTr,
+        description_en: descriptionEn ?? null,
+        description_tr: descriptionTr ?? null,
+        status:         "pending",
+      })
+      .select("id, genre_id, name_en, name_tr, description_en, description_tr, status, created_at")
+      .single();
+
+    if (error) {
+      res.status(500).json(errorResponse("DB_ERROR", error.message));
+      return;
+    }
+
+    res.status(201).json(successResponse({
+      id:            (data as any).id,
+      genreId:       (data as any).genre_id,
+      nameEn:        (data as any).name_en,
+      nameTr:        (data as any).name_tr,
+      descriptionEn: (data as any).description_en ?? null,
+      descriptionTr: (data as any).description_tr ?? null,
+      status:        (data as any).status,
+      createdAt:     (data as any).created_at,
+    }));
+  }
+);
+
+// ─── GET /dish-varieties/requests/me ──────────────────────────────────────────
+// Returns the authenticated user's own variety requests.
+
+router.get("/requests/me", requireAuth, async (req, res): Promise<void> => {
+  const user = (req as AuthenticatedRequest).user;
+
+  const { data, error } = await supabase
+    .from("dish_variety_requests")
+    .select("id, genre_id, name_en, name_tr, description_en, description_tr, status, decision_note, created_at, decided_at")
+    .eq("requested_by", user.profileId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    res.status(500).json(errorResponse("DB_ERROR", error.message));
+    return;
+  }
+
+  res.status(200).json(successResponse(
+    (data ?? []).map((r: any) => ({
+      id:            r.id,
+      genreId:       r.genre_id,
+      nameEn:        r.name_en,
+      nameTr:        r.name_tr,
+      descriptionEn: r.description_en ?? null,
+      descriptionTr: r.description_tr ?? null,
+      status:        r.status,
+      decisionNote:  r.decision_note ?? null,
+      createdAt:     r.created_at,
+      decidedAt:     r.decided_at ?? null,
+    }))
+  ));
 });
 
 export default router;

--- a/frontend/src/__tests__/integration/admin-content-requests.test.tsx
+++ b/frontend/src/__tests__/integration/admin-content-requests.test.tsx
@@ -1,0 +1,280 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '@/i18n/i18n'
+import { ContentRequestRow } from '@/pages/Admin/Parts/ContentRequestRow'
+import { ApproveContentRequestDialog } from '@/pages/Admin/Parts/ApproveContentRequestDialog'
+import type { DishGenreRequest, DishVarietyRequest } from '@/services/types/admin'
+
+const pendingGenreRequest: DishGenreRequest = {
+  id: 1,
+  nameEn: 'Pastries',
+  nameTr: 'Börek Çeşitleri',
+  descriptionEn: 'Baked goods made from dough',
+  descriptionTr: 'Hamurdan yapılan yiyecekler',
+  status: 'pending',
+  decisionNote: null,
+  decidedBy: null,
+  createdAt: '2026-05-10T00:00:00Z',
+  decidedAt: null,
+  requester: { id: 'p1', username: 'expert_user' },
+}
+
+const approvedGenreRequest: DishGenreRequest = {
+  ...pendingGenreRequest,
+  id: 2,
+  status: 'approved',
+  decisionNote: 'Great genre.',
+  decidedAt: '2026-05-11T00:00:00Z',
+}
+
+const pendingVarietyRequest: DishVarietyRequest = {
+  id: 3,
+  genreId: 5,
+  nameEn: 'Börek',
+  nameTr: 'Börek',
+  descriptionEn: 'A flaky pastry',
+  descriptionTr: 'Çıtır bir hamur işi',
+  status: 'pending',
+  decisionNote: null,
+  decidedBy: null,
+  createdAt: '2026-05-10T00:00:00Z',
+  decidedAt: null,
+  requester: { id: 'p2', username: 'another_expert' },
+}
+
+function wrap(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+// ─── ContentRequestRow ────────────────────────────────────────────────────────
+
+describe('ContentRequestRow — genre', () => {
+  it('renders requester username, nameEn, nameTr for a genre request', () => {
+    wrap(
+      <ContentRequestRow
+        type="genre"
+        request={pendingGenreRequest}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('expert_user')).toBeInTheDocument()
+    expect(screen.getByText('Pastries')).toBeInTheDocument()
+    expect(screen.getByText('Börek Çeşitleri')).toBeInTheDocument()
+  })
+
+  it('renders variety request with genreId', () => {
+    wrap(
+      <ContentRequestRow
+        type="variety"
+        request={pendingVarietyRequest}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('another_expert')).toBeInTheDocument()
+    // nameEn and nameTr are both "Börek" so use getAllByText
+    expect(screen.getAllByText('Börek').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('shows Approve and Reject buttons for pending requests', () => {
+    wrap(
+      <ContentRequestRow
+        type="genre"
+        request={pendingGenreRequest}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
+  })
+
+  it('hides action buttons for non-pending requests', () => {
+    wrap(
+      <ContentRequestRow
+        type="genre"
+        request={approvedGenreRequest}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /reject/i })).not.toBeInTheDocument()
+  })
+
+  it('calls onApprove when Approve button is clicked', async () => {
+    const onApprove = vi.fn()
+    const user = userEvent.setup()
+
+    wrap(
+      <ContentRequestRow
+        type="genre"
+        request={pendingGenreRequest}
+        onApprove={onApprove}
+        onReject={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /approve/i }))
+    expect(onApprove).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onReject when Reject button is clicked', async () => {
+    const onReject = vi.fn()
+    const user = userEvent.setup()
+
+    wrap(
+      <ContentRequestRow
+        type="genre"
+        request={pendingGenreRequest}
+        onApprove={vi.fn()}
+        onReject={onReject}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /reject/i }))
+    expect(onReject).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── ApproveContentRequestDialog — genre ─────────────────────────────────────
+
+describe('ApproveContentRequestDialog — genre', () => {
+  it('pre-fills nameEn and nameTr from the genre request', () => {
+    wrap(
+      <ApproveContentRequestDialog
+        type="genre"
+        request={pendingGenreRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue('Pastries')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Börek Çeşitleri')).toBeInTheDocument()
+  })
+
+  it('does not render genreId input for genre type', () => {
+    wrap(
+      <ApproveContentRequestDialog
+        type="genre"
+        request={pendingGenreRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    // The genre ID field label should not be present for genre type
+    expect(screen.queryByDisplayValue('5')).not.toBeInTheDocument()
+  })
+
+  it('disables the Approve button when nameEn is cleared', async () => {
+    const user = userEvent.setup()
+
+    wrap(
+      <ApproveContentRequestDialog
+        type="genre"
+        request={pendingGenreRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    const nameEnInput = screen.getByDisplayValue('Pastries')
+    await user.clear(nameEnInput)
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeDisabled()
+  })
+
+  it('calls onSubmit with correct payload when Approve is clicked', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+
+    wrap(
+      <ApproveContentRequestDialog
+        type="genre"
+        request={pendingGenreRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    const nameEnInput = screen.getByDisplayValue('Pastries')
+    await user.clear(nameEnInput)
+    await user.type(nameEnInput, 'Baked Goods')
+
+    await user.click(screen.getByRole('button', { name: /approve/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ nameEn: 'Baked Goods' })
+    )
+  })
+
+  it('disables all buttons when busy', () => {
+    wrap(
+      <ApproveContentRequestDialog
+        type="genre"
+        request={pendingGenreRequest}
+        busy={true}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    const buttons = screen.getAllByRole('button')
+    buttons.forEach((btn) => expect(btn).toBeDisabled())
+  })
+})
+
+// ─── ApproveContentRequestDialog — variety ───────────────────────────────────
+
+describe('ApproveContentRequestDialog — variety', () => {
+  it('pre-fills nameEn, nameTr, and genreId from the variety request', () => {
+    wrap(
+      <ApproveContentRequestDialog
+        type="variety"
+        request={pendingVarietyRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    // nameEn and nameTr are both "Börek" — use getAllByDisplayValue
+    expect(screen.getAllByDisplayValue('Börek').length).toBeGreaterThanOrEqual(1)
+    // genreId pre-filled as "5"
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument()
+  })
+
+  it('calls onSubmit with genreId in payload when Approve is clicked', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+
+    wrap(
+      <ApproveContentRequestDialog
+        type="variety"
+        request={pendingVarietyRequest}
+        busy={false}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /approve/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ nameEn: 'Börek', genreId: 5 })
+    )
+  })
+})

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -459,7 +459,8 @@
     "tabs": {
       "requests": "Expert Requests",
       "users": "Users",
-      "culturalTags": "Cultural Tag Requests"
+      "culturalTags": "Cultural Tag Requests",
+      "contentRequests": "Content Requests"
     },
     "refresh": "Refresh",
     "cancel": "Cancel",
@@ -541,12 +542,45 @@
       "approvedToast": "Cultural tag '{{labelEn}}' created and approved.",
       "rejectedToast": "Tag request rejected."
     },
+    "contentRequests": {
+      "statusAria": "Filter by status",
+      "subfilterAria": "Content type",
+      "subfilter": { "genre": "Genres", "variety": "Varieties" },
+      "empty": "No requests in this state.",
+      "unknownRequester": "(unknown requester)",
+      "nameEn": "English name",
+      "nameTr": "Turkish name",
+      "descriptionEn": "English description",
+      "descriptionTr": "Turkish description",
+      "genreId": "Genre ID",
+      "decisionAt": "Decision date",
+      "decisionNote": "Admin note",
+      "approve": "Approve",
+      "reject": "Reject",
+      "approveTitle": "Approve content request",
+      "rejectTitle": "Reject this content request?",
+      "approveConfirm": "Approve & create",
+      "rejectConfirm": "Reject request",
+      "nameEnLabel": "English name (required)",
+      "nameTrLabel": "Turkish name",
+      "descriptionEnLabel": "English description (optional)",
+      "descriptionTrLabel": "Turkish description (optional)",
+      "genreIdLabel": "Genre ID",
+      "decisionNoteLabel": "Decision note",
+      "decisionNotePlaceholder": "Optional — leave a short message.",
+      "decisionNoteOptional": "optional",
+      "approvedGenreToast": "Genre '{{nameEn}}' created and approved.",
+      "approvedVarietyToast": "Variety '{{nameEn}}' created and approved.",
+      "rejectedToast": "Content request rejected."
+    },
     "errors": {
       "loadRequests": "Could not load requests.",
       "loadUsers": "Could not load users.",
       "loadCulturalTagRequests": "Could not load cultural tag requests.",
+      "loadContentRequests": "Could not load content requests.",
       "decisionFailed": "Decision could not be saved.",
       "tagDecisionFailed": "Tag decision could not be saved.",
+      "contentDecisionFailed": "Decision could not be saved.",
       "updateFailed": "Could not update user.",
       "deleteFailed": "Could not delete user."
     }

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -459,7 +459,8 @@
     "tabs": {
       "requests": "Uzman Başvuruları",
       "users": "Kullanıcılar",
-      "culturalTags": "Kültürel Etiket Başvuruları"
+      "culturalTags": "Kültürel Etiket Başvuruları",
+      "contentRequests": "İçerik Başvuruları"
     },
     "refresh": "Yenile",
     "cancel": "İptal",
@@ -541,12 +542,45 @@
       "approvedToast": "'{{labelEn}}' kültürel etiketi oluşturuldu ve onaylandı.",
       "rejectedToast": "Etiket başvurusu reddedildi."
     },
+    "contentRequests": {
+      "statusAria": "Duruma göre filtrele",
+      "subfilterAria": "İçerik türü",
+      "subfilter": { "genre": "Türler", "variety": "Çeşitler" },
+      "empty": "Bu durumda başvuru yok.",
+      "unknownRequester": "(bilinmeyen başvuran)",
+      "nameEn": "İngilizce ad",
+      "nameTr": "Türkçe ad",
+      "descriptionEn": "İngilizce açıklama",
+      "descriptionTr": "Türkçe açıklama",
+      "genreId": "Tür ID",
+      "decisionAt": "Karar tarihi",
+      "decisionNote": "Yönetici notu",
+      "approve": "Onayla",
+      "reject": "Reddet",
+      "approveTitle": "İçerik başvurusunu onayla",
+      "rejectTitle": "Bu içerik başvurusu reddedilsin mi?",
+      "approveConfirm": "Onayla ve oluştur",
+      "rejectConfirm": "Başvuruyu reddet",
+      "nameEnLabel": "İngilizce ad (zorunlu)",
+      "nameTrLabel": "Türkçe ad",
+      "descriptionEnLabel": "İngilizce açıklama (isteğe bağlı)",
+      "descriptionTrLabel": "Türkçe açıklama (isteğe bağlı)",
+      "genreIdLabel": "Tür ID",
+      "decisionNoteLabel": "Karar notu",
+      "decisionNotePlaceholder": "İsteğe bağlı — kısa bir mesaj.",
+      "decisionNoteOptional": "isteğe bağlı",
+      "approvedGenreToast": "'{{nameEn}}' türü oluşturuldu ve onaylandı.",
+      "approvedVarietyToast": "'{{nameEn}}' çeşidi oluşturuldu ve onaylandı.",
+      "rejectedToast": "İçerik başvurusu reddedildi."
+    },
     "errors": {
       "loadRequests": "Başvurular yüklenemedi.",
       "loadUsers": "Kullanıcılar yüklenemedi.",
       "loadCulturalTagRequests": "Kültürel etiket başvuruları yüklenemedi.",
+      "loadContentRequests": "İçerik başvuruları yüklenemedi.",
       "decisionFailed": "Karar kaydedilemedi.",
       "tagDecisionFailed": "Etiket kararı kaydedilemedi.",
+      "contentDecisionFailed": "Karar kaydedilemedi.",
       "updateFailed": "Kullanıcı güncellenemedi.",
       "deleteFailed": "Kullanıcı silinemedi."
     }

--- a/frontend/src/pages/Admin/AdminPage.tsx
+++ b/frontend/src/pages/Admin/AdminPage.tsx
@@ -5,6 +5,14 @@ import { adminService } from '@/services/admin-service'
 import type {
   AdminUser,
   AdminUserUpdate,
+  ApproveCulturalTagPayload,
+  ApproveDishGenrePayload,
+  ApproveDishVarietyPayload,
+  ContentRequestStatus,
+  CulturalTagRequest,
+  CulturalTagRequestStatus,
+  DishGenreRequest,
+  DishVarietyRequest,
   ExpertRequest,
   ExpertRequestStatus,
 } from '@/services/types/admin'
@@ -16,10 +24,11 @@ import { DecisionDialog } from '@/pages/Admin/Parts/DecisionDialog'
 import { EditUserDialog } from '@/pages/Admin/Parts/EditUserDialog'
 import { CulturalTagRequestRow } from '@/pages/Admin/Parts/CulturalTagRequestRow'
 import { ApproveCulturalTagDialog } from '@/pages/Admin/Parts/ApproveCulturalTagDialog'
-import type { CulturalTagRequest, CulturalTagRequestStatus, ApproveCulturalTagPayload } from '@/services/types/admin'
+import { ContentRequestRow } from '@/pages/Admin/Parts/ContentRequestRow'
+import { ApproveContentRequestDialog } from '@/pages/Admin/Parts/ApproveContentRequestDialog'
 import './AdminPage.css'
 
-type Tab = 'requests' | 'users' | 'culturalTags'
+type Tab = 'requests' | 'users' | 'culturalTags' | 'contentRequests'
 
 type Toast = { id: number; kind: 'success' | 'error'; message: string }
 
@@ -45,6 +54,7 @@ function extractError(err: unknown, fallback: string): string {
 
 const STATUSES: ExpertRequestStatus[] = ['pending', 'approved', 'rejected']
 const TAG_STATUSES: CulturalTagRequestStatus[] = ['pending', 'approved', 'rejected']
+const CONTENT_STATUSES: ContentRequestStatus[] = ['pending', 'approved', 'rejected']
 const ROLES_FOR_FILTER: UserRole[] = ['learner', 'cook', 'expert', 'admin']
 const PAGE_LIMIT = 20
 
@@ -261,10 +271,114 @@ export function AdminPage() {
     }
   }
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // Content Requests tab (dish genres + varieties)
+  // ─────────────────────────────────────────────────────────────────────────
+  const [contentSubtype, setContentSubtype] = useState<'genre' | 'variety'>('genre')
+  const [contentStatus, setContentStatus] = useState<ContentRequestStatus>('pending')
+  const [contentPage, setContentPage] = useState(1)
+  const [genreRequests, setGenreRequests] = useState<Pending<DishGenreRequest[]>>(initial())
+  const [genreTotal, setGenreTotal] = useState(0)
+  const [varietyRequests, setVarietyRequests] = useState<Pending<DishVarietyRequest[]>>(initial())
+  const [varietyTotal, setVarietyTotal] = useState(0)
+
+  const [approvingContent, setApprovingContent] = useState<DishGenreRequest | DishVarietyRequest | null>(null)
+  const [rejectingContent, setRejectingContent] = useState<DishGenreRequest | DishVarietyRequest | null>(null)
+  const [contentDecisionBusy, setContentDecisionBusy] = useState(false)
+
+  const reloadGenreRequests = useCallback(async () => {
+    setGenreRequests((s) => ({ ...s, status: 'loading', error: null }))
+    try {
+      const result = await adminService.listDishGenreRequests({
+        status: contentStatus,
+        page: contentPage,
+        limit: PAGE_LIMIT,
+      })
+      setGenreRequests({ status: 'succeeded', data: result.requests, error: null })
+      setGenreTotal(result.pagination.total)
+    } catch (err) {
+      setGenreRequests({
+        status: 'failed',
+        data: null,
+        error: extractError(err, t('admin.errors.loadContentRequests')),
+      })
+    }
+  }, [contentStatus, contentPage, t])
+
+  const reloadVarietyRequests = useCallback(async () => {
+    setVarietyRequests((s) => ({ ...s, status: 'loading', error: null }))
+    try {
+      const result = await adminService.listDishVarietyRequests({
+        status: contentStatus,
+        page: contentPage,
+        limit: PAGE_LIMIT,
+      })
+      setVarietyRequests({ status: 'succeeded', data: result.requests, error: null })
+      setVarietyTotal(result.pagination.total)
+    } catch (err) {
+      setVarietyRequests({
+        status: 'failed',
+        data: null,
+        error: extractError(err, t('admin.errors.loadContentRequests')),
+      })
+    }
+  }, [contentStatus, contentPage, t])
+
+  useEffect(() => {
+    if (tab === 'contentRequests') {
+      if (contentSubtype === 'genre') void reloadGenreRequests()
+      else void reloadVarietyRequests()
+    }
+  }, [tab, contentSubtype, reloadGenreRequests, reloadVarietyRequests])
+
+  async function handleApproveContent(payload: ApproveDishGenrePayload | ApproveDishVarietyPayload) {
+    if (!approvingContent) return
+    setContentDecisionBusy(true)
+    try {
+      if (contentSubtype === 'genre') {
+        await adminService.approveDishGenreRequest(approvingContent.id, payload as ApproveDishGenrePayload)
+        pushToast('success', t('admin.contentRequests.approvedGenreToast', { nameEn: (payload as ApproveDishGenrePayload).nameEn ?? approvingContent.nameEn ?? '' }))
+        setApprovingContent(null)
+        await reloadGenreRequests()
+      } else {
+        await adminService.approveDishVarietyRequest(approvingContent.id, payload as ApproveDishVarietyPayload)
+        pushToast('success', t('admin.contentRequests.approvedVarietyToast', { nameEn: (payload as ApproveDishVarietyPayload).nameEn ?? approvingContent.nameEn ?? '' }))
+        setApprovingContent(null)
+        await reloadVarietyRequests()
+      }
+    } catch (err) {
+      pushToast('error', extractError(err, t('admin.errors.contentDecisionFailed')))
+    } finally {
+      setContentDecisionBusy(false)
+    }
+  }
+
+  async function handleRejectContent(decisionNote: string) {
+    if (!rejectingContent) return
+    setContentDecisionBusy(true)
+    try {
+      if (contentSubtype === 'genre') {
+        await adminService.rejectDishGenreRequest(rejectingContent.id, { decisionNote: decisionNote || undefined })
+        await reloadGenreRequests()
+      } else {
+        await adminService.rejectDishVarietyRequest(rejectingContent.id, { decisionNote: decisionNote || undefined })
+        await reloadVarietyRequests()
+      }
+      pushToast('success', t('admin.contentRequests.rejectedToast'))
+      setRejectingContent(null)
+    } catch (err) {
+      pushToast('error', extractError(err, t('admin.errors.contentDecisionFailed')))
+    } finally {
+      setContentDecisionBusy(false)
+    }
+  }
+
   // Pagination labels are tiny enough to compute inline.
   const requestTotalPages = Math.max(1, Math.ceil(requestTotal / PAGE_LIMIT))
   const userTotalPages = Math.max(1, Math.ceil(userTotal / PAGE_LIMIT))
   const tagTotalPages = Math.max(1, Math.ceil(tagTotal / PAGE_LIMIT))
+  const genreTotalPages = Math.max(1, Math.ceil(genreTotal / PAGE_LIMIT))
+  const varietyTotalPages = Math.max(1, Math.ceil(varietyTotal / PAGE_LIMIT))
 
   const isApproveAction = decisionFor?.action === 'approve'
   const decisionTitle = useMemo(() => {
@@ -311,6 +425,15 @@ export function AdminPage() {
           onClick={() => setTab('culturalTags')}
         >
           {t('admin.tabs.culturalTags')}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'contentRequests'}
+          className={`admin-tab ${tab === 'contentRequests' ? 'admin-tab--active' : ''}`}
+          onClick={() => setTab('contentRequests')}
+        >
+          {t('admin.tabs.contentRequests')}
         </button>
       </nav>
 
@@ -522,6 +645,141 @@ export function AdminPage() {
         </section>
       )}
 
+      {tab === 'contentRequests' && (
+        <section className="admin-section" aria-labelledby="admin-content-requests-h">
+          <h2 id="admin-content-requests-h" className="sr-only">
+            {t('admin.tabs.contentRequests')}
+          </h2>
+
+          {/* Sub-type filter */}
+          <div className="admin-toolbar">
+            <div className="admin-chip-row" role="tablist" aria-label={t('admin.contentRequests.subfilterAria')}>
+              {(['genre', 'variety'] as const).map((sub) => (
+                <button
+                  key={sub}
+                  type="button"
+                  role="tab"
+                  aria-selected={contentSubtype === sub}
+                  className={`admin-chip ${contentSubtype === sub ? 'admin-chip--active' : ''}`}
+                  onClick={() => {
+                    setContentSubtype(sub)
+                    setContentPage(1)
+                  }}
+                >
+                  {t(`admin.contentRequests.subfilter.${sub}`)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Status filter */}
+          <div className="admin-toolbar">
+            <div className="admin-chip-row" role="tablist" aria-label={t('admin.contentRequests.statusAria')}>
+              {CONTENT_STATUSES.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  role="tab"
+                  aria-selected={contentStatus === s}
+                  className={`admin-chip ${contentStatus === s ? 'admin-chip--active' : ''}`}
+                  onClick={() => {
+                    setContentStatus(s)
+                    setContentPage(1)
+                  }}
+                >
+                  {t(`admin.requests.status.${s}`)}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="admin-btn admin-btn--ghost"
+              onClick={() => {
+                if (contentSubtype === 'genre') void reloadGenreRequests()
+                else void reloadVarietyRequests()
+              }}
+              disabled={
+                contentSubtype === 'genre'
+                  ? genreRequests.status === 'loading'
+                  : varietyRequests.status === 'loading'
+              }
+            >
+              {t('admin.refresh')}
+            </button>
+          </div>
+
+          {/* Genre requests list */}
+          {contentSubtype === 'genre' && (
+            <>
+              {genreRequests.status === 'loading' && (
+                <div className="admin-empty"><span className="ui-spinner" /></div>
+              )}
+              {genreRequests.status === 'failed' && (
+                <div className="admin-empty admin-empty--error">{genreRequests.error}</div>
+              )}
+              {genreRequests.status === 'succeeded' && genreRequests.data?.length === 0 && (
+                <div className="admin-empty">{t('admin.contentRequests.empty')}</div>
+              )}
+              {genreRequests.status === 'succeeded' && genreRequests.data && genreRequests.data.length > 0 && (
+                <ul className="admin-list">
+                  {genreRequests.data.map((r) => (
+                    <ContentRequestRow
+                      key={r.id}
+                      type="genre"
+                      request={r}
+                      onApprove={() => setApprovingContent(r)}
+                      onReject={() => setRejectingContent(r)}
+                    />
+                  ))}
+                </ul>
+              )}
+              <Pagination
+                page={contentPage}
+                totalPages={genreTotalPages}
+                onPrev={() => setContentPage((p) => Math.max(1, p - 1))}
+                onNext={() => setContentPage((p) => Math.min(genreTotalPages, p + 1))}
+                label={t('admin.pagination.label', { page: contentPage, total: genreTotalPages })}
+              />
+            </>
+          )}
+
+          {/* Variety requests list */}
+          {contentSubtype === 'variety' && (
+            <>
+              {varietyRequests.status === 'loading' && (
+                <div className="admin-empty"><span className="ui-spinner" /></div>
+              )}
+              {varietyRequests.status === 'failed' && (
+                <div className="admin-empty admin-empty--error">{varietyRequests.error}</div>
+              )}
+              {varietyRequests.status === 'succeeded' && varietyRequests.data?.length === 0 && (
+                <div className="admin-empty">{t('admin.contentRequests.empty')}</div>
+              )}
+              {varietyRequests.status === 'succeeded' && varietyRequests.data && varietyRequests.data.length > 0 && (
+                <ul className="admin-list">
+                  {varietyRequests.data.map((r) => (
+                    <ContentRequestRow
+                      key={r.id}
+                      type="variety"
+                      request={r}
+                      onApprove={() => setApprovingContent(r)}
+                      onReject={() => setRejectingContent(r)}
+                    />
+                  ))}
+                </ul>
+              )}
+              <Pagination
+                page={contentPage}
+                totalPages={varietyTotalPages}
+                onPrev={() => setContentPage((p) => Math.max(1, p - 1))}
+                onNext={() => setContentPage((p) => Math.min(varietyTotalPages, p + 1))}
+                label={t('admin.pagination.label', { page: contentPage, total: varietyTotalPages })}
+              />
+            </>
+          )}
+        </section>
+      )}
+
       {/* ── Modals ─────────────────────────────────────────────────────────── */}
       {decisionFor && (
         <DecisionDialog
@@ -555,6 +813,27 @@ export function AdminPage() {
           busy={tagDecisionBusy}
           onCancel={() => (tagDecisionBusy ? null : setRejectingTag(null))}
           onSubmit={(note) => void handleRejectTag(note)}
+        />
+      )}
+
+      {approvingContent && (
+        <ApproveContentRequestDialog
+          type={contentSubtype}
+          request={approvingContent}
+          busy={contentDecisionBusy}
+          onCancel={() => (contentDecisionBusy ? null : setApprovingContent(null))}
+          onSubmit={(payload) => void handleApproveContent(payload)}
+        />
+      )}
+
+      {rejectingContent && (
+        <DecisionDialog
+          title={t('admin.contentRequests.rejectTitle')}
+          confirmLabel={t('admin.contentRequests.rejectConfirm')}
+          confirmVariant="danger"
+          busy={contentDecisionBusy}
+          onCancel={() => (contentDecisionBusy ? null : setRejectingContent(null))}
+          onSubmit={(note) => void handleRejectContent(note)}
         />
       )}
 

--- a/frontend/src/pages/Admin/Parts/ApproveContentRequestDialog.tsx
+++ b/frontend/src/pages/Admin/Parts/ApproveContentRequestDialog.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type {
+  ApproveDishGenrePayload,
+  ApproveDishVarietyPayload,
+  DishGenreRequest,
+  DishVarietyRequest,
+} from '@/services/types/admin'
+
+interface Props {
+  type: 'genre' | 'variety'
+  request: DishGenreRequest | DishVarietyRequest
+  busy: boolean
+  onCancel: () => void
+  onSubmit: (payload: ApproveDishGenrePayload | ApproveDishVarietyPayload) => void
+}
+
+export function ApproveContentRequestDialog({ type, request, busy, onCancel, onSubmit }: Props) {
+  const { t } = useTranslation('common')
+  const titleId = useId()
+
+  const [nameEn, setNameEn] = useState(request.nameEn ?? '')
+  const [nameTr, setNameTr] = useState(request.nameTr ?? '')
+  const [descriptionEn, setDescriptionEn] = useState(request.descriptionEn ?? '')
+  const [descriptionTr, setDescriptionTr] = useState(request.descriptionTr ?? '')
+  const [genreId, setGenreId] = useState(
+    type === 'variety' ? String((request as DishVarietyRequest).genreId) : ''
+  )
+  const [note, setNote] = useState('')
+
+  const firstInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    firstInputRef.current?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !busy) onCancel()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = prevOverflow
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [busy, onCancel])
+
+  function handleSubmit() {
+    const en = nameEn.trim()
+    const tr = nameTr.trim()
+    const descEn = descriptionEn.trim()
+    const descTr = descriptionTr.trim()
+    const n = note.trim()
+
+    if (type === 'genre') {
+      const payload: ApproveDishGenrePayload = {}
+      if (en) payload.nameEn = en
+      if (tr) payload.nameTr = tr
+      if (descEn) payload.descriptionEn = descEn
+      if (descTr) payload.descriptionTr = descTr
+      if (n) payload.decisionNote = n
+      onSubmit(payload)
+    } else {
+      const payload: ApproveDishVarietyPayload = {}
+      if (en) payload.nameEn = en
+      if (tr) payload.nameTr = tr
+      if (descEn) payload.descriptionEn = descEn
+      if (descTr) payload.descriptionTr = descTr
+      const gid = Number(genreId)
+      if (Number.isInteger(gid) && gid > 0) payload.genreId = gid
+      if (n) payload.decisionNote = n
+      onSubmit(payload)
+    }
+  }
+
+  const nameEnId = useId()
+  const nameTrId = useId()
+  const descriptionEnId = useId()
+  const descriptionTrId = useId()
+  const genreIdInputId = useId()
+  const noteId = useId()
+
+  return (
+    <div className="admin-modal" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+      <div className="admin-modal__backdrop" onClick={() => (busy ? null : onCancel())} />
+      <div className="admin-modal__panel" role="document">
+        <h2 id={titleId} className="admin-modal__title">
+          {t('admin.contentRequests.approveTitle')}
+        </h2>
+
+        <label htmlFor={nameEnId} className="admin-field-label">
+          {t('admin.contentRequests.nameEnLabel')}
+        </label>
+        <input
+          id={nameEnId}
+          ref={firstInputRef}
+          type="text"
+          className="admin-input"
+          value={nameEn}
+          onChange={(e) => setNameEn(e.target.value)}
+          maxLength={200}
+          disabled={busy}
+          required
+        />
+
+        <label htmlFor={nameTrId} className="admin-field-label" style={{ marginTop: '0.75rem' }}>
+          {t('admin.contentRequests.nameTrLabel')}
+        </label>
+        <input
+          id={nameTrId}
+          type="text"
+          className="admin-input"
+          value={nameTr}
+          onChange={(e) => setNameTr(e.target.value)}
+          maxLength={200}
+          disabled={busy}
+        />
+
+        <label htmlFor={descriptionEnId} className="admin-field-label" style={{ marginTop: '0.75rem' }}>
+          {t('admin.contentRequests.descriptionEnLabel')}
+        </label>
+        <textarea
+          id={descriptionEnId}
+          className="admin-textarea"
+          value={descriptionEn}
+          onChange={(e) => setDescriptionEn(e.target.value)}
+          rows={3}
+          maxLength={2000}
+          disabled={busy}
+        />
+
+        <label htmlFor={descriptionTrId} className="admin-field-label" style={{ marginTop: '0.75rem' }}>
+          {t('admin.contentRequests.descriptionTrLabel')}
+        </label>
+        <textarea
+          id={descriptionTrId}
+          className="admin-textarea"
+          value={descriptionTr}
+          onChange={(e) => setDescriptionTr(e.target.value)}
+          rows={3}
+          maxLength={2000}
+          disabled={busy}
+        />
+
+        {type === 'variety' && (
+          <>
+            <label htmlFor={genreIdInputId} className="admin-field-label" style={{ marginTop: '0.75rem' }}>
+              {t('admin.contentRequests.genreIdLabel')}
+            </label>
+            <input
+              id={genreIdInputId}
+              type="number"
+              className="admin-input"
+              value={genreId}
+              onChange={(e) => setGenreId(e.target.value)}
+              min={1}
+              disabled={busy}
+            />
+          </>
+        )}
+
+        <label htmlFor={noteId} className="admin-field-label" style={{ marginTop: '0.75rem' }}>
+          {t('admin.contentRequests.decisionNoteLabel')}
+        </label>
+        <textarea
+          id={noteId}
+          className="admin-textarea"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder={t('admin.contentRequests.decisionNotePlaceholder')}
+          rows={3}
+          maxLength={2000}
+          disabled={busy}
+        />
+        <span className="admin-field-hint">
+          {note.length}/2000 — {t('admin.contentRequests.decisionNoteOptional')}
+        </span>
+
+        <div className="admin-modal__actions">
+          <button
+            type="button"
+            className="admin-btn admin-btn--ghost"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            {t('admin.cancel')}
+          </button>
+          <button
+            type="button"
+            className="admin-btn admin-btn--primary"
+            onClick={handleSubmit}
+            disabled={busy || !nameEn.trim()}
+            aria-busy={busy}
+          >
+            {busy ? <span className="ui-spinner" aria-hidden /> : t('admin.contentRequests.approveConfirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin/Parts/ContentRequestRow.tsx
+++ b/frontend/src/pages/Admin/Parts/ContentRequestRow.tsx
@@ -1,0 +1,95 @@
+import { useTranslation } from 'react-i18next'
+import type { DishGenreRequest, DishVarietyRequest } from '@/services/types/admin'
+
+interface Props {
+  type: 'genre' | 'variety'
+  request: DishGenreRequest | DishVarietyRequest
+  onApprove: () => void
+  onReject: () => void
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+export function ContentRequestRow({ type, request, onApprove, onReject }: Props) {
+  const { t } = useTranslation('common')
+  const isPending = request.status === 'pending'
+  const varietyRequest = request as DishVarietyRequest
+
+  return (
+    <li className="admin-card">
+      <div className="admin-card__head">
+        <div className="admin-card__heading">
+          <strong className="admin-card__title">
+            {request.requester?.username ?? t('admin.contentRequests.unknownRequester')}
+          </strong>
+          <span
+            className={`admin-badge admin-badge--${request.status}`}
+            aria-label={t(`admin.requests.status.${request.status}`)}
+          >
+            {t(`admin.requests.status.${request.status}`)}
+          </span>
+        </div>
+        <span className="admin-card__time">{formatDate(request.createdAt)}</span>
+      </div>
+
+      <dl className="admin-card__body">
+        <div>
+          <dt>{t('admin.contentRequests.nameEn')}</dt>
+          <dd>{request.nameEn ?? '—'}</dd>
+        </div>
+        <div>
+          <dt>{t('admin.contentRequests.nameTr')}</dt>
+          <dd>{request.nameTr ?? '—'}</dd>
+        </div>
+        {request.descriptionEn && (
+          <div>
+            <dt>{t('admin.contentRequests.descriptionEn')}</dt>
+            <dd>
+              {request.descriptionEn.length > 100
+                ? `${request.descriptionEn.slice(0, 100)}…`
+                : request.descriptionEn}
+            </dd>
+          </div>
+        )}
+        {type === 'variety' && (
+          <div>
+            <dt>{t('admin.contentRequests.genreId')}</dt>
+            <dd>{varietyRequest.genreId}</dd>
+          </div>
+        )}
+        {!isPending && (
+          <>
+            <div>
+              <dt>{t('admin.contentRequests.decisionAt')}</dt>
+              <dd>{formatDate(request.decidedAt)}</dd>
+            </div>
+            {request.decisionNote && (
+              <div>
+                <dt>{t('admin.contentRequests.decisionNote')}</dt>
+                <dd className="admin-card__reason">{request.decisionNote}</dd>
+              </div>
+            )}
+          </>
+        )}
+      </dl>
+
+      {isPending && (
+        <div className="admin-card__actions">
+          <button type="button" className="admin-btn admin-btn--primary" onClick={onApprove}>
+            {t('admin.contentRequests.approve')}
+          </button>
+          <button type="button" className="admin-btn admin-btn--danger" onClick={onReject}>
+            {t('admin.contentRequests.reject')}
+          </button>
+        </div>
+      )}
+    </li>
+  )
+}

--- a/frontend/src/services/admin-service.ts
+++ b/frontend/src/services/admin-service.ts
@@ -4,9 +4,16 @@ import type {
   AdminUserList,
   AdminUserUpdate,
   ApproveCulturalTagPayload,
+  ApproveDishGenrePayload,
+  ApproveDishVarietyPayload,
+  ContentRequestStatus,
   CulturalTagRequest,
   CulturalTagRequestList,
   CulturalTagRequestStatus,
+  DishGenreRequest,
+  DishGenreRequestList,
+  DishVarietyRequest,
+  DishVarietyRequestList,
   ExpertRequest,
   ExpertRequestList,
   ExpertRequestStatus,
@@ -119,6 +126,74 @@ export const adminService = {
   ): Promise<CulturalTagRequest> {
     const { data } = await httpClient.post<Envelope<CulturalTagRequest>>(
       `/admin/cultural-tag-requests/${id}/reject`,
+      payload
+    )
+    return data.data
+  },
+
+  // ── Dish genre requests ────────────────────────────────────────────────────
+
+  async listDishGenreRequests(
+    params: { status?: ContentRequestStatus; page?: number; limit?: number } = {}
+  ): Promise<DishGenreRequestList> {
+    const { data } = await httpClient.get<Envelope<DishGenreRequestList>>(
+      '/admin/dish-genre-requests',
+      { params: compact(params) }
+    )
+    return data.data
+  },
+
+  async approveDishGenreRequest(
+    id: number,
+    payload: ApproveDishGenrePayload = {}
+  ): Promise<DishGenreRequest> {
+    const { data } = await httpClient.post<Envelope<DishGenreRequest>>(
+      `/admin/dish-genre-requests/${id}/approve`,
+      payload
+    )
+    return data.data
+  },
+
+  async rejectDishGenreRequest(
+    id: number,
+    payload: { decisionNote?: string } = {}
+  ): Promise<DishGenreRequest> {
+    const { data } = await httpClient.post<Envelope<DishGenreRequest>>(
+      `/admin/dish-genre-requests/${id}/reject`,
+      payload
+    )
+    return data.data
+  },
+
+  // ── Dish variety requests ──────────────────────────────────────────────────
+
+  async listDishVarietyRequests(
+    params: { status?: ContentRequestStatus; page?: number; limit?: number } = {}
+  ): Promise<DishVarietyRequestList> {
+    const { data } = await httpClient.get<Envelope<DishVarietyRequestList>>(
+      '/admin/dish-variety-requests',
+      { params: compact(params) }
+    )
+    return data.data
+  },
+
+  async approveDishVarietyRequest(
+    id: number,
+    payload: ApproveDishVarietyPayload = {}
+  ): Promise<DishVarietyRequest> {
+    const { data } = await httpClient.post<Envelope<DishVarietyRequest>>(
+      `/admin/dish-variety-requests/${id}/approve`,
+      payload
+    )
+    return data.data
+  },
+
+  async rejectDishVarietyRequest(
+    id: number,
+    payload: { decisionNote?: string } = {}
+  ): Promise<DishVarietyRequest> {
+    const { data } = await httpClient.post<Envelope<DishVarietyRequest>>(
+      `/admin/dish-variety-requests/${id}/reject`,
       payload
     )
     return data.data

--- a/frontend/src/services/types/admin.ts
+++ b/frontend/src/services/types/admin.ts
@@ -85,3 +85,65 @@ export interface ApproveCulturalTagPayload {
   country?: string
   decisionNote?: string
 }
+
+// ── Dish genre requests ────────────────────────────────────────────────────────
+
+export type ContentRequestStatus = 'pending' | 'approved' | 'rejected'
+
+export interface DishGenreRequest {
+  id: number
+  nameEn: string | null
+  nameTr: string | null
+  descriptionEn: string | null
+  descriptionTr: string | null
+  status: ContentRequestStatus
+  decisionNote: string | null
+  decidedBy: string | null
+  createdAt: string
+  decidedAt: string | null
+  requester: { id: string; username: string } | null
+}
+
+export interface DishGenreRequestList {
+  requests: DishGenreRequest[]
+  pagination: { page: number; limit: number; total: number }
+}
+
+export interface ApproveDishGenrePayload {
+  nameEn?: string
+  nameTr?: string
+  descriptionEn?: string
+  descriptionTr?: string
+  decisionNote?: string
+}
+
+// ── Dish variety requests ──────────────────────────────────────────────────────
+
+export interface DishVarietyRequest {
+  id: number
+  genreId: number
+  nameEn: string | null
+  nameTr: string | null
+  descriptionEn: string | null
+  descriptionTr: string | null
+  status: ContentRequestStatus
+  decisionNote: string | null
+  decidedBy: string | null
+  createdAt: string
+  decidedAt: string | null
+  requester: { id: string; username: string } | null
+}
+
+export interface DishVarietyRequestList {
+  requests: DishVarietyRequest[]
+  pagination: { page: number; limit: number; total: number }
+}
+
+export interface ApproveDishVarietyPayload {
+  nameEn?: string
+  nameTr?: string
+  descriptionEn?: string
+  descriptionTr?: string
+  genreId?: number
+  decisionNote?: string
+}


### PR DESCRIPTION
Adds a "Content Requests" tab to the admin panel for reviewing expert-submitted dish genre and variety proposals.

## Changes
- New tab with Genres / Varieties sub-filter and pending/approved/rejected status filter
- Each card shows requester, nameEn, nameTr, description, and genreId (varieties only)
- Approve modal with pre-filled editable fields (nameEn required)
- Reject dialog with optional decision note
- Toast notifications for success and error cases
- New types and service methods for genre/variety request endpoints
- EN/TR locale strings added
- 11 integration tests added


closes #513 
closes #514 