### PR TITLE
[Frontend/Task] Add draft saving with publish and delete actions in profile (#428)

### DIFF
--- a/frontend/src/__tests__/integration/recipe-service-drafts.test.ts
+++ b/frontend/src/__tests__/integration/recipe-service-drafts.test.ts
@@ -1,0 +1,136 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { recipeService } from '@/services/recipe-service'
+
+const BASE = 'http://localhost/api'
+
+describe('recipeService drafts', () => {
+  describe('listDrafts()', () => {
+    it('calls GET /users/me/drafts and normalizes response', async () => {
+      let requestUrl: string | null = null
+
+      server.use(
+        http.get(`${BASE}/users/me/drafts`, ({ request }) => {
+          requestUrl = request.url
+          return HttpResponse.json({
+            success: true,
+            data: [
+              {
+                id: 'draft-1',
+                title: 'Untitled Stew',
+                type: 'community',
+                isPublished: false,
+                averageRating: null,
+                ratingCount: 0,
+                country: 'Turkey',
+                city: 'Istanbul',
+                district: null,
+                createdAt: '2026-05-09T12:00:00Z',
+                updatedAt: '2026-05-09T12:00:00Z',
+                coverImageUrl: null,
+              },
+              {
+                id: 'draft-2',
+                title: 'Cultural Sweet',
+                type: 'cultural',
+                isPublished: false,
+                averageRating: null,
+                ratingCount: 0,
+                country: null,
+                city: null,
+                district: null,
+                createdAt: '2026-05-08T10:00:00Z',
+                updatedAt: '2026-05-08T10:00:00Z',
+                coverImageUrl: 'https://example.com/img.jpg',
+              },
+            ],
+            error: null,
+          })
+        }),
+      )
+
+      const drafts = await recipeService.listDrafts()
+
+      expect(requestUrl).toContain('/users/me/drafts')
+      expect(drafts).toHaveLength(2)
+      expect(drafts[0]).toMatchObject({
+        id: 'draft-1',
+        title: 'Untitled Stew',
+        type: 'community',
+        isPublished: false,
+        country: 'Turkey',
+        city: 'Istanbul',
+      })
+      expect(drafts[1]).toMatchObject({
+        id: 'draft-2',
+        type: 'cultural',
+        coverImageUrl: 'https://example.com/img.jpg',
+      })
+    })
+
+    it('returns empty array when no drafts', async () => {
+      server.use(
+        http.get(`${BASE}/users/me/drafts`, () =>
+          HttpResponse.json({ success: true, data: [], error: null }),
+        ),
+      )
+
+      const drafts = await recipeService.listDrafts()
+      expect(drafts).toEqual([])
+    })
+
+    it('coerces numeric ids to strings and falls back to defaults', async () => {
+      server.use(
+        http.get(`${BASE}/users/me/drafts`, () =>
+          HttpResponse.json({
+            success: true,
+            data: [{ id: 42, title: null, type: 'unknown' }],
+            error: null,
+          }),
+        ),
+      )
+
+      const drafts = await recipeService.listDrafts()
+      expect(drafts[0].id).toBe('42')
+      expect(drafts[0].title).toBe('')
+      // unknown type falls back to community
+      expect(drafts[0].type).toBe('community')
+    })
+  })
+
+  describe('publish()', () => {
+    it('calls POST /recipes/:id/publish', async () => {
+      let requestUrl: string | null = null
+      let method: string | null = null
+
+      server.use(
+        http.post(`${BASE}/recipes/draft-1/publish`, ({ request }) => {
+          requestUrl = request.url
+          method = request.method
+          return HttpResponse.json({ success: true, data: null, error: null })
+        }),
+      )
+
+      await recipeService.publish('draft-1')
+
+      expect(method).toBe('POST')
+      expect(requestUrl).toContain('/recipes/draft-1/publish')
+    })
+  })
+
+  describe('delete()', () => {
+    it('calls DELETE /recipes/:id', async () => {
+      let method: string | null = null
+
+      server.use(
+        http.delete(`${BASE}/recipes/draft-1`, ({ request }) => {
+          method = request.method
+          return HttpResponse.json({ success: true, data: null, error: null })
+        }),
+      )
+
+      await recipeService.delete('draft-1')
+      expect(method).toBe('DELETE')
+    })
+  })
+})

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -164,7 +164,16 @@
     "noRecipes": "No recipes yet. Start creating!",
     "favorites": "Favorites",
     "noFavorites": "No favorites yet. Explore recipes!",
-    "seeAllFavorites": "See all {{count}} favorites"
+    "seeAllFavorites": "See all {{count}} favorites",
+    "drafts": "Drafts",
+    "noDrafts": "No drafts yet. Start creating a recipe!",
+    "draftEdit": "Edit",
+    "draftPublish": "Publish",
+    "draftDelete": "Delete",
+    "draftPublishConfirm": "Publish this recipe? It will be visible to everyone.",
+    "draftDeleteConfirm": "Delete this draft? This cannot be undone.",
+    "draftPublished": "Recipe published successfully.",
+    "draftDeleted": "Draft deleted."
   },
   "home": {
     "featured": "Featured Recipe",

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -164,7 +164,16 @@
     "noRecipes": "Henüz tarif yok. Oluşturmaya başla!",
     "favorites": "Favorilerim",
     "noFavorites": "Henüz favori yok. Tarifleri keşfet!",
-    "seeAllFavorites": "Tüm {{count}} favoriyi gör"
+    "seeAllFavorites": "Tüm {{count}} favoriyi gör",
+    "drafts": "Taslaklar",
+    "noDrafts": "Henüz taslak yok. Tarif oluşturmaya başlayın!",
+    "draftEdit": "Düzenle",
+    "draftPublish": "Yayınla",
+    "draftDelete": "Sil",
+    "draftPublishConfirm": "Bu tarif yayınlansın mı? Herkese görünür olacak.",
+    "draftDeleteConfirm": "Bu taslak silinsin mi? Bu işlem geri alınamaz.",
+    "draftPublished": "Tarif başarıyla yayınlandı.",
+    "draftDeleted": "Taslak silindi."
   },
   "home": {
     "featured": "Öne Çıkan Tarif",

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
@@ -124,8 +124,6 @@ interface RecipeDraft {
   steps: StepItem[]
   /** Numeric IDs from GET /dietary-tags where category === 'dietary' */
   dietaryTagIds: number[]
-  /** Numeric IDs from GET /dietary-tags where category === 'allergen' */
-  allergenTagIds: number[]
   /** Allergen IDs from GET /allergens — auto-detected via POST /allergens/detect */
   allergenIds: number[]
 }
@@ -144,7 +142,6 @@ const INITIAL_DRAFT: RecipeDraft = {
   tools: [''],
   steps: [{ text: '' }],
   dietaryTagIds: [],
-  allergenTagIds: [],
   allergenIds: [],
 }
 
@@ -298,7 +295,7 @@ export function CreateRecipePage() {
     setDraft((d) => ({ ...d, tools: d.tools.filter((_, i) => i !== idx) }))
 
   // tags
-  const toggleTag = (field: 'dietaryTagIds' | 'allergenTagIds', id: number) =>
+  const toggleTag = (field: 'dietaryTagIds', id: number) =>
     setDraft((d) => {
       const current = d[field]
       const next = current.includes(id) ? current.filter((x) => x !== id) : [...current, id]
@@ -372,7 +369,7 @@ export function CreateRecipePage() {
           .filter((t) => t.trim())
           .map((t) => ({ name: t.trim() })),
         isPublished: publish,
-        tagIds: [...draft.dietaryTagIds, ...draft.allergenTagIds],
+        tagIds: draft.dietaryTagIds,
         allergenIds: draft.allergenIds,
       })
       recipeCreated = true
@@ -805,33 +802,6 @@ export function CreateRecipePage() {
               </div>
             )}
 
-            {/* Allergen Tags */}
-            {allTags.filter((tag) => tag.category === 'allergen').length > 0 && (
-              <div className="cr-field">
-                <label className="cr-label">{t('create.fields.allergenTags')}</label>
-                <p className="cr-field-hint">{t('create.fields.allergenTagsHint')}</p>
-                <div className="cr-tag-grid">
-                  {allTags
-                    .filter((tag) => tag.category === 'allergen')
-                    .map((tag) => {
-                      const id = Number(tag.id)
-                      const checked = draft.allergenTagIds.includes(id)
-                      return (
-                        <label key={tag.id} className={`cr-tag-chip cr-tag-chip--allergen${checked ? ' cr-tag-chip--active' : ''}`}>
-                          <input
-                            type="checkbox"
-                            className="cr-tag-chip__input"
-                            checked={checked}
-                            onChange={() => toggleTag('allergenTagIds', id)}
-                          />
-                          {tag.name}
-                        </label>
-                      )
-                    })}
-                </div>
-              </div>
-            )}
-
 
             {/* Photos & video (upload after recipe is created) */}
             <div className="cr-field cr-media">
@@ -1120,18 +1090,12 @@ export function CreateRecipePage() {
                 )}
               </div>
 
-              {(draft.dietaryTagIds.length > 0 || draft.allergenTagIds.length > 0 || draft.allergenIds.length > 0) && (
+              {(draft.dietaryTagIds.length > 0 || draft.allergenIds.length > 0) && (
                 <div className="cr-review-card__tags">
                   {draft.dietaryTagIds.map((id) => {
                     const tag = allTags.find((t) => Number(t.id) === id)
                     return tag ? (
                       <span key={id} className="cr-review-tag cr-review-tag--dietary">{tag.name}</span>
-                    ) : null
-                  })}
-                  {draft.allergenTagIds.map((id) => {
-                    const tag = allTags.find((t) => Number(t.id) === id)
-                    return tag ? (
-                      <span key={id} className="cr-review-tag cr-review-tag--allergen">⚠ {tag.name}</span>
                     ) : null
                   })}
                   {draft.allergenIds.map((id) => {

--- a/frontend/src/pages/Profile/ProfilePage.css
+++ b/frontend/src/pages/Profile/ProfilePage.css
@@ -288,3 +288,88 @@
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
 }
+
+/* ── Drafts ─────────────────────────────────────────────────────────────────── */
+
+.profile-page__draft-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.profile-page__draft-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.profile-page__draft-thumb {
+  width: 52px;
+  height: 52px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--surface-muted);
+}
+
+.profile-page__draft-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-page__draft-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile-page__draft-actions {
+  display: flex;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+.profile-page__draft-btn {
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: opacity 0.15s;
+}
+
+.profile-page__draft-btn:hover { opacity: 0.8; }
+
+.profile-page__draft-btn--edit {
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  border-color: var(--border-subtle);
+}
+
+.profile-page__draft-btn--publish {
+  background: var(--color-main);
+  color: #fff;
+}
+
+.profile-page__draft-btn--delete {
+  background: transparent;
+  color: var(--color-error, #e53e3e);
+  border-color: var(--color-error, #e53e3e);
+}
+
+.profile-page__error {
+  margin: 0 0 var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-error-bg, #fff5f5);
+  color: var(--color-error, #e53e3e);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+}

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { isAxiosError } from 'axios'
 import { useAppSelector } from '@/store/hooks'
 import { recipeService, type MyRecipeSummary } from '@/services/recipe-service'
 import { favoriteService, type FavoriteRecipe } from '@/services/favorite-service'
@@ -21,18 +22,58 @@ export function ProfilePage() {
 
   const [recipes, setRecipes] = useState<MyRecipeSummary[]>([])
   const [recipesLoading, setRecipesLoading] = useState(true)
+  const [drafts, setDrafts] = useState<MyRecipeSummary[]>([])
+  const [draftsLoading, setDraftsLoading] = useState(true)
+  const [draftActionError, setDraftActionError] = useState<string | null>(null)
   const [favorites, setFavorites] = useState<FavoriteRecipe[]>([])
   const [favoritesTotal, setFavoritesTotal] = useState(0)
   const [favoritesLoading, setFavoritesLoading] = useState(true)
 
   useEffect(() => {
     let cancelled = false
-    recipeService.getMyRecipes()
+    recipeService.getMyRecipes('published')
       .then((data) => { if (!cancelled) setRecipes(data) })
       .catch(() => { if (!cancelled) setRecipes([]) })
       .finally(() => { if (!cancelled) setRecipesLoading(false) })
     return () => { cancelled = true }
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    recipeService.listDrafts()
+      .then((data) => { if (!cancelled) setDrafts(data) })
+      .catch(() => { if (!cancelled) setDrafts([]) })
+      .finally(() => { if (!cancelled) setDraftsLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  const handlePublishDraft = async (id: string) => {
+    if (!window.confirm(t('profileScreen.draftPublishConfirm'))) return
+    setDraftActionError(null)
+    try {
+      await recipeService.publish(id)
+      const updated = await recipeService.listDrafts()
+      setDrafts(updated)
+      const published = await recipeService.getMyRecipes('published')
+      setRecipes(published)
+    } catch (err) {
+      const msg = isAxiosError(err)
+        ? (err.response?.data as any)?.error?.message
+        : null
+      setDraftActionError(msg || t('profileScreen.draftPublished'))
+    }
+  }
+
+  const handleDeleteDraft = async (id: string) => {
+    if (!window.confirm(t('profileScreen.draftDeleteConfirm'))) return
+    setDraftActionError(null)
+    try {
+      await recipeService.delete(id)
+      setDrafts((prev) => prev.filter((d) => d.id !== id))
+    } catch {
+      setDraftActionError(t('profileScreen.draftDeleted'))
+    }
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -48,8 +89,7 @@ export function ProfilePage() {
     return () => { cancelled = true }
   }, [])
 
-  const publishedRecipes = recipes.filter((r) => r.isPublished)
-  const draftCount = recipes.filter((r) => !r.isPublished).length
+  const publishedRecipes = recipes
   const recentPublished = publishedRecipes.slice(0, 5)
 
   const initials = profile.username
@@ -84,10 +124,10 @@ export function ProfilePage() {
       </div>
 
       {/* ── Stats ── */}
-      {!recipesLoading && (
+      {!recipesLoading && !draftsLoading && (
         <div className="profile-page__stats">
           <div className="profile-page__stat">
-            <span className="profile-page__stat-val">{recipes.length}</span>
+            <span className="profile-page__stat-val">{publishedRecipes.length + drafts.length}</span>
             <span className="profile-page__stat-label">{t('profileScreen.statTotal')}</span>
           </div>
           <div className="profile-page__stat-divider" />
@@ -97,10 +137,65 @@ export function ProfilePage() {
           </div>
           <div className="profile-page__stat-divider" />
           <div className="profile-page__stat">
-            <span className="profile-page__stat-val">{draftCount}</span>
+            <span className="profile-page__stat-val">{drafts.length}</span>
             <span className="profile-page__stat-label">{t('profileScreen.statDraft')}</span>
           </div>
         </div>
+      )}
+
+      {/* ── Drafts ── */}
+      {!draftsLoading && (
+        <section className="profile-page__section">
+          <h2 className="profile-page__section-title">{t('profileScreen.drafts')}</h2>
+          {draftActionError && (
+            <p className="profile-page__error">{draftActionError}</p>
+          )}
+          {drafts.length === 0 ? (
+            <p className="profile-page__empty">{t('profileScreen.noDrafts')}</p>
+          ) : (
+            <div className="profile-page__draft-list">
+              {drafts.map((draft) => (
+                <div key={draft.id} className="profile-page__draft-card">
+                  <div className="profile-page__draft-thumb">
+                    {draft.coverImageUrl
+                      ? <img src={draft.coverImageUrl} alt={draft.title} loading="lazy" />
+                      : <div className="profile-page__recipe-placeholder" />
+                    }
+                  </div>
+                  <div className="profile-page__draft-body">
+                    <p className="profile-page__recipe-title">{draft.title}</p>
+                    <span className={`profile-page__type profile-page__type--${draft.type}`}>
+                      {t(draft.type === 'cultural' ? 'library.typeCultural' : 'library.typeCommunity')}
+                    </span>
+                  </div>
+                  <div className="profile-page__draft-actions">
+                    <button
+                      type="button"
+                      className="profile-page__draft-btn profile-page__draft-btn--edit"
+                      onClick={() => navigate(`/recipes/${draft.id}/edit`)}
+                    >
+                      {t('profileScreen.draftEdit')}
+                    </button>
+                    <button
+                      type="button"
+                      className="profile-page__draft-btn profile-page__draft-btn--publish"
+                      onClick={() => void handlePublishDraft(draft.id)}
+                    >
+                      {t('profileScreen.draftPublish')}
+                    </button>
+                    <button
+                      type="button"
+                      className="profile-page__draft-btn profile-page__draft-btn--delete"
+                      onClick={() => void handleDeleteDraft(draft.id)}
+                    >
+                      {t('profileScreen.draftDelete')}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
       )}
 
       {/* ── Recent published recipes ── */}
@@ -150,7 +245,7 @@ export function ProfilePage() {
         </section>
       )}
 
-      {!recipesLoading && recipes.length === 0 && (
+      {!recipesLoading && publishedRecipes.length === 0 && (
         <p className="profile-page__empty">{t('profileScreen.noRecipes')}</p>
       )}
 

--- a/frontend/src/services/recipe-service.ts
+++ b/frontend/src/services/recipe-service.ts
@@ -221,6 +221,28 @@ export const recipeService = {
   },
 
   /**
+   * GET /users/me/drafts — list unpublished recipes belonging to the authenticated user.
+   */
+  listDrafts: async (): Promise<MyRecipeSummary[]> => {
+    const res = await httpClient.get('/users/me/drafts')
+    const raw: unknown[] = Array.isArray(res.data?.data) ? res.data.data : []
+    return raw.map((r: any) => ({
+      id: String(r.id),
+      title: r.title ?? '',
+      type: r.type === 'cultural' ? 'cultural' : 'community',
+      isPublished: r.isPublished ?? false,
+      averageRating: r.averageRating ?? null,
+      ratingCount: r.ratingCount ?? 0,
+      country: r.country ?? null,
+      city: r.city ?? null,
+      district: r.district ?? null,
+      createdAt: r.createdAt ?? '',
+      updatedAt: r.updatedAt ?? '',
+      coverImageUrl: r.coverImageUrl ?? null,
+    }))
+  },
+
+  /**
    * GET /recipes/mine — list all recipes belonging to the authenticated user.
    * Optional status filter: 'published' | 'draft'
    */


### PR DESCRIPTION


## What

- Adds a `listDrafts()` call to `recipeService` that hits `GET /users/me/drafts` and normalizes the response (id coercion to string, default fallbacks for missing fields).
- Adds a **Drafts** section to the Profile page that lists every unpublished recipe belonging to the current user, with three actions per draft:
  - **Edit** — navigates to `/recipes/:id/edit`
  - **Publish** — confirms via `window.confirm`, calls `POST /recipes/:id/publish`, then refreshes both the drafts list and the published-recipes list so the card moves into the "Recent Recipes" section.
  - **Delete** — confirms, calls `DELETE /recipes/:id`, removes the card from local state.
- Profile stats now reflect the split between drafts (from the new endpoint) and published recipes (from `getMyRecipes('published')`).
- Cleanup: removed the standalone "Allergen Tags" checkbox group from step 1 of the recipe creation wizard. Allergens are now solely managed in the dedicated step 3 introduced in #191, and `allergenTagIds` has been dropped from the draft state and submit payload.

## How to test

1. Start a recipe creation flow and click **Save as Draft** at any step ≥ 1 — recipe is saved with `isPublished: false`.
2. Open `/profile` — the new **Drafts** section lists the just-saved recipe with Edit / Publish / Delete buttons. Stats panel reflects `drafts: 1`.
3. Click **Edit** — opens the existing edit recipe screen.
4. Click **Publish** — after confirmation, the draft disappears from the Drafts list and shows up under "Recent Recipes". Stats update.
5. Click **Delete** on another draft — after confirmation, the card disappears. Refresh the page — it should still be gone.
6. Create a recipe end-to-end: step 1 shows no "Allergen Tags" group anymore. Step 3 (Allergens) is the only place allergens are managed; submit payload sends only `tagIds` (dietary) and `allergenIds` (auto-detected).

## Tests

`recipe-service-drafts.test.ts` — 5 tests:
- `listDrafts()` calls `GET /users/me/drafts` and normalizes the response
- Returns `[]` when the endpoint returns no drafts
- Coerces numeric ids to strings, falls back to defaults for missing fields, defaults unknown `type` to `community`
- `publish(id)` calls `POST /recipes/:id/publish`
- `delete(id)` calls `DELETE /recipes/:id`

## Related issue

Closes #428
