### PR TITLE
[Mobile/Feature] Integrate cultural tag API

### DIFF
--- a/mobile/src/__tests__/api.cultural-tags.test.ts
+++ b/mobile/src/__tests__/api.cultural-tags.test.ts
@@ -1,39 +1,57 @@
-import {
-  getCulturalTags,
-  pickCulturalTagLabel,
-  getMockCulturalTagsForRecipe,
-} from '../api/cultural-tags';
+import { getCulturalTags, pickCulturalTagLabel } from '../api/cultural-tags';
+import { fetchApi } from '../api/client';
 
 jest.mock('../api/client', () => ({
-  mockDelay: jest.fn().mockResolvedValue(undefined),
+  fetchApi: jest.fn(),
 }));
 
+const mockedFetchApi = fetchApi as jest.MockedFunction<typeof fetchApi>;
+
 describe('getCulturalTags', () => {
-  it('returns the full taxonomy when no country is given', async () => {
-    const tags = await getCulturalTags();
-    expect(tags.length).toBeGreaterThanOrEqual(10);
-    expect(tags.find((t) => t.key === 'wedding')).toBeDefined();
-    expect(tags.find((t) => t.key === 'mochitsuki')).toBeDefined();
+  beforeEach(() => {
+    mockedFetchApi.mockReset();
   });
 
-  it('returns global tags plus country-scoped tags when country = Turkey', async () => {
-    const tags = await getCulturalTags('Turkey');
-    expect(tags.find((t) => t.key === 'sira-gecesi')).toBeDefined();
-    expect(tags.find((t) => t.key === 'iftar')).toBeDefined();
-    expect(tags.find((t) => t.key === 'mochitsuki')).toBeUndefined();
-    // global tags still present
-    expect(tags.find((t) => t.key === 'wedding')).toBeDefined();
+  it('calls /cultural-tags without query params when no country given', async () => {
+    mockedFetchApi.mockResolvedValueOnce([]);
+    await getCulturalTags();
+    expect(mockedFetchApi).toHaveBeenCalledWith('/cultural-tags');
   });
 
-  it('matches country case-insensitively', async () => {
-    const tags = await getCulturalTags('japan');
-    expect(tags.find((t) => t.key === 'mochitsuki')).toBeDefined();
-    expect(tags.find((t) => t.key === 'sira-gecesi')).toBeUndefined();
+  it('passes country as a query param', async () => {
+    mockedFetchApi.mockResolvedValueOnce([]);
+    await getCulturalTags('Turkey');
+    expect(mockedFetchApi).toHaveBeenCalledWith('/cultural-tags?country=Turkey');
   });
 
-  it('treats empty/whitespace country as global-only filter (returns full list)', async () => {
-    const tags = await getCulturalTags('');
-    expect(tags.length).toBeGreaterThanOrEqual(10);
+  it('URL-encodes countries with special characters', async () => {
+    mockedFetchApi.mockResolvedValueOnce([]);
+    await getCulturalTags('United Kingdom');
+    expect(mockedFetchApi).toHaveBeenCalledWith(
+      '/cultural-tags?country=United%20Kingdom',
+    );
+  });
+
+  it('treats empty string as no country', async () => {
+    mockedFetchApi.mockResolvedValueOnce([]);
+    await getCulturalTags('');
+    expect(mockedFetchApi).toHaveBeenCalledWith('/cultural-tags');
+  });
+
+  it('returns the array resolved by fetchApi', async () => {
+    const tags = [
+      { id: 1, key: 'wedding', labelEn: 'Wedding', labelTr: 'Düğün', country: null },
+    ];
+    mockedFetchApi.mockResolvedValueOnce(tags);
+    await expect(getCulturalTags()).resolves.toEqual(tags);
+  });
+
+  it('falls back to [] and logs when fetchApi rejects', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockedFetchApi.mockRejectedValueOnce(new Error('network down'));
+    await expect(getCulturalTags('Turkey')).resolves.toEqual([]);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 });
 
@@ -56,63 +74,5 @@ describe('pickCulturalTagLabel', () => {
 
   it('falls back to English for unknown locales', () => {
     expect(pickCulturalTagLabel(tag, 'de')).toBe('Wedding');
-  });
-});
-
-describe('getMockCulturalTagsForRecipe', () => {
-  it('returns deterministic tags for the same recipe id', () => {
-    const a = getMockCulturalTagsForRecipe('recipe-42', null);
-    const b = getMockCulturalTagsForRecipe('recipe-42', null);
-    expect(a).toEqual(b);
-  });
-
-  it('returns different selections for different recipe ids', () => {
-    // Across a wide id space, at least one pair should differ. This protects
-    // against a regression that would always pick the same tag.
-    const samples = ['r-1', 'r-2', 'r-3', 'r-4', 'r-5'].map((id) =>
-      getMockCulturalTagsForRecipe(id, null).map((t) => t.id).join(','),
-    );
-    const unique = new Set(samples);
-    expect(unique.size).toBeGreaterThan(1);
-  });
-
-  it('returns 1 or 2 tags', () => {
-    const tags = getMockCulturalTagsForRecipe('recipe-id', null);
-    expect(tags.length).toBeGreaterThanOrEqual(1);
-    expect(tags.length).toBeLessThanOrEqual(2);
-  });
-
-  it('never returns duplicate tag ids in the result', () => {
-    for (const id of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']) {
-      const tags = getMockCulturalTagsForRecipe(id, null);
-      const ids = tags.map((t) => t.id);
-      expect(new Set(ids).size).toBe(ids.length);
-    }
-  });
-
-  it('respects country scoping (Japan-only set excludes Turkey-only tags)', () => {
-    // Across many ids, every returned tag for country=Japan must be either
-    // global (country=null) or Japan-scoped — never a Turkey-only tag.
-    for (const id of ['j1', 'j2', 'j3', 'j4', 'j5']) {
-      const tags = getMockCulturalTagsForRecipe(id, 'Japan');
-      for (const tag of tags) {
-        expect(tag.country === null || tag.country === 'Japan').toBe(true);
-      }
-    }
-  });
-
-  it('matches country case-insensitively', () => {
-    const upper = getMockCulturalTagsForRecipe('same-id', 'TURKEY');
-    const lower = getMockCulturalTagsForRecipe('same-id', 'turkey');
-    expect(upper).toEqual(lower);
-  });
-
-  it('returns an empty array for an unknown country with no global pool overlap is impossible (sanity check global tags exist)', () => {
-    // Even with a country that matches nothing, global tags are still eligible.
-    const tags = getMockCulturalTagsForRecipe('id', 'Atlantis');
-    expect(tags.length).toBeGreaterThan(0);
-    for (const tag of tags) {
-      expect(tag.country).toBeNull();
-    }
   });
 });

--- a/mobile/src/__tests__/recipeMapper.cultural.test.ts
+++ b/mobile/src/__tests__/recipeMapper.cultural.test.ts
@@ -35,48 +35,25 @@ function makeBackendRecipe(
 }
 
 describe('mapBackendRecipeToMobile cultural tags', () => {
-  it('uses backend-provided culturalTags verbatim when present', () => {
+  it('passes backend-provided culturalTags through verbatim', () => {
     const provided: CulturalTagItem[] = [
       { id: 99, key: 'iftar', labelEn: 'Iftar', labelTr: 'İftar', country: 'Turkey' },
     ];
     const result = mapBackendRecipeToMobile(
-      makeBackendRecipe({ culturalTags: provided } as Partial<BackendRecipeDetail> & {
-        culturalTags: CulturalTagItem[];
-      }),
+      makeBackendRecipe({ culturalTags: provided }),
     );
     expect(result.culturalTags).toBe(provided);
   });
 
-  it('falls back to mock tags when backend payload omits culturalTags', () => {
+  it('returns [] when backend payload omits culturalTags', () => {
     const result = mapBackendRecipeToMobile(makeBackendRecipe());
-    expect(result.culturalTags.length).toBeGreaterThan(0);
-    // All fallback tags must be eligible for the recipe's country
-    for (const tag of result.culturalTags) {
-      expect(tag.country === null || tag.country === 'Turkey').toBe(true);
-    }
+    expect(result.culturalTags).toEqual([]);
   });
 
-  it('fallback is deterministic for the same recipe id+country', () => {
-    const a = mapBackendRecipeToMobile(makeBackendRecipe());
-    const b = mapBackendRecipeToMobile(makeBackendRecipe());
-    expect(a.culturalTags.map((t) => t.id)).toEqual(b.culturalTags.map((t) => t.id));
-  });
-
-  it('different recipe ids can produce different fallback tag sets', () => {
-    const sets = new Set(
-      ['r-a', 'r-b', 'r-c', 'r-d', 'r-e'].map((id) =>
-        mapBackendRecipeToMobile(makeBackendRecipe({ id }))
-          .culturalTags.map((t) => t.id)
-          .join(','),
-      ),
+  it('returns [] when backend payload sets culturalTags to an empty array', () => {
+    const result = mapBackendRecipeToMobile(
+      makeBackendRecipe({ culturalTags: [] }),
     );
-    expect(sets.size).toBeGreaterThan(1);
-  });
-
-  it('respects country scoping in the fallback (Japan recipe never gets Turkey-only tags)', () => {
-    const result = mapBackendRecipeToMobile(makeBackendRecipe({ country: 'Japan' }));
-    for (const tag of result.culturalTags) {
-      expect(tag.country === null || tag.country === 'Japan').toBe(true);
-    }
+    expect(result.culturalTags).toEqual([]);
   });
 });

--- a/mobile/src/api/cultural-tags.ts
+++ b/mobile/src/api/cultural-tags.ts
@@ -1,18 +1,4 @@
-// TODO: replace mock implementation with `fetchApi` once GET /cultural-tags ships.
-// The shape below mirrors the planned API: a region-scoped lookup keyed off the
-// user's selected country. Tags whose `country` is null are global and are
-// always returned.
-//
-// Once the backend is live, swap the body of `getCulturalTags` for:
-//   const qs = country ? `?country=${encodeURIComponent(country)}` : '';
-//   try {
-//     return await fetchApi<CulturalTagItem[]>(`/cultural-tags${qs}`);
-//   } catch (err) {
-//     console.error('getCulturalTags error:', err);
-//     return [];
-//   }
-
-import { mockDelay } from './client';
+import { fetchApi } from './client';
 
 export interface CulturalTagItem {
   id: number;
@@ -22,54 +8,16 @@ export interface CulturalTagItem {
   country: string | null;
 }
 
-const MOCK_CULTURAL_TAGS: CulturalTagItem[] = [
-  { id: 1, key: 'wedding',          labelEn: 'Wedding',             labelTr: 'Düğün',           country: null },
-  { id: 2, key: 'funeral',          labelEn: 'Funeral / Mourning',  labelTr: 'Cenaze / Yas',    country: null },
-  { id: 3, key: 'birth',            labelEn: 'Birth / Newborn',     labelTr: 'Doğum',           country: null },
-  { id: 4, key: 'new-year',         labelEn: 'New Year',            labelTr: 'Yılbaşı',         country: null },
-  { id: 5, key: 'harvest',          labelEn: 'Harvest',             labelTr: 'Hasat',           country: null },
-  { id: 6, key: 'religious-feast',  labelEn: 'Religious Feast',     labelTr: 'Dini Bayram',     country: null },
-  { id: 7, key: 'social-gathering', labelEn: 'Social Gathering',    labelTr: 'Sosyal Toplantı', country: null },
-  { id: 8, key: 'sira-gecesi',      labelEn: 'Sıra Gecesi',         labelTr: 'Sıra Gecesi',     country: 'Turkey' },
-  { id: 9, key: 'iftar',            labelEn: 'Iftar',               labelTr: 'İftar',           country: 'Turkey' },
-  { id: 10, key: 'mochitsuki',      labelEn: 'Mochitsuki',          labelTr: 'Mochitsuki',      country: 'Japan' },
-];
-
 export async function getCulturalTags(country?: string | null): Promise<CulturalTagItem[]> {
-  await mockDelay(150);
-  if (!country) {
-    return MOCK_CULTURAL_TAGS;
+  const qs = country ? `?country=${encodeURIComponent(country)}` : '';
+  try {
+    return await fetchApi<CulturalTagItem[]>(`/cultural-tags${qs}`);
+  } catch (err) {
+    console.error('getCulturalTags error:', err);
+    return [];
   }
-  const normalized = country.trim().toLowerCase();
-  return MOCK_CULTURAL_TAGS.filter(
-    (tag) => tag.country === null || tag.country.toLowerCase() === normalized,
-  );
 }
 
 export function pickCulturalTagLabel(tag: CulturalTagItem, locale: string): string {
   return locale.startsWith('tr') ? tag.labelTr : tag.labelEn;
-}
-
-// MOCK FALLBACK — remove once the backend returns `culturalTags` on the
-// recipe-detail payload. Picks 2 deterministic tags based on a hash of the
-// recipe id, scoped to the recipe's country, so different recipes display
-// different tags and the UI is visibly populated.
-export function getMockCulturalTagsForRecipe(
-  recipeId: string,
-  country: string | null,
-): CulturalTagItem[] {
-  const eligible = country
-    ? MOCK_CULTURAL_TAGS.filter(
-        (tag) =>
-          tag.country === null ||
-          tag.country.toLowerCase() === country.trim().toLowerCase(),
-      )
-    : MOCK_CULTURAL_TAGS;
-  if (eligible.length === 0) return [];
-
-  const hash = [...recipeId].reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  const first = eligible[hash % eligible.length];
-  const second = eligible[(hash * 7 + 3) % eligible.length];
-  if (!second || second.id === first.id) return [first];
-  return [first, second];
 }

--- a/mobile/src/api/recipeMapper.ts
+++ b/mobile/src/api/recipeMapper.ts
@@ -1,7 +1,6 @@
 import type { Recipe } from '../types/recipe';
 import type { AllergenTag, DietaryTag, MeasurementUnit, UserRole } from '../types/common';
 import type { BackendRecipeDetail } from './recipes';
-import { getMockCulturalTagsForRecipe } from './cultural-tags';
 
 const ALLERGEN_MAP: Record<string, AllergenTag> = {
   peanuts: 'PEANUTS',
@@ -132,13 +131,7 @@ export function mapBackendRecipeToMobile(data: BackendRecipeDetail): Recipe {
     dishVarietyName: data.dishVarietyName ?? '',
     tags,
     allergens,
-    // Cultural tags ride along once the backend ships /cultural-tags. Until
-    // then, fall back to a deterministic mock so Recipe Detail has visible
-    // chips. Drop `getMockCulturalTagsForRecipe` once the backend returns
-    // `culturalTags` on the payload.
-    culturalTags:
-      (data as { culturalTags?: Recipe['culturalTags'] }).culturalTags ??
-      getMockCulturalTagsForRecipe(data.id, data.country ?? null),
+    culturalTags: data.culturalTags ?? [],
     status: data.isPublished ? 'PUBLISHED' : 'DRAFT',
     createdAt: data.createdAt,
     updatedAt: data.updatedAt,

--- a/mobile/src/api/recipes.ts
+++ b/mobile/src/api/recipes.ts
@@ -1,4 +1,5 @@
 import { fetchApi } from './client';
+import type { CulturalTagItem } from './cultural-tags';
 
 export interface CreateRecipeStep {
   stepOrder: number;
@@ -164,6 +165,7 @@ export interface BackendRecipeDetail {
   tools: BackendTool[];
   media: BackendMedia[];
   tags: BackendTag[];
+  culturalTags?: CulturalTagItem[];
   country: string | null;
   city: string | null;
   district: string | null;

--- a/mobile/src/components/create-basic/CreateBasicInfoScreen.tsx
+++ b/mobile/src/components/create-basic/CreateBasicInfoScreen.tsx
@@ -770,7 +770,7 @@ const styles = StyleSheet.create({
   },
   // ── Cultural Tags ──
   culturalTagsBlock: {
-    marginTop: spacing.lg,
+    marginTop: -spacing["2xl"],
   },
   culturalTagsHelp: {
     fontFamily: fonts.sans,


### PR DESCRIPTION
## What does this PR do?
Replaces the cultural-tagging mocks with real API calls. `getCulturalTags()` now hits `GET /cultural-tags` (with optional `country` query), and the recipe-detail mapper reads `culturalTags` directly from the backend payload — the deterministic mock fallback and the entire mock taxonomy are gone. Also tightens the gap between the Story field and the Cultural Tags chips in Step 1 of the Create wizard.

## How to test
1. Pull the branch and run `cd mobile && npm test` — all 30 suites should pass
2. `npm start`, sign in as a cook or expert
3. Search tab → open Filters → pick a country → confirm cultural-tag chips render real data and filter results
4. Create → Step 1 → pick a country → confirm cultural-tag chips load from the API; the Story field and the chips should sit close together
5. Open a recipe known to have cultural tags on the backend → chips render on the detail screen
6. Open a recipe with none → no chips, no crash

## Related issue
Closes #526