### PR TITLE
[Frontend/Task] Video step annotations and voice input for recipe creation (#414, #423)

### DIFF
--- a/frontend/src/__tests__/integration/parse-service-audio.test.ts
+++ b/frontend/src/__tests__/integration/parse-service-audio.test.ts
@@ -1,0 +1,108 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { parseService } from '@/services/parse-service'
+
+const BASE = 'http://localhost/api'
+
+describe('parseService.parseRecipeAudio()', () => {
+  it('hits POST /parse/recipe-audio with multipart content-type', async () => {
+    let contentType: string | null = null
+    let bodyPresent = false
+
+    server.use(
+      http.post(`${BASE}/parse/recipe-audio`, async ({ request }) => {
+        contentType = request.headers.get('content-type')
+        bodyPresent = request.body !== null
+        return HttpResponse.json({
+          success: true,
+          data: {
+            transcription: {
+              text: 'Heat olive oil. Add onions.',
+              languageCode: 'en',
+              languageProbability: 0.97,
+              truncated: false,
+              source: 'audio',
+            },
+            recipe: {
+              title: 'Caramelized Onions',
+              ingredients: [{ name: 'onion', quantity: 2, unit: 'pcs' }],
+              steps: [{ stepOrder: 1, description: 'Heat oil and add onions.' }],
+              tools: ['Pan'],
+            },
+          },
+          error: null,
+        })
+      }),
+    )
+
+    const blob = new Blob(['fake audio'], { type: 'audio/webm' })
+    const result = await parseService.parseRecipeAudio(blob, 'en', 'cooking.webm')
+
+    expect(contentType).toMatch(/multipart\/form-data/)
+    expect(bodyPresent).toBe(true)
+
+    expect(result.transcription.text).toBe('Heat olive oil. Add onions.')
+    expect(result.transcription.languageCode).toBe('en')
+    expect(result.transcription.source).toBe('audio')
+    expect(result.recipe.title).toBe('Caramelized Onions')
+    expect(result.recipe.ingredients).toHaveLength(1)
+    expect(result.recipe.ingredients[0].name).toBe('onion')
+    expect(result.recipe.steps).toHaveLength(1)
+    expect(result.recipe.tools).toEqual(['Pan'])
+  })
+
+  it('normalizes a response with truncated=true and source=video', async () => {
+    server.use(
+      http.post(`${BASE}/parse/recipe-audio`, () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            transcription: {
+              text: 'Long video transcript...',
+              languageCode: 'tr',
+              languageProbability: 0.95,
+              truncated: true,
+              source: 'video',
+            },
+            recipe: { title: 'V', ingredients: [], steps: [], tools: [] },
+          },
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await parseService.parseRecipeAudio(
+      new Blob([''], { type: 'video/mp4' }),
+      'tr',
+    )
+    expect(result.transcription.truncated).toBe(true)
+    expect(result.transcription.source).toBe('video')
+    expect(result.transcription.languageProbability).toBe(0.95)
+  })
+
+  it('treats an empty/unknown source field as "audio"', async () => {
+    server.use(
+      http.post(`${BASE}/parse/recipe-audio`, () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            transcription: {
+              text: 'foo',
+              languageCode: 'tr',
+              languageProbability: 0.8,
+              truncated: false,
+              // source missing
+            },
+            recipe: { title: '', ingredients: [], steps: [], tools: [] },
+          },
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await parseService.parseRecipeAudio(
+      new Blob([''], { type: 'audio/webm' }),
+    )
+    expect(result.transcription.source).toBe('audio')
+  })
+})

--- a/frontend/src/__tests__/integration/recipe-service-video-annotations.test.ts
+++ b/frontend/src/__tests__/integration/recipe-service-video-annotations.test.ts
@@ -1,0 +1,104 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { recipeService } from '@/services/recipe-service'
+
+const BASE = 'http://localhost/api'
+
+describe('recipeService.getById — videoAnnotations normalization', () => {
+  it('normalizes camelCase videoAnnotations from GET /recipes/:id', async () => {
+    server.use(
+      http.get(`${BASE}/recipes/r1`, () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            id: 'r1',
+            title: 'Test Recipe',
+            videoAnnotations: [
+              {
+                id: 1,
+                recipeId: 'r1',
+                startTime: 12.5,
+                endTime: 18.75,
+                note: 'Searing the meat',
+                technique: 'Searing',
+                createdAt: '2026-05-09T10:00:00Z',
+              },
+              {
+                id: 2,
+                recipeId: 'r1',
+                startTime: 60,
+                endTime: 90,
+                note: 'Stirring continuously',
+                technique: null,
+                createdAt: '2026-05-09T10:01:00Z',
+              },
+            ],
+          },
+          error: null,
+        }),
+      ),
+    )
+
+    const recipe = await recipeService.getById('r1')
+
+    expect(recipe.videoAnnotations).toHaveLength(2)
+    expect(recipe.videoAnnotations[0]).toMatchObject({
+      id: '1',
+      recipeId: 'r1',
+      startTime: 12.5,
+      endTime: 18.75,
+      note: 'Searing the meat',
+      technique: 'Searing',
+    })
+    expect(recipe.videoAnnotations[1].technique).toBeNull()
+  })
+
+  it('returns empty array when videoAnnotations is missing', async () => {
+    server.use(
+      http.get(`${BASE}/recipes/r2`, () =>
+        HttpResponse.json({
+          success: true,
+          data: { id: 'r2', title: 'No Annotations' },
+          error: null,
+        }),
+      ),
+    )
+
+    const recipe = await recipeService.getById('r2')
+    expect(recipe.videoAnnotations).toEqual([])
+  })
+
+  it('also accepts snake_case fields (defensive)', async () => {
+    server.use(
+      http.get(`${BASE}/recipes/r3`, () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            id: 'r3',
+            title: 'Snake Case',
+            videoAnnotations: [
+              {
+                id: 9,
+                recipe_id: 'r3',
+                start_time: '5',
+                end_time: '10',
+                note: 'Test',
+                created_at: '2026-05-09T11:00:00Z',
+              },
+            ],
+          },
+          error: null,
+        }),
+      ),
+    )
+
+    const recipe = await recipeService.getById('r3')
+    expect(recipe.videoAnnotations[0]).toMatchObject({
+      id: '9',
+      recipeId: 'r3',
+      startTime: 5,
+      endTime: 10,
+      note: 'Test',
+    })
+  })
+})

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -303,7 +303,10 @@
     "substituteNoResults": "No substitutes found for this ingredient.",
     "substituteLoadError": "Could not load substitutes.",
     "substituteClose": "Close",
-    "substituteConfidence": "Confidence: {{pct}}%"
+    "substituteConfidence": "Confidence: {{pct}}%",
+    "videoAnnotations": {
+      "seekAria": "Jump to {{start}}: {{note}}"
+    }
   },
   "dishVariety": {
     "notFound": "Dish variety not found.",
@@ -454,6 +457,19 @@
       "removeAria": "Remove {{name}}",
       "addAria": "Add {{name}}",
       "detecting": "Detecting allergens..."
+    },
+    "voice": {
+      "label": "Or describe with your voice",
+      "hint": "Record audio or upload an audio/video file. We will transcribe and parse it into a recipe.",
+      "start": "Start recording",
+      "stop": "Stop & parse",
+      "upload": "Upload file",
+      "recording": "Recording...",
+      "languageAria": "Recording language",
+      "langAuto": "Auto",
+      "notSupported": "Audio recording is not supported by this browser. Please use the upload option.",
+      "permissionDenied": "Microphone permission denied. Please use the upload option or grant access.",
+      "fileTooLarge": "File must be smaller than 100 MB."
     }
   },
   "comments": {
@@ -567,7 +583,10 @@
     "contentRequests": {
       "statusAria": "Filter by status",
       "subfilterAria": "Content type",
-      "subfilter": { "genre": "Genres", "variety": "Varieties" },
+      "subfilter": {
+        "genre": "Genres",
+        "variety": "Varieties"
+      },
       "empty": "No requests in this state.",
       "unknownRequester": "(unknown requester)",
       "nameEn": "English name",

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -303,7 +303,10 @@
     "substituteNoResults": "Bu malzeme için alternatif bulunamadı.",
     "substituteLoadError": "Alternatifler yüklenemedi.",
     "substituteClose": "Kapat",
-    "substituteConfidence": "Güven: %{{pct}}"
+    "substituteConfidence": "Güven: %{{pct}}",
+    "videoAnnotations": {
+      "seekAria": "{{start}} zamanına git: {{note}}"
+    }
   },
   "dishVariety": {
     "notFound": "Yemek çeşidi bulunamadı.",
@@ -454,6 +457,19 @@
       "removeAria": "{{name}} kaldır",
       "addAria": "{{name}} ekle",
       "detecting": "Alerjenler tespit ediliyor..."
+    },
+    "voice": {
+      "label": "Ya da sesinle anlat",
+      "hint": "Ses kaydı yapın veya bir ses/video dosyası yükleyin. Transkripsiyonunu yapıp tarife dönüştüreceğiz.",
+      "start": "Kaydı başlat",
+      "stop": "Durdur ve işle",
+      "upload": "Dosya yükle",
+      "recording": "Kaydediliyor...",
+      "languageAria": "Kayıt dili",
+      "langAuto": "Otomatik",
+      "notSupported": "Bu tarayıcı ses kaydını desteklemiyor. Lütfen dosya yükleme seçeneğini kullanın.",
+      "permissionDenied": "Mikrofon izni reddedildi. Lütfen izin verin ya da dosya yükleyin.",
+      "fileTooLarge": "Dosya 100 MBdan küçük olmalı."
     }
   },
   "comments": {
@@ -567,7 +583,10 @@
     "contentRequests": {
       "statusAria": "Duruma göre filtrele",
       "subfilterAria": "İçerik türü",
-      "subfilter": { "genre": "Türler", "variety": "Çeşitler" },
+      "subfilter": {
+        "genre": "Türler",
+        "variety": "Çeşitler"
+      },
       "empty": "Bu durumda başvuru yok.",
       "unknownRequester": "(bilinmeyen başvuran)",
       "nameEn": "İngilizce ad",

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.css
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.css
@@ -845,3 +845,75 @@
     border-right: 1px solid rgba(134, 69, 42, 0.2);
   }
 }
+
+/* ── Voice input (Faz 13) ───────────────────────────────────────────────── */
+
+.cr-voice {
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  background: var(--surface-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.cr-voice__label {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cr-voice__hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.cr-voice__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+  margin-top: var(--space-xs);
+}
+
+.cr-voice__btn {
+  cursor: pointer;
+}
+
+.cr-voice__btn--stop {
+  background: var(--color-error, #e53e3e);
+  color: #fff;
+  border-color: transparent;
+}
+
+.cr-voice__upload {
+  position: relative;
+  cursor: pointer;
+}
+
+.cr-voice__upload input[type="file"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.cr-voice__lang {
+  max-width: 100px;
+}
+
+.cr-voice__recording {
+  margin: 0;
+  color: var(--color-error, #e53e3e);
+  font-weight: 600;
+  font-size: 0.875rem;
+  animation: cr-voice-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes cr-voice-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { isAxiosError } from 'axios'
@@ -225,6 +225,8 @@ export function CreateRecipePage() {
   const [parseError, setParseError] = useState<string | null>(null)
   const [parsedOutput, setParsedOutput] = useState<ParsedRecipeOutput | null>(null)
   const [unmatchedParsedIngredients, setUnmatchedParsedIngredients] = useState<string[]>([])
+  const [recording, setRecording] = useState(false)
+  const [voiceLanguage, setVoiceLanguage] = useState<'auto' | 'en' | 'tr'>('auto')
   // Cook can only create community; expert can create both
   const canCreateCultural = role === 'expert'
 
@@ -415,6 +417,50 @@ export function CreateRecipePage() {
     return exact ?? candidates[0] ?? null
   }
 
+  /** Maps a parsed recipe (from text or audio) into the draft form. */
+  const applyParsedRecipe = async (parsed: ParsedRecipeOutput) => {
+    setParsedOutput(parsed)
+
+    const ingredientMatches = await Promise.all(
+      parsed.ingredients.map(async (ing) => {
+        try {
+          const match = await findBestIngredientMatch(ing.name)
+          return { ing, match }
+        } catch {
+          return { ing, match: null }
+        }
+      }),
+    )
+
+    const matchedRows: IngredientRow[] = ingredientMatches
+      .filter((item) => item.match !== null)
+      .map((item) => ({
+        ingredientId: item.match?.id ?? null,
+        name: item.match?.name ?? '',
+        searchQuery: '',
+        quantity: item.ing.quantity !== null ? String(item.ing.quantity) : '',
+        unit: item.ing.unit,
+      }))
+
+    const unmatched = uniqueNonEmpty(
+      ingredientMatches
+        .filter((item) => item.match === null)
+        .map((item) => item.ing.name),
+    )
+    setUnmatchedParsedIngredients(unmatched)
+
+    setDraft((current) => ({
+      ...current,
+      title: current.title.trim() ? current.title : parsed.title,
+      tools: parsed.tools.length > 0 ? parsed.tools : current.tools,
+      steps:
+        parsed.steps.length > 0
+          ? parsed.steps.map((step) => ({ text: step.description }))
+          : current.steps,
+      ingredients: matchedRows.length > 0 ? matchedRows : current.ingredients,
+    }))
+  }
+
   const handleParseNarrative = async () => {
     if (parseText.trim().length < 10 || parsing) return
     setParsing(true)
@@ -423,46 +469,7 @@ export function CreateRecipePage() {
 
     try {
       const parsed = await parseService.parseRecipeText(parseText.trim())
-      setParsedOutput(parsed)
-
-      const ingredientMatches = await Promise.all(
-        parsed.ingredients.map(async (ing) => {
-          try {
-            const match = await findBestIngredientMatch(ing.name)
-            return { ing, match }
-          } catch {
-            return { ing, match: null }
-          }
-        }),
-      )
-
-      const matchedRows: IngredientRow[] = ingredientMatches
-        .filter((item) => item.match !== null)
-        .map((item) => ({
-          ingredientId: item.match?.id ?? null,
-          name: item.match?.name ?? '',
-          searchQuery: '',
-          quantity: item.ing.quantity !== null ? String(item.ing.quantity) : '',
-          unit: item.ing.unit,
-        }))
-
-      const unmatched = uniqueNonEmpty(
-        ingredientMatches
-          .filter((item) => item.match === null)
-          .map((item) => item.ing.name),
-      )
-      setUnmatchedParsedIngredients(unmatched)
-
-      setDraft((current) => ({
-        ...current,
-        title: current.title.trim() ? current.title : parsed.title,
-        tools: parsed.tools.length > 0 ? parsed.tools : current.tools,
-        steps:
-          parsed.steps.length > 0
-            ? parsed.steps.map((step) => ({ text: step.description }))
-            : current.steps,
-        ingredients: matchedRows.length > 0 ? matchedRows : current.ingredients,
-      }))
+      await applyParsedRecipe(parsed)
     } catch (err: unknown) {
       if (isAxiosError(err)) {
         const msg = (err.response?.data as { error?: { message?: string } } | undefined)?.error?.message
@@ -475,6 +482,96 @@ export function CreateRecipePage() {
       setParsing(false)
     }
   }
+
+  // ── Voice input (Faz 13) ─────────────────────────────────────────────────────
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const recordedChunksRef = useRef<Blob[]>([])
+  const recordingStreamRef = useRef<MediaStream | null>(null)
+
+  const sendAudioForParsing = async (blob: Blob) => {
+    setParsing(true)
+    setParseError(null)
+    setUnmatchedParsedIngredients([])
+    try {
+      const result = await parseService.parseRecipeAudio(blob, voiceLanguage)
+      if (result.transcription.text.trim()) {
+        setParseText(result.transcription.text)
+      }
+      await applyParsedRecipe(result.recipe)
+    } catch (err) {
+      if (isAxiosError(err)) {
+        const msg = (err.response?.data as { error?: { message?: string } } | undefined)?.error?.message
+        setParseError(msg || t('create.parse.error'))
+      } else {
+        setParseError(t('create.parse.error'))
+      }
+    } finally {
+      setParsing(false)
+    }
+  }
+
+  const handleStartRecording = async () => {
+    setParseError(null)
+    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
+      setParseError(t('create.voice.notSupported'))
+      return
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      recordingStreamRef.current = stream
+      recordedChunksRef.current = []
+      const mime = MediaRecorder.isTypeSupported('audio/webm')
+        ? 'audio/webm'
+        : ''
+      const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
+      mediaRecorderRef.current = recorder
+      recorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) recordedChunksRef.current.push(e.data)
+      }
+      recorder.onstop = () => {
+        const blob = new Blob(recordedChunksRef.current, {
+          type: recorder.mimeType || 'audio/webm',
+        })
+        recordingStreamRef.current?.getTracks().forEach((tr) => tr.stop())
+        recordingStreamRef.current = null
+        if (blob.size > 0) void sendAudioForParsing(blob)
+      }
+      recorder.start()
+      setRecording(true)
+    } catch {
+      setParseError(t('create.voice.permissionDenied'))
+    }
+  }
+
+  const handleStopRecording = () => {
+    const recorder = mediaRecorderRef.current
+    if (recorder && recorder.state !== 'inactive') {
+      recorder.stop()
+    }
+    setRecording(false)
+  }
+
+  const handleAudioFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    if (file.size > 100 * 1024 * 1024) {
+      setParseError(t('create.voice.fileTooLarge'))
+      return
+    }
+    await sendAudioForParsing(file)
+  }
+
+  // Cleanup on unmount: stop any running recorder + tracks
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+        mediaRecorderRef.current.stop()
+      }
+      recordingStreamRef.current?.getTracks().forEach((tr) => tr.stop())
+    }
+  }, [])
 
   // ── Navigation guards ────────────────────────────────────────────────────────
 
@@ -598,6 +695,63 @@ export function CreateRecipePage() {
                 </button>
                 <span className="cr-parse__hint">{t('create.parse.hint')}</span>
               </div>
+
+              {/* Voice input (Faz 13) */}
+              <div className="cr-voice">
+                <p className="cr-voice__label">{t('create.voice.label')}</p>
+                <p className="cr-voice__hint">{t('create.voice.hint')}</p>
+                <div className="cr-voice__row">
+                  {!recording ? (
+                    <button
+                      type="button"
+                      className="cr-add-btn cr-voice__btn"
+                      disabled={parsing}
+                      onClick={() => void handleStartRecording()}
+                    >
+                      🎙 {t('create.voice.start')}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="cr-add-btn cr-voice__btn cr-voice__btn--stop"
+                      onClick={handleStopRecording}
+                    >
+                      ⏹ {t('create.voice.stop')}
+                    </button>
+                  )}
+
+                  <label className="cr-voice__upload">
+                    <input
+                      type="file"
+                      accept="audio/*,video/mp4,video/quicktime,video/webm,video/x-matroska"
+                      className="cr-media__input"
+                      disabled={parsing || recording}
+                      onChange={(e) => void handleAudioFileUpload(e)}
+                    />
+                    <span className="cr-add-btn cr-voice__btn">
+                      📎 {t('create.voice.upload')}
+                    </span>
+                  </label>
+
+                  <select
+                    className="cr-input cr-voice__lang"
+                    value={voiceLanguage}
+                    onChange={(e) => setVoiceLanguage(e.target.value as 'auto' | 'en' | 'tr')}
+                    disabled={recording || parsing}
+                    aria-label={t('create.voice.languageAria')}
+                  >
+                    <option value="auto">{t('create.voice.langAuto')}</option>
+                    <option value="en">EN</option>
+                    <option value="tr">TR</option>
+                  </select>
+                </div>
+                {recording && (
+                  <p className="cr-voice__recording" role="status" aria-live="polite">
+                    ● {t('create.voice.recording')}
+                  </p>
+                )}
+              </div>
+
               {parseError && <p className="cr-error cr-error--inline">{parseError}</p>}
 
               {parsedOutput && (

--- a/frontend/src/pages/RecipeDetail/RecipeDetailPage.css
+++ b/frontend/src/pages/RecipeDetail/RecipeDetailPage.css
@@ -803,3 +803,117 @@
   color: #c0392b;
   border: 1px solid rgba(192, 57, 43, 0.25);
 }
+
+/* ── Video player with annotations ─────────────────────────────────────────── */
+
+.rd-video-player {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.rd-video-player__container {
+  position: relative;
+  width: 100%;
+}
+
+.rd-video-player__video {
+  display: block;
+  width: 100%;
+  border-radius: var(--radius-md);
+  background: #000;
+}
+
+.rd-video-player__markers {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 36px;
+  height: 6px;
+  pointer-events: none;
+}
+
+.rd-video-player__marker {
+  position: absolute;
+  top: -3px;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  background: var(--color-main);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  cursor: pointer;
+  pointer-events: auto;
+  transition: transform 0.15s, box-shadow 0.15s;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+.rd-video-player__marker:hover {
+  transform: scale(1.2);
+}
+
+.rd-video-player__marker--active {
+  transform: scale(1.3);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.4);
+}
+
+.rd-video-player__annotation-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.rd-video-player__annotation {
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.rd-video-player__annotation--active {
+  border-color: var(--color-main);
+  background: var(--color-main-soft, rgba(0, 120, 255, 0.06));
+}
+
+.rd-video-player__annotation-btn {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-md);
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.rd-video-player__annotation-time {
+  flex-shrink: 0;
+  min-width: 80px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--color-main);
+}
+
+.rd-video-player__annotation-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rd-video-player__annotation-technique {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.rd-video-player__annotation-note {
+  color: var(--text-primary);
+}

--- a/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
+++ b/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
@@ -9,6 +9,7 @@ import { favoriteService } from '@/services/favorite-service'
 import { RecipeRating } from '@/components/RecipeRating/RecipeRating'
 import { ConfirmModal } from '@/components/ConfirmModal/ConfirmModal'
 import { CommentsSection } from '@/components/Comments/CommentsSection'
+import { VideoPlayerWithAnnotations } from '@/pages/RecipeDetail/VideoPlayerWithAnnotations'
 import { useAppSelector } from '@/store/hooks'
 import './RecipeDetailPage.css'
 
@@ -564,18 +565,14 @@ export function RecipeDetailPage() {
           <section className="recipe-detail__block">
             <h2 className="recipe-detail__h2">{t('recipeDetail.video')}</h2>
             <div className="recipe-detail__uploaded-videos">
-              {uploadedVideos.map((m) => (
-                <video
+              {uploadedVideos.map((m, idx) => (
+                <VideoPlayerWithAnnotations
                   key={m.id}
-                  className="recipe-detail__uploaded-video"
-                  controls
-                  playsInline
-                  preload="metadata"
                   src={m.url}
-                  aria-label={t('recipeDetail.videoPlayerAria')}
-                >
-                  {t('recipeDetail.video')}
-                </video>
+                  // attach annotations only to the first video — backend ties annotations to recipe, not media item
+                  annotations={idx === 0 ? recipe.videoAnnotations : []}
+                  ariaLabel={t('recipeDetail.videoPlayerAria')}
+                />
               ))}
             </div>
           </section>

--- a/frontend/src/pages/RecipeDetail/VideoPlayerWithAnnotations.tsx
+++ b/frontend/src/pages/RecipeDetail/VideoPlayerWithAnnotations.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { VideoAnnotation } from '@/services/recipe-service'
+
+export interface VideoPlayerWithAnnotationsProps {
+  src: string
+  annotations: VideoAnnotation[]
+  ariaLabel: string
+}
+
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00'
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+export function VideoPlayerWithAnnotations({
+  src,
+  annotations,
+  ariaLabel,
+}: VideoPlayerWithAnnotationsProps) {
+  const { t } = useTranslation('common')
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [duration, setDuration] = useState(0)
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const handleLoadedMeta = useCallback(() => {
+    const v = videoRef.current
+    if (v && Number.isFinite(v.duration)) setDuration(v.duration)
+  }, [])
+
+  const handleTimeUpdate = useCallback(() => {
+    const v = videoRef.current
+    if (!v) return
+    const t = v.currentTime
+    const current = annotations.find((a) => t >= a.startTime && t <= a.endTime)
+    setActiveId(current?.id ?? null)
+  }, [annotations])
+
+  const seekTo = useCallback((seconds: number) => {
+    const v = videoRef.current
+    if (!v) return
+    v.currentTime = seconds
+    void v.play()
+  }, [])
+
+  useEffect(() => {
+    setActiveId(null)
+  }, [src])
+
+  const sortedAnnotations = [...annotations].sort((a, b) => a.startTime - b.startTime)
+
+  return (
+    <div className="rd-video-player">
+      <div className="rd-video-player__container">
+        <video
+          ref={videoRef}
+          className="rd-video-player__video"
+          controls
+          playsInline
+          preload="metadata"
+          src={src}
+          aria-label={ariaLabel}
+          onLoadedMetadata={handleLoadedMeta}
+          onTimeUpdate={handleTimeUpdate}
+        />
+        {duration > 0 && sortedAnnotations.length > 0 && (
+          <div
+            className="rd-video-player__markers"
+            aria-hidden
+          >
+            {sortedAnnotations.map((a) => {
+              const left = Math.max(0, Math.min(100, (a.startTime / duration) * 100))
+              return (
+                <button
+                  key={a.id}
+                  type="button"
+                  className={`rd-video-player__marker${activeId === a.id ? ' rd-video-player__marker--active' : ''}`}
+                  style={{ left: `${left}%` }}
+                  onClick={() => seekTo(a.startTime)}
+                  title={`${formatTime(a.startTime)} — ${a.note}`}
+                  aria-label={`${formatTime(a.startTime)} ${a.note}`}
+                />
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {sortedAnnotations.length > 0 && (
+        <ol className="rd-video-player__annotation-list">
+          {sortedAnnotations.map((a) => (
+            <li
+              key={a.id}
+              className={`rd-video-player__annotation${activeId === a.id ? ' rd-video-player__annotation--active' : ''}`}
+            >
+              <button
+                type="button"
+                className="rd-video-player__annotation-btn"
+                onClick={() => seekTo(a.startTime)}
+                aria-label={t('recipeDetail.videoAnnotations.seekAria', {
+                  start: formatTime(a.startTime),
+                  note: a.note,
+                })}
+              >
+                <span className="rd-video-player__annotation-time">
+                  {formatTime(a.startTime)}–{formatTime(a.endTime)}
+                </span>
+                <span className="rd-video-player__annotation-body">
+                  {a.technique && (
+                    <span className="rd-video-player__annotation-technique">{a.technique}</span>
+                  )}
+                  <span className="rd-video-player__annotation-note">{a.note}</span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/services/parse-service.ts
+++ b/frontend/src/services/parse-service.ts
@@ -98,7 +98,66 @@ export interface StandardizeUnitsOutput {
 
 // ── service ───────────────────────────────────────────────────────────────────
 
+export interface AudioTranscription {
+  text: string
+  languageCode: string
+  languageProbability: number
+  truncated: boolean
+  source: 'audio' | 'video'
+}
+
+export interface ParsedRecipeAudioOutput {
+  transcription: AudioTranscription
+  recipe: ParsedRecipeOutput
+}
+
 export const parseService = {
+  /**
+   * POST /parse/recipe-audio — multipart upload of an audio/video recording.
+   * Returns the raw transcription plus the structured recipe parsed from it.
+   */
+  parseRecipeAudio: async (
+    blob: Blob,
+    language: 'auto' | 'en' | 'tr' = 'auto',
+    filename = 'recording.webm',
+  ): Promise<ParsedRecipeAudioOutput> => {
+    const fd = new FormData()
+    fd.append('audio', blob, filename)
+    fd.append('language', language)
+    // Let axios set the multipart Content-Type with its own boundary.
+    const res = await httpClient.post('/parse/recipe-audio', fd)
+    const payload = (res.data?.data ?? {}) as Record<string, unknown>
+    const t = (payload.transcription ?? {}) as Record<string, unknown>
+    const r = (payload.recipe ?? {}) as Record<string, unknown>
+
+    const ingredients = (Array.isArray(r.ingredients) ? r.ingredients : [])
+      .map(normalizeIngredient)
+      .filter((row): row is ParsedIngredient => row !== null)
+    const steps = (Array.isArray(r.steps) ? r.steps : [])
+      .map((row, idx) => normalizeStep(row, idx + 1))
+      .filter((row): row is ParsedStep => row !== null)
+      .sort((a, b) => a.stepOrder - b.stepOrder)
+    const tools = (Array.isArray(r.tools) ? r.tools : [])
+      .map(normalizeTool)
+      .filter((row): row is string => row !== null)
+
+    return {
+      transcription: {
+        text: typeof t.text === 'string' ? t.text : '',
+        languageCode: typeof t.languageCode === 'string' ? t.languageCode : '',
+        languageProbability: toNumber(t.languageProbability) ?? 0,
+        truncated: Boolean(t.truncated),
+        source: t.source === 'video' ? 'video' : 'audio',
+      },
+      recipe: {
+        title: typeof r.title === 'string' ? r.title.trim() : '',
+        ingredients,
+        steps,
+        tools,
+      },
+    }
+  },
+
   parseRecipeText: async (text: string): Promise<ParsedRecipeOutput> => {
     const res = await httpClient.post('/parse/recipe-text', { text })
     const payload = (res.data?.data ?? {}) as Record<string, unknown>

--- a/frontend/src/services/recipe-service.ts
+++ b/frontend/src/services/recipe-service.ts
@@ -37,6 +37,16 @@ export interface RecipeMedia {
   type: 'image' | 'video'
 }
 
+export interface VideoAnnotation {
+  id: string
+  recipeId: string
+  startTime: number
+  endTime: number
+  note: string
+  technique: string | null
+  createdAt: string
+}
+
 export interface RecipeDetail {
   id: string
   title: string
@@ -60,6 +70,7 @@ export interface RecipeDetail {
   tools: RecipeTool[]
   media: RecipeMedia[]
   tags: { id: string; name: string; category: 'dietary' | 'allergen' }[]
+  videoAnnotations: VideoAnnotation[]
   createdAt: string
   updatedAt: string
   isFavorited: boolean
@@ -187,6 +198,15 @@ export const recipeService = {
         id: String(tag.id),
         name: tag.name ?? '',
         category: tag.category === 'allergen' ? 'allergen' : 'dietary',
+      })),
+      videoAnnotations: (d.videoAnnotations ?? []).map((a: any) => ({
+        id: String(a.id),
+        recipeId: String(a.recipeId ?? a.recipe_id ?? ''),
+        startTime: Number(a.startTime ?? a.start_time ?? 0),
+        endTime: Number(a.endTime ?? a.end_time ?? 0),
+        note: String(a.note ?? ''),
+        technique: a.technique ?? null,
+        createdAt: a.createdAt ?? a.created_at ?? '',
       })),
       country: d.country ?? null,
       city: d.city ?? null,


### PR DESCRIPTION
## Summary
- Display recipe video annotations with seekable markers and a clickable annotation list on the recipe detail page (#423)
- Add voice input to the recipe creation flow via \`POST /parse/recipe-audio\` — record with \`MediaRecorder\` or upload an audio/video file, transcription + parsed recipe auto-fills the form (#414)

## Changes
- \`services/recipe-service.ts\` — \`VideoAnnotation\` type, \`videoAnnotations[]\` on \`RecipeDetail\`, snake/camel normalization
- \`pages/RecipeDetail/VideoPlayerWithAnnotations.tsx\` — new component: overlay markers, active highlight via \`onTimeUpdate\`, click-to-seek
- \`pages/RecipeDetail/RecipeDetailPage.tsx\` — swap native \`<video>\` for the new player
- \`services/parse-service.ts\` — \`parseRecipeAudio()\` (multipart), plus existing \`parseRecipeText\` / \`standardizeUnits\` consolidated here
- \`pages/CreateRecipe/CreateRecipePage.tsx\` — mic record / stop / upload buttons, language select (auto/en/tr), recording status, unmount cleanup; shared \`applyParsedRecipe()\` helper
- EN/TR i18n strings under \`recipeDetail.videoAnnotations.*\` and \`create.voice.*\`
- Integration tests: \`parse-service-audio.test.ts\`, \`recipe-service-video-annotations.test.ts\`

## How to test
- [ ] Recipe with annotations → markers visible on seek bar, current annotation highlights as video plays, click jumps to timestamp
- [ ] Recipe with no annotations → renders cleanly without markers
- [ ] Create flow → "Start recording" / "Stop & parse" populates the form
- [ ] Upload an audio or video file (≤ 100 MB) → form fills in
- [ ] Permission denied / unsupported browser → user-friendly message
- [ ] EN / TR i18n applies to all new strings
- [ ] \`npm run build\` passes

## Related issues
Closes #414
Closes #423