### PR TITLE
[Mobile/Feature] Implement persistent recipe draft saving

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -17,6 +17,7 @@ import {
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { NavigationContainer } from '@react-navigation/native';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
+import { RecipeFormProvider } from './src/context/RecipeFormContext';
 import { AuthStack } from './src/navigation/AuthStack';
 import { TabNavigator } from './src/navigation/TabNavigator';
 import { colors } from './src/theme';
@@ -66,9 +67,11 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <AuthProvider>
-        <NavigationContainer>
-          <RootNavigator />
-        </NavigationContainer>
+        <RecipeFormProvider>
+          <NavigationContainer>
+            <RootNavigator />
+          </NavigationContainer>
+        </RecipeFormProvider>
       </AuthProvider>
       <StatusBar style="dark" />
     </SafeAreaProvider>

--- a/mobile/src/__tests__/CreateScreensDraft.test.tsx
+++ b/mobile/src/__tests__/CreateScreensDraft.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import { CreateBasicInfoScreen } from '../components/create-basic/CreateBasicInfoScreen';
+import { CreateIngredientsToolsScreen } from '../components/create-ingredients/CreateIngredientsToolsScreen';
+import { CreateStepsScreen } from '../components/create-steps/CreateStepsScreen';
+import { CreateReviewScreen } from '../components/create-review/CreateReviewScreen';
+import * as RecipeFormContext from '../context/RecipeFormContext';
+
+// --- Mocks ---
+
+// Mock navigation
+jest.mock('@react-navigation/native', () => {
+  return {
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      getParent: jest.fn(() => ({ navigate: jest.fn() })),
+    }),
+    useIsFocused: () => true,
+  };
+});
+
+// Mock expo-image-picker
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+// Mock APIs for BasicInfo
+jest.mock('../api/dish-genres', () => ({
+  getDishGenres: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../api/dietary-tags', () => ({
+  getDietaryTags: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../api/cultural-tags', () => ({
+  getCulturalTags: jest.fn().mockResolvedValue([]),
+  pickCulturalTagLabel: jest.fn(),
+}));
+jest.mock('../api/images', () => ({
+  uploadImage: jest.fn(),
+}));
+
+// Mock APIs for Ingredients/Tools
+jest.mock('../api/ingredients', () => ({
+  searchIngredients: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../api/tools', () => ({
+  getTools: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../api/units', () => ({
+  getUnits: jest.fn().mockResolvedValue([]),
+}));
+
+// Mock API for recipes
+jest.mock('../api/recipes', () => ({
+  createRecipe: jest.fn().mockResolvedValue({ id: 'new-id' }),
+  publishRecipe: jest.fn().mockResolvedValue({ id: 'new-id', isPublished: true }),
+  attachRecipeMedia: jest.fn().mockResolvedValue({}),
+}));
+
+// Mock i18next
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+// Mock AuthContext
+jest.mock('../context/AuthContext', () => ({
+  useAuth: () => ({
+    authState: { status: 'authenticated', user: { role: 'expert' } },
+  }),
+}));
+
+// Spy on Alert
+jest.spyOn(Alert, 'alert').mockImplementation((title, message, buttons) => {
+  // Auto-press the OK button for alerts
+  if (buttons && buttons.length > 0) {
+    const okBtn = buttons.find(b => b.text === 'OK' || !b.style);
+    if (okBtn && okBtn.onPress) okBtn.onPress();
+  }
+});
+
+// --- Tests ---
+
+describe('Save Draft from Create Screens', () => {
+  let saveDraftMock: jest.Mock;
+  let resetDraftMock: jest.Mock;
+  let updateDraftMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    saveDraftMock = jest.fn().mockResolvedValue(true);
+    resetDraftMock = jest.fn();
+    updateDraftMock = jest.fn();
+
+    // Mock useRecipeForm hook
+    jest.spyOn(RecipeFormContext, 'useRecipeForm').mockReturnValue({
+      draft: {
+        recipeId: null,
+        title: '',
+        type: 'COMMUNITY',
+        originCountry: '',
+        originCity: '',
+        originDistrict: '',
+        genreId: null,
+        varietyId: null,
+        dietaryTagIds: [],
+        dietaryTagNames: [],
+        allergenTagIds: [],
+        allergenTagNames: [],
+        culturalTagIds: [],
+        culturalTags: [],
+        story: '',
+        imageUrls: [],
+        ingredients: [],
+        tools: [],
+        steps: [],
+        videoUrl: null,
+        videoFileName: null,
+      },
+      updateDraft: updateDraftMock,
+      resetDraft: resetDraftMock,
+      saveDraft: saveDraftMock,
+    } as any);
+  });
+
+  it('CreateBasicInfoScreen should save draft with basic info', async () => {
+    const { getByText } = render(<CreateBasicInfoScreen />);
+
+    // Wait for the button to appear
+    await waitFor(() => {
+      expect(getByText('create.saveDraft')).toBeTruthy();
+    });
+
+    const saveDraftBtn = getByText('create.saveDraft');
+    fireEvent.press(saveDraftBtn);
+
+    await waitFor(() => {
+      expect(saveDraftMock).toHaveBeenCalledTimes(1);
+      // It should pass partial state to saveDraft
+      expect(saveDraftMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: '',
+          type: 'COMMUNITY',
+          originCountry: '',
+        })
+      );
+    });
+  });
+
+  it('CreateIngredientsToolsScreen should save draft with ingredients and tools', async () => {
+    const { getByText } = render(<CreateIngredientsToolsScreen />);
+
+    await waitFor(() => {
+      expect(getByText('create.saveDraft')).toBeTruthy();
+    });
+
+    const saveDraftBtn = getByText('create.saveDraft');
+    fireEvent.press(saveDraftBtn);
+
+    await waitFor(() => {
+      expect(saveDraftMock).toHaveBeenCalledTimes(1);
+      // Expected to save ingredients and tools arrays
+      expect(saveDraftMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ingredients: expect.any(Array),
+          tools: expect.any(Array),
+        })
+      );
+    });
+  });
+
+  it('CreateStepsScreen should save draft with steps', async () => {
+    const { getByText } = render(<CreateStepsScreen />);
+
+    await waitFor(() => {
+      expect(getByText('create.saveDraft')).toBeTruthy();
+    });
+
+    const saveDraftBtn = getByText('create.saveDraft');
+    fireEvent.press(saveDraftBtn);
+
+    await waitFor(() => {
+      expect(saveDraftMock).toHaveBeenCalledTimes(1);
+      // Expected to save steps array and video data
+      expect(saveDraftMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          steps: expect.any(Array),
+          videoUrl: null,
+          videoFileName: null,
+        })
+      );
+    });
+  });
+
+  it('CreateReviewScreen should save draft with empty object to trigger backend update', async () => {
+    const { getByText } = render(<CreateReviewScreen />);
+
+    // In Review screen, the button text might be different based on translation mock
+    // "create.review.saveDraft" is used in Review Screen
+    await waitFor(() => {
+      expect(getByText('create.review.saveDraft')).toBeTruthy();
+    });
+
+    const saveDraftBtn = getByText('create.review.saveDraft');
+    fireEvent.press(saveDraftBtn);
+
+    await waitFor(() => {
+      expect(saveDraftMock).toHaveBeenCalledTimes(1);
+      // Review screen simply triggers saveDraft({})
+      expect(saveDraftMock).toHaveBeenCalledWith({});
+    });
+  });
+});

--- a/mobile/src/__tests__/RecipeFormContext.test.tsx
+++ b/mobile/src/__tests__/RecipeFormContext.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { renderHook, act } from '@testing-library/react-native';
 import { RecipeFormProvider, useRecipeForm } from '../context/RecipeFormContext';
+import * as recipesApi from '../api/recipes';
+
+jest.mock('../api/recipes', () => ({
+  createRecipe: jest.fn(),
+  updateRecipe: jest.fn(),
+}));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <RecipeFormProvider>{children}</RecipeFormProvider>
@@ -120,5 +126,47 @@ describe('RecipeFormContext', () => {
       'useRecipeForm must be used inside RecipeFormProvider'
     );
     consoleError.mockRestore();
+  });
+
+  describe('saveDraft', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a new recipe when draft.recipeId is null', async () => {
+      (recipesApi.createRecipe as jest.Mock).mockResolvedValueOnce({ id: 'new-id-123' });
+      const { result } = renderHook(() => useRecipeForm(), { wrapper });
+      
+      await act(async () => {
+        await result.current.saveDraft({ title: 'New Draft' });
+      });
+
+      expect(recipesApi.createRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'New Draft', isPublished: false })
+      );
+      expect(result.current.draft.recipeId).toBe('new-id-123');
+    });
+
+    it('updates existing recipe when draft.recipeId is present', async () => {
+      (recipesApi.updateRecipe as jest.Mock).mockResolvedValueOnce({ message: 'Success' });
+      const { result } = renderHook(() => useRecipeForm(), { wrapper });
+      
+      // Setup initial state with an ID
+      act(() => {
+        result.current.updateDraft({ recipeId: 'existing-id', title: 'Existing' });
+      });
+
+      await act(async () => {
+        await result.current.saveDraft({ title: 'Updated Title' });
+      });
+
+      expect(recipesApi.createRecipe).not.toHaveBeenCalled();
+      expect(recipesApi.updateRecipe).toHaveBeenCalledWith(
+        'existing-id',
+        expect.objectContaining({ title: 'Updated Title', isPublished: false })
+      );
+      expect(result.current.draft.title).toBe('Updated Title');
+      expect(result.current.draft.recipeId).toBe('existing-id');
+    });
   });
 });

--- a/mobile/src/components/create-basic/CreateBasicInfoScreen.tsx
+++ b/mobile/src/components/create-basic/CreateBasicInfoScreen.tsx
@@ -58,7 +58,8 @@ export function CreateBasicInfoScreen() {
       ? (authState.user.role ?? "").toUpperCase()
       : "";
   const canCreateCultural = role === "EXPERT";
-  const { draft, updateDraft, resetDraft } = useRecipeForm();
+  const { draft, updateDraft, resetDraft, saveDraft } = useRecipeForm();
+  const [savingDraft, setSavingDraft] = useState(false);
   const [recipeType, setRecipeType] = useState<RecipeType>(draft.type);
   const [title, setTitle] = useState(draft.title);
   const [country, setCountry] = useState(draft.originCountry);
@@ -177,6 +178,18 @@ export function CreateBasicInfoScreen() {
       })
       .catch((err) => console.error("[BasicInfo] dietary-tags error:", err));
   }, []);
+
+  // Infer genreId from varietyId when resuming a draft where backend only provides dishVarietyId
+  useEffect(() => {
+    if (varietyId !== null && genreId === null && genres.length > 0) {
+      for (const g of genres) {
+        if (g.varieties.some((v) => v.id === varietyId)) {
+          setGenreId(g.id);
+          break;
+        }
+      }
+    }
+  }, [genres, varietyId, genreId]);
 
   // Refetch cultural tags whenever the selected country changes (region scoping).
   useEffect(() => {
@@ -300,8 +313,53 @@ export function CreateBasicInfoScreen() {
     }
   };
 
-  const handleSaveDraft = () => {
-    Alert.alert(t("create.draftSaved"), t("create.draftSavedMsg"));
+  const handleSaveDraft = async () => {
+    try {
+      setSavingDraft(true);
+      const dietaryNames = dietaryChipOptions
+        .filter((o) => selectedDietaryIds.includes(o.value))
+        .map((o) => o.label);
+      const allergenNames = allergenChipOptions
+        .filter((o) => selectedAllergenIds.includes(o.value))
+        .map((o) => o.label);
+      const culturalTagIdsNum = selectedCulturalIds.map(Number);
+      const selectedCulturalObjects = culturalTags.filter((tag) =>
+        selectedCulturalIds.includes(String(tag.id)),
+      );
+      await saveDraft({
+        title,
+        type: recipeType,
+        originCountry: country,
+        originCity: city,
+        originDistrict: district,
+        genreId,
+        varietyId,
+        dietaryTagIds: selectedDietaryIds.map(Number),
+        dietaryTagNames: dietaryNames,
+        allergenTagIds: selectedAllergenIds.map(Number),
+        allergenTagNames: allergenNames,
+        culturalTagIds: culturalTagIdsNum,
+        culturalTags: selectedCulturalObjects,
+        story,
+        servingSize: servingSize ? parseInt(servingSize, 10) : undefined,
+        imageUrls: images.filter((img) => img.cdnUrl).map((img) => img.cdnUrl!),
+      });
+      Alert.alert(t("create.draftSaved"), t("create.draftSavedMsg2"), [
+        {
+          text: "OK",
+          onPress: () => {
+            resetDraft();
+            navigation.navigate("CreateBasicInfo" as never);
+            navigation.getParent()?.navigate("HomeTab" as never);
+          },
+        },
+      ]);
+    } catch (err) {
+      console.error(err);
+      Alert.alert("Error", "Could not save draft. Please try again.");
+    } finally {
+      setSavingDraft(false);
+    }
   };
 
   const handleClose = () => {
@@ -326,6 +384,8 @@ export function CreateBasicInfoScreen() {
           setStory("");
           setImages([]);
           setErrors({});
+          resetDraft();
+          navigation.navigate("CreateBasicInfo" as never);
           navigation.getParent()?.navigate("HomeTab" as never);
         },
       },
@@ -627,8 +687,13 @@ export function CreateBasicInfoScreen() {
           style={styles.saveDraftButton}
           onPress={handleSaveDraft}
           activeOpacity={0.7}
+          disabled={savingDraft}
         >
-          <Text style={styles.saveDraftText}>{t("create.saveDraft")}</Text>
+          {savingDraft ? (
+            <ActivityIndicator color={colors.onSurfaceVariant} size="small" />
+          ) : (
+            <Text style={styles.saveDraftText}>{t("create.saveDraft")}</Text>
+          )}
         </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>

--- a/mobile/src/components/create-ingredients/CreateIngredientsToolsScreen.tsx
+++ b/mobile/src/components/create-ingredients/CreateIngredientsToolsScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import {
+  ActivityIndicator,
   Alert,
   ScrollView,
   StyleSheet,
@@ -50,7 +51,8 @@ export function CreateIngredientsToolsScreen() {
   const navigation =
     useNavigation<NativeStackNavigationProp<CreateStackParamList>>();
   const isFocused = useIsFocused();
-  const { draft, updateDraft, resetDraft } = useRecipeForm();
+  const { draft, updateDraft, resetDraft, saveDraft } = useRecipeForm();
+  const [savingDraft, setSavingDraft] = useState(false);
   const [ingredients, setIngredients] = useState<IngredientFormItem[]>(
     draft.ingredients.length > 0
       ? draft.ingredients
@@ -159,8 +161,26 @@ export function CreateIngredientsToolsScreen() {
     }
   };
 
-  const handleSaveDraft = () => {
-    Alert.alert(t("create.draftSaved"), t("create.draftSavedMsg"));
+  const handleSaveDraft = async () => {
+    try {
+      setSavingDraft(true);
+      await saveDraft({ ingredients, tools });
+      Alert.alert(t("create.draftSaved"), t("create.draftSavedMsg2"), [
+        {
+          text: "OK",
+          onPress: () => {
+            resetDraft();
+            navigation.navigate("CreateBasicInfo" as never);
+            navigation.getParent()?.navigate("HomeTab" as never);
+          },
+        },
+      ]);
+    } catch (err) {
+      console.error(err);
+      Alert.alert("Error", "Could not save draft. Please try again.");
+    } finally {
+      setSavingDraft(false);
+    }
   };
 
   const handleClose = () => {
@@ -171,7 +191,7 @@ export function CreateIngredientsToolsScreen() {
         style: "destructive",
         onPress: () => {
           resetDraft();
-          navigation.popToTop();
+          navigation.navigate("CreateBasicInfo" as never);
           navigation.getParent()?.navigate("HomeTab" as never);
         },
       },
@@ -270,8 +290,13 @@ export function CreateIngredientsToolsScreen() {
           style={styles.saveDraftButton}
           onPress={handleSaveDraft}
           activeOpacity={0.7}
+          disabled={savingDraft}
         >
-          <Text style={styles.saveDraftText}>{t("create.saveDraft")}</Text>
+          {savingDraft ? (
+            <ActivityIndicator color={colors.onSurfaceVariant} size="small" />
+          ) : (
+            <Text style={styles.saveDraftText}>{t("create.saveDraft")}</Text>
+          )}
         </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>

--- a/mobile/src/components/create-review/CreateReviewScreen.tsx
+++ b/mobile/src/components/create-review/CreateReviewScreen.tsx
@@ -27,8 +27,9 @@ import { validateForPublish } from "../../utils/recipeValidation";
 export function CreateReviewScreen() {
   const { t } = useTranslation("common");
   const navigation = useNavigation<NativeStackNavigationProp<CreateStackParamList>>();
-  const { draft, resetDraft } = useRecipeForm();
+  const { draft, resetDraft, saveDraft } = useRecipeForm();
   const [publishing, setPublishing] = useState(false);
+  const [savingDraft, setSavingDraft] = useState(false);
 
   const hasDietaryTags = draft.dietaryTagNames.length > 0;
   const hasAllergenTags = draft.allergenTagNames.length > 0;
@@ -38,7 +39,7 @@ export function CreateReviewScreen() {
 
   const goHome = () => {
     resetDraft();
-    navigation.popToTop();
+    navigation.navigate("CreateBasicInfo" as never);
     navigation.getParent()?.navigate("HomeTab" as never);
   };
 
@@ -79,13 +80,22 @@ export function CreateReviewScreen() {
     }
     try {
       setPublishing(true);
-      const created = await createRecipe({
-        ...buildRecipePayload(draft),
-        isPublished: false,
-      });
-      console.log("[publish] recipe created:", created.id);
-      await attachMedia(created.id);
-      const published = await publishRecipe(created.id);
+      let targetId = draft.recipeId;
+      
+      if (!targetId) {
+        const created = await createRecipe({
+          ...buildRecipePayload(draft),
+          isPublished: false,
+        });
+        targetId = created.id;
+        console.log("[publish] recipe created:", targetId);
+      } else {
+        await saveDraft({});
+        console.log("[publish] draft updated:", targetId);
+      }
+
+      await attachMedia(targetId);
+      const published = await publishRecipe(targetId);
       console.log("[publish] recipe published:", published);
       Alert.alert(t("create.published"), t("create.publishedMsg"), [
         { text: "OK", onPress: goHome },
@@ -96,15 +106,18 @@ export function CreateReviewScreen() {
   };
 
   const handleSaveDraft = async () => {
-    const result = await createRecipe({
-      ...buildRecipePayload(draft),
-      isPublished: false,
-    });
-    console.log("[draft] recipe saved:", result.id);
-    await attachMedia(result.id);
-    Alert.alert(t("create.draftSaved"), t("create.draftSavedMsg2"), [
-      { text: "OK", onPress: goHome },
-    ]);
+    try {
+      setSavingDraft(true);
+      await saveDraft({});
+      Alert.alert(t("create.draftSaved"), t("create.draftSavedMsg2"), [
+        { text: "OK", onPress: goHome },
+      ]);
+    } catch (err) {
+      console.error(err);
+      Alert.alert("Error", "Could not save draft. Please try again.");
+    } finally {
+      setSavingDraft(false);
+    }
   };
 
   const handleClose = () => {
@@ -314,8 +327,13 @@ export function CreateReviewScreen() {
           style={styles.saveDraftButton}
           onPress={handleSaveDraft}
           activeOpacity={0.7}
+          disabled={savingDraft || publishing}
         >
-          <Text style={styles.saveDraftText}>{t("create.review.saveDraft")}</Text>
+          {savingDraft ? (
+            <ActivityIndicator color={colors.onSurfaceVariant} size="small" />
+          ) : (
+            <Text style={styles.saveDraftText}>{t("create.review.saveDraft")}</Text>
+          )}
         </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>

--- a/mobile/src/components/create-steps/CreateStepsScreen.tsx
+++ b/mobile/src/components/create-steps/CreateStepsScreen.tsx
@@ -48,7 +48,8 @@ function createEmptyStep(): StepFormItem {
 export function CreateStepsScreen() {
   const { t } = useTranslation('common');
   const navigation = useNavigation<NativeStackNavigationProp<CreateStackParamList>>();
-  const { draft, updateDraft, resetDraft } = useRecipeForm();
+  const { draft, updateDraft, resetDraft, saveDraft } = useRecipeForm();
+  const [savingDraft, setSavingDraft] = useState(false);
 
   // Single recipe video — restore from draft when coming back
   const [videoFileName, setVideoFileName] = useState<string | null>(draft.videoFileName);
@@ -156,8 +157,31 @@ export function CreateStepsScreen() {
     navigation.navigate('CreateReview');
   };
 
-  const handleSaveDraft = () => {
-    Alert.alert(t('create.draftSaved'), t('create.draftSavedMsg'));
+  const handleSaveDraft = async () => {
+    try {
+      setSavingDraft(true);
+      await saveDraft({
+        steps: steps.map((s) => ({
+          description: s.description,
+          timestamp: s.timestamp,
+        })),
+      });
+      Alert.alert(t("create.draftSaved"), t("create.draftSavedMsg2"), [
+        {
+          text: "OK",
+          onPress: () => {
+            resetDraft();
+            navigation.navigate("CreateBasicInfo" as never);
+            navigation.getParent()?.navigate("HomeTab" as never);
+          },
+        },
+      ]);
+    } catch (err) {
+      console.error(err);
+      Alert.alert("Error", "Could not save draft. Please try again.");
+    } finally {
+      setSavingDraft(false);
+    }
   };
 
   const handleClose = () => {
@@ -168,7 +192,7 @@ export function CreateStepsScreen() {
         style: 'destructive',
         onPress: () => {
           resetDraft();
-          navigation.popToTop();
+          navigation.navigate("CreateBasicInfo" as never);
           navigation.getParent()?.navigate('HomeTab' as never);
         },
       },
@@ -283,8 +307,12 @@ export function CreateStepsScreen() {
           <MaterialCommunityIcons name="arrow-right" size={20} color={colors.white} />
         </TouchableOpacity>
 
-        <TouchableOpacity style={styles.saveDraftButton} onPress={handleSaveDraft} activeOpacity={0.7}>
-          <Text style={styles.saveDraftText}>{t('create.saveDraft')}</Text>
+        <TouchableOpacity style={styles.saveDraftButton} onPress={handleSaveDraft} activeOpacity={0.7} disabled={savingDraft}>
+          {savingDraft ? (
+            <ActivityIndicator color={colors.onSurfaceVariant} size="small" />
+          ) : (
+            <Text style={styles.saveDraftText}>{t('create.saveDraft')}</Text>
+          )}
         </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>

--- a/mobile/src/context/RecipeFormContext.tsx
+++ b/mobile/src/context/RecipeFormContext.tsx
@@ -10,6 +10,7 @@ export interface ReviewStep {
 }
 
 export interface RecipeFormState {
+  recipeId?: string;
   // Screen 12 — Basic Info
   title: string;
   type: RecipeType;
@@ -38,6 +39,7 @@ export interface RecipeFormState {
 }
 
 const EMPTY_DRAFT: RecipeFormState = {
+  recipeId: undefined,
   title: '',
   type: 'COMMUNITY',
   originCountry: '',
@@ -65,9 +67,13 @@ interface RecipeFormContextValue {
   draft: RecipeFormState;
   updateDraft: (partial: Partial<RecipeFormState>) => void;
   resetDraft: () => void;
+  saveDraft: (partial: Partial<RecipeFormState>) => Promise<void>;
 }
 
 const RecipeFormContext = createContext<RecipeFormContextValue | null>(null);
+
+import { createRecipe, updateRecipe, attachRecipeMedia } from '../api/recipes';
+import { buildRecipePayload } from '../utils/buildRecipePayload';
 
 export function RecipeFormProvider({ children }: { children: React.ReactNode }) {
   const [draft, setDraft] = useState<RecipeFormState>(EMPTY_DRAFT);
@@ -80,8 +86,30 @@ export function RecipeFormProvider({ children }: { children: React.ReactNode }) 
     setDraft(EMPTY_DRAFT);
   };
 
+  const saveDraft = async (partial: Partial<RecipeFormState>) => {
+    const newDraft = { ...draft, ...partial };
+    setDraft(newDraft);
+    const payload = { ...buildRecipePayload(newDraft), isPublished: false };
+    let rId = newDraft.recipeId;
+    if (rId) {
+      await updateRecipe(rId, payload);
+    } else {
+      const created = await createRecipe(payload);
+      rId = created.id;
+      setDraft((prev) => ({ ...prev, recipeId: rId }));
+    }
+    
+    const imageAttachments = newDraft.imageUrls.map((url) =>
+      attachRecipeMedia(rId!, url, 'image').catch((err) => console.log('Media error', err))
+    );
+    const videoAttachment = newDraft.videoUrl
+      ? [attachRecipeMedia(rId!, newDraft.videoUrl, 'video').catch((err) => console.log('Media error', err))]
+      : [];
+    await Promise.all([...imageAttachments, ...videoAttachment]);
+  };
+
   return (
-    <RecipeFormContext.Provider value={{ draft, updateDraft, resetDraft }}>
+    <RecipeFormContext.Provider value={{ draft, updateDraft, resetDraft, saveDraft }}>
       {children}
     </RecipeFormContext.Provider>
   );

--- a/mobile/src/navigation/CreateStack.tsx
+++ b/mobile/src/navigation/CreateStack.tsx
@@ -5,7 +5,6 @@ import { useNavigation } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { useTranslation } from 'react-i18next';
 import type { CreateStackParamList, RootTabParamList } from './types';
-import { RecipeFormProvider } from '../context/RecipeFormContext';
 import { useAuth } from '../context/AuthContext';
 import { CreateBasicInfoScreen } from '../components/create-basic/CreateBasicInfoScreen';
 import { CreateIngredientsToolsScreen } from '../components/create-ingredients/CreateIngredientsToolsScreen';
@@ -32,13 +31,11 @@ export function CreateStack() {
   if (!canCreate) return null;
 
   return (
-    <RecipeFormProvider>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="CreateBasicInfo" component={CreateBasicInfoScreen} />
-        <Stack.Screen name="CreateIngredientsTools" component={CreateIngredientsToolsScreen} />
-        <Stack.Screen name="CreateSteps" component={CreateStepsScreen} />
-        <Stack.Screen name="CreateReview" component={CreateReviewScreen} />
-      </Stack.Navigator>
-    </RecipeFormProvider>
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="CreateBasicInfo" component={CreateBasicInfoScreen} />
+      <Stack.Screen name="CreateIngredientsTools" component={CreateIngredientsToolsScreen} />
+      <Stack.Screen name="CreateSteps" component={CreateStepsScreen} />
+      <Stack.Screen name="CreateReview" component={CreateReviewScreen} />
+    </Stack.Navigator>
   );
 }

--- a/mobile/src/screens/MyLibraryScreen.tsx
+++ b/mobile/src/screens/MyLibraryScreen.tsx
@@ -20,10 +20,12 @@ import {
   deleteRecipe,
   getFavorites,
   getMyRecipes,
-  publishRecipe,
+  getRecipeById,
   type FavoriteRecipe,
   type MyRecipeSummary,
 } from '../api/recipes';
+import { mapBackendToDraft } from '../utils/draftHelpers';
+import { useRecipeForm } from '../context/RecipeFormContext';
 import type { LibraryStackParamList } from '../navigation/types';
 import { colors, fontSizes, spacing } from '../theme';
 
@@ -65,7 +67,6 @@ export function MyLibraryScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [publishBusyId, setPublishBusyId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{
     id: string;
     title: string;
@@ -74,6 +75,9 @@ export function MyLibraryScreen() {
   const [sortModalOpen, setSortModalOpen] = useState(false);
   const [countryModalOpen, setCountryModalOpen] = useState(false);
   const [cityModalOpen, setCityModalOpen] = useState(false);
+
+  const { updateDraft } = useRecipeForm();
+  const [resumingId, setResumingId] = useState<string | null>(null);
 
   const isFavoritesTab = filter === 'favorites';
 
@@ -149,19 +153,6 @@ export function MyLibraryScreen() {
     : displayedRecipes.length === 0;
 
   const hasLocationData = countries.length > 0;
-
-  async function handlePublish(id: string) {
-    setActionError(null);
-    setPublishBusyId(id);
-    try {
-      await publishRecipe(id);
-      await load(false);
-    } catch {
-      setActionError(t('library.publishError'));
-    } finally {
-      setPublishBusyId(null);
-    }
-  }
 
   async function confirmDelete() {
     if (!deleteTarget) return;
@@ -266,16 +257,37 @@ export function MyLibraryScreen() {
 
   function renderItem({ item }: { item: MyRecipeSummary }) {
     const location = [item.city, item.country].filter(Boolean).join(', ');
+    const isResuming = resumingId === item.id;
     return (
       <TouchableOpacity
         activeOpacity={0.85}
         style={styles.card}
-        onPress={() =>
-          navigation.navigate('RecipeDetail', { recipeId: item.id })
-        }
+        disabled={isResuming}
+        onPress={async () => {
+          if (!item.isPublished) {
+            try {
+              setResumingId(item.id);
+              const detail = await getRecipeById(item.id);
+              const draftState = mapBackendToDraft(detail);
+              updateDraft(draftState);
+              navigation.getParent()?.navigate('CreateTab' as never);
+            } catch (err) {
+              console.error(err);
+              setActionError(t('library.errorRetry'));
+            } finally {
+              setResumingId(null);
+            }
+          } else {
+            navigation.navigate('RecipeDetail', { recipeId: item.id });
+          }
+        }}
       >
         <View style={styles.thumb}>
-          {item.coverImageUrl ? (
+          {isResuming ? (
+            <View style={styles.thumbPlaceholder}>
+              <ActivityIndicator color={colors.primary} />
+            </View>
+          ) : item.coverImageUrl ? (
             <Image
               source={{ uri: item.coverImageUrl }}
               style={styles.thumbImage}
@@ -368,19 +380,6 @@ export function MyLibraryScreen() {
           </View>
 
           <View style={styles.actionsRow}>
-            {!item.isPublished && (
-              <TouchableOpacity
-                style={[styles.actionBtn, styles.publishBtn]}
-                disabled={publishBusyId === item.id}
-                onPress={() => handlePublish(item.id)}
-              >
-                <Text style={styles.publishBtnText}>
-                  {publishBusyId === item.id
-                    ? t('library.publishing')
-                    : t('library.publish')}
-                </Text>
-              </TouchableOpacity>
-            )}
             <TouchableOpacity
               style={[styles.actionBtn, styles.deleteBtn]}
               onPress={() => openDeleteConfirm(item)}

--- a/mobile/src/screens/ProfileScreen.tsx
+++ b/mobile/src/screens/ProfileScreen.tsx
@@ -16,6 +16,9 @@ import { useTranslation } from 'react-i18next';
 import * as SecureStore from 'expo-secure-store';
 import { useAuth } from '../context/AuthContext';
 import { fetchApi } from '../api/client';
+import { getRecipeById } from '../api/recipes';
+import { mapBackendToDraft } from '../utils/draftHelpers';
+import { useRecipeForm } from '../context/RecipeFormContext';
 import { colors, fonts, fontSizes, spacing } from '../theme';
 import type { ProfileStackParamList } from '../navigation/types';
 
@@ -57,6 +60,9 @@ export function ProfileScreen() {
 
   const user = authState.status === 'authenticated' ? authState.user : null;
 
+  const { updateDraft } = useRecipeForm();
+  const [resumingId, setResumingId] = useState<string | null>(null);
+
   const [recipes, setRecipes] = useState<RecipeSummary[]>([]);
   const [recipesLoading, setRecipesLoading] = useState(true);
 
@@ -92,8 +98,24 @@ export function ProfileScreen() {
   const roleColor = ROLE_COLORS[role] ?? colors.primary;
 
   const publishedRecipes = recipes.filter((r) => r.isPublished);
-  const draftCount = recipes.filter((r) => !r.isPublished).length;
+  const drafts = recipes.filter((r) => !r.isPublished);
+  const draftCount = drafts.length;
   const recentPublished = publishedRecipes.slice(0, 5);
+  const recentDrafts = drafts.slice(0, 5);
+
+  const handleResumeDraft = async (recipeId: string) => {
+    try {
+      setResumingId(recipeId);
+      const detail = await getRecipeById(recipeId);
+      const draftState = mapBackendToDraft(detail);
+      updateDraft(draftState);
+      navigation.getParent()?.navigate('CreateTab' as never);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setResumingId(null);
+    }
+  };
 
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
@@ -219,6 +241,48 @@ export function ProfileScreen() {
                 </Text>
               </TouchableOpacity>
             )}
+          </View>
+        )}
+
+        {/* ── Recent drafts ── */}
+        {!recipesLoading && recentDrafts.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>{t('profileScreen.recentDrafts', 'My Drafts')}</Text>
+            {recentDrafts.map((recipe) => (
+              <TouchableOpacity
+                key={recipe.id}
+                style={styles.recipeCard}
+                activeOpacity={0.75}
+                disabled={resumingId === recipe.id}
+                onPress={() => handleResumeDraft(recipe.id)}
+              >
+                <View style={styles.recipeThumb}>
+                  {resumingId === recipe.id ? (
+                     <ActivityIndicator style={{ flex: 1 }} color={colors.primary} />
+                  ) : recipe.coverImageUrl ? (
+                    <Image
+                      source={{ uri: recipe.coverImageUrl }}
+                      style={StyleSheet.absoluteFillObject}
+                      resizeMode="cover"
+                    />
+                  ) : (
+                    <View style={styles.recipePlaceholder} />
+                  )}
+                </View>
+                <View style={styles.recipeBody}>
+                  <Text style={styles.recipeTitle} numberOfLines={2}>
+                    {recipe.title || 'Untitled Recipe'}
+                  </Text>
+                  <View style={styles.recipeMeta}>
+                    <View style={[styles.typeBadge, styles.typeCommunity, { backgroundColor: colors.surfaceContainer }]}>
+                       <Text style={[styles.typeBadgeText, { color: colors.onSurfaceVariant }]}>
+                         {t('library.statusDraft', 'Draft')}
+                       </Text>
+                    </View>
+                  </View>
+                </View>
+              </TouchableOpacity>
+            ))}
           </View>
         )}
 

--- a/mobile/src/utils/draftHelpers.ts
+++ b/mobile/src/utils/draftHelpers.ts
@@ -1,0 +1,52 @@
+import type { BackendRecipeDetail } from '../api/recipes';
+import type { RecipeFormState } from '../context/RecipeFormContext';
+
+export function mapBackendToDraft(recipe: BackendRecipeDetail): RecipeFormState {
+  const dietaryTags = recipe.tags.filter(t => t.category === 'dietary');
+  const allergenTags = recipe.tags.filter(t => t.category === 'allergen');
+
+  // Currently we only have ingredient names and tools in the frontend form
+  return {
+    recipeId: recipe.id,
+    title: recipe.title,
+    type: recipe.type === 'cultural' ? 'CULTURAL' : 'COMMUNITY',
+    originCountry: recipe.country || '',
+    originCity: recipe.city || '',
+    originDistrict: recipe.district || '',
+    genreId: null, // We don't have genreId from backend directly, we have genreName. But we can ignore it or try to find it.
+    varietyId: recipe.dishVarietyId,
+    dietaryTagIds: dietaryTags.map(t => t.id).filter(Boolean) as number[],
+    dietaryTagNames: dietaryTags.map(t => t.name).filter(Boolean) as string[],
+    allergenTagIds: allergenTags.map(t => t.id).filter(Boolean) as number[],
+    allergenTagNames: allergenTags.map(t => t.name).filter(Boolean) as string[],
+    culturalTagIds: [], // Not supported fully in backend yet
+    culturalTags: [],
+    story: recipe.story || '',
+    servingSize: recipe.servingSize || undefined,
+    ingredients: recipe.ingredients.map(ing => ({
+      id: ing.id,
+      ingredientId: ing.ingredientId,
+      name: ing.ingredientName || '',
+      quantity: String(ing.quantity || ''),
+      unit: ing.unit || 'g',
+    })),
+    tools: recipe.tools.map(t => ({ id: t.id, name: t.name })),
+    imageUrls: recipe.media.filter(m => m.type === 'image').map(m => m.url),
+    videoUrl: recipe.media.find(m => m.type === 'video')?.url || null,
+    videoFileName: recipe.media.find(m => m.type === 'video') ? 'video.mp4' : null,
+    steps: recipe.steps.map(s => {
+      let timestamp = '';
+      if (s.videoTimestamp) {
+        const mm = Math.floor(s.videoTimestamp / 60).toString().padStart(2, '0');
+        const ss = (s.videoTimestamp % 60).toString().padStart(2, '0');
+        timestamp = `${mm}:${ss}`;
+      }
+      return {
+        id: s.id,
+        description: s.description,
+        timestamp,
+        isExpanded: false
+      };
+    })
+  };
+}


### PR DESCRIPTION
## What does this PR do?
This PR completes the end-to-end integration of the "Save Draft" feature for the recipe creation wizard. It allows users to seamlessly save their progress across all four creation steps, properly updates existing drafts instead of duplicating them upon publishing, fetches missing category data upon resuming, and safely handles React Navigation stack resets.

## How to test
1. Navigate to the **Create Tab** and fill in some initial details on the Basic Info screen.
2. Click the **Save Draft** button and confirm the alert.
3. Go to the **Profile** screen or **My Library** screen to find your saved draft.
4. Tap the draft to resume editing. Verify that the previous fields (including Dropdowns) are populated correctly.
5. Proceed to the **Review** screen and press **Publish** to verify the draft correctly transitions to a published recipe without creating a duplicate.
6. Run `npm test` locally to ensure the new `CreateScreensDraft.test.tsx` suite passes.

## Related issue
Closes #429