### PR TITLE
Add tool translations and language-aware names for recipes

### DIFF
--- a/backend/migrations/008_recipe_tool_translations.sql
+++ b/backend/migrations/008_recipe_tool_translations.sql
@@ -1,0 +1,14 @@
+-- Migration 008: recipe_tool_translations
+-- Stores DeepL-generated translations of recipe tool names (EN↔TR).
+-- Follows the same pattern as recipe_step_translations.
+
+CREATE TABLE public.recipe_tool_translations (
+  recipe_tool_id integer NOT NULL
+    REFERENCES public.recipe_tools(id) ON DELETE CASCADE,
+  language_code  text    NOT NULL CHECK (language_code IN ('EN', 'TR')),
+  name           text    NOT NULL,
+  PRIMARY KEY (recipe_tool_id, language_code)
+);
+
+CREATE INDEX recipe_tool_translations_tool_id_idx
+  ON public.recipe_tool_translations (recipe_tool_id);

--- a/backend/src/__tests__/translation.test.ts
+++ b/backend/src/__tests__/translation.test.ts
@@ -75,12 +75,18 @@ describe("translateRecipe()", () => {
     delete process.env["DEEPL_API_KEY"];
   });
 
+  const DEFAULT_TOOLS = [
+    { id: "tool-1", name: "Oven" },
+    { id: "tool-2", name: "Bowl" },
+  ];
+
   /** Sets up supabase.from with default table responses, accepting per-table overrides. */
   const setupDb = (overrides: {
     recipe?: any;
     recipeError?: any;
     steps?: any[];
     ingredients?: any[];
+    tools?: any[];
   } = {}) => {
     (supabase.from as jest.Mock).mockImplementation((table: string) => {
       switch (table) {
@@ -93,6 +99,8 @@ describe("translateRecipe()", () => {
           return chain({ data: overrides.steps ?? DEFAULT_STEPS, error: null });
         case "recipe_ingredients":
           return chain({ data: overrides.ingredients ?? DEFAULT_INGREDIENTS, error: null });
+        case "recipe_tools":
+          return chain({ data: overrides.tools ?? DEFAULT_TOOLS, error: null });
         default:
           return chain({ data: null, error: null });
       }
@@ -377,11 +385,11 @@ describe("translateRecipe()", () => {
   // ─── Edge cases ───────────────────────────────────────────────────────────────
 
   it("handles recipe with no story — story is excluded from DeepL batch", async () => {
-    setupDb({ recipe: { title: "Pasta", story: null } });
+    setupDb({ recipe: { title: "Pasta", story: null }, tools: [] });
     mockTranslateText
       .mockResolvedValueOnce({ text: "Makarna", detectedSourceLang: "en" })
       .mockResolvedValueOnce([
-        { text: "Makarna" },       // title
+        { text: "Makarna" },         // title
         { text: "Unu karıştırın." }, // step 1
         { text: "180°C'de pişirin." }, // step 2
       ]);
@@ -389,7 +397,7 @@ describe("translateRecipe()", () => {
     const spy = jest.spyOn(console, "log").mockImplementation(() => {});
     await translationService.translateRecipe(RECIPE_ID);
 
-    // Second call: [title, step1, step2] — no story → 3 items
+    // Second call: [title, step1, step2] — no story, no tools → 3 items
     const textsArg: string[] = mockTranslateText.mock.calls[1]?.[0];
     expect(textsArg).toHaveLength(3);
     spy.mockRestore();
@@ -429,6 +437,86 @@ describe("translateRecipe()", () => {
       ([t]: [string]) => t === "recipe_ingredient_translations"
     );
     expect(ingTransCalls).toHaveLength(0);
+    spy.mockRestore();
+  });
+
+  // ─── Tool translation ─────────────────────────────────────────────────────────
+
+  it("includes tool names in the DeepL batch after steps", async () => {
+    setupDb({ tools: [{ id: "tool-1", name: "Oven" }] });
+    mockTranslateText
+      .mockResolvedValueOnce({ text: "Çikolatalı Kek", detectedSourceLang: "en" })
+      .mockResolvedValueOnce([
+        { text: "Çikolatalı Kek" },
+        { text: "Lezzetli bir pasta." },
+        { text: "Unu karıştırın." },
+        { text: "180°C'de pişirin." },
+        { text: "Fırın" },
+      ]);
+
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await translationService.translateRecipe(RECIPE_ID);
+
+    const textsArg: string[] = mockTranslateText.mock.calls[1]?.[0];
+    expect(textsArg).toContain("Oven");
+    // Tool comes after steps
+    expect(textsArg.indexOf("Oven")).toBeGreaterThan(textsArg.indexOf("Bake at 180°C."));
+    spy.mockRestore();
+  });
+
+  it("upserts translated tool names to recipe_tool_translations", async () => {
+    const upsertMock = jest.fn().mockResolvedValue({ error: null });
+
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "recipes") return chain({ data: DEFAULT_RECIPE, error: null });
+      if (table === "recipe_steps") return chain({ data: DEFAULT_STEPS, error: null });
+      if (table === "recipe_ingredients") return chain({ data: DEFAULT_INGREDIENTS, error: null });
+      if (table === "recipe_tools")
+        return chain({ data: [{ id: "tool-1", name: "Oven" }], error: null });
+      if (table === "recipe_tool_translations") return { upsert: upsertMock };
+      return chain({ data: null, error: null });
+    });
+
+    mockTranslateText
+      .mockResolvedValueOnce({ text: "Çikolatalı Kek", detectedSourceLang: "en" })
+      .mockResolvedValueOnce([
+        { text: "Çikolatalı Kek" },
+        { text: "Lezzetli bir pasta." },
+        { text: "Unu karıştırın." },
+        { text: "180°C'de pişirin." },
+        { text: "Fırın" },
+      ]);
+
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await translationService.translateRecipe(RECIPE_ID);
+
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ recipe_tool_id: "tool-1", language_code: "TR", name: "Fırın" }),
+      ]),
+      expect.anything()
+    );
+    spy.mockRestore();
+  });
+
+  it("skips recipe_tool_translations upsert when recipe has no tools", async () => {
+    setupDb({ tools: [] });
+    mockTranslateText
+      .mockResolvedValueOnce({ text: "Çikolatalı Kek", detectedSourceLang: "en" })
+      .mockResolvedValueOnce([
+        { text: "Çikolatalı Kek" },
+        { text: "Lezzetli bir pasta." },
+        { text: "Unu karıştırın." },
+        { text: "180°C'de pişirin." },
+      ]);
+
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await translationService.translateRecipe(RECIPE_ID);
+
+    const toolTransCalls = (supabase.from as jest.Mock).mock.calls.filter(
+      ([t]: [string]) => t === "recipe_tool_translations"
+    );
+    expect(toolTransCalls).toHaveLength(0);
     spy.mockRestore();
   });
 });
@@ -569,6 +657,120 @@ describe("GET /recipes/:id?lang=", () => {
     const res = await request(app).get("/recipes/recipe-1?lang=tr");
     expect(res.status).toBe(200);
     expect(res.body.data.ingredients[0].unit).toBe("cup");
+  });
+
+  // ─── dishVarietyName / genreName / ingredientName lang resolution ─────────────
+
+  const mockRecipeWithNames = {
+    ...mockRecipeData,
+    dish_variety: {
+      id: 2,
+      name: "Adana Kebap",
+      name_en: "Adana Kebap",
+      name_tr: "Adana Kebabı",
+      dish_genre: { id: 1, name: "Kebap", name_en: "Kebab", name_tr: "Kebap" },
+    },
+    recipe_ingredients: [
+      {
+        id: "ri-1",
+        quantity: 2,
+        unit: "cup",
+        ingredient: { id: 1, name: "Flour", name_en: "Flour", name_tr: "Un", ingredient_allergens: [] },
+      },
+    ],
+    recipe_tools: [{ id: "tool-1", name: "Oven" }],
+  };
+
+  it("dishVarietyName returns name_en when ?lang=en", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithNames, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=en");
+    expect(res.status).toBe(200);
+    expect(res.body.data.dishVarietyName).toBe("Adana Kebap");
+    expect(res.body.data.genreName).toBe("Kebab");
+  });
+
+  it("dishVarietyName returns name_tr when ?lang=tr", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithNames, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.dishVarietyName).toBe("Adana Kebabı");
+    expect(res.body.data.genreName).toBe("Kebap");
+  });
+
+  it("dishVarietyName falls back to name_en when name_tr is null and ?lang=tr", async () => {
+    setupMock({
+      recipes: {
+        data: {
+          ...mockRecipeWithNames,
+          dish_variety: {
+            id: 2, name: "Urfa Kebap", name_en: "Urfa Kebap", name_tr: null,
+            dish_genre: { id: 1, name: "Kebap", name_en: "Kebab", name_tr: null },
+          },
+        },
+        error: null,
+      },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.dishVarietyName).toBe("Urfa Kebap");
+  });
+
+  it("ingredientName returns lang-appropriate value when ?lang=tr", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithNames, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].ingredientName).toBe("Un");
+  });
+
+  it("tools[].name returns translated name when ?lang=tr and translation exists", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithNames, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: {
+        data: [{ recipe_tool_id: "tool-1", name: "Fırın" }],
+        error: null,
+      },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.tools[0].name).toBe("Fırın");
+  });
+
+  it("tools[].name falls back to original when no tool translation exists", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithNames, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.tools[0].name).toBe("Oven");
   });
 });
 

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -11,6 +11,20 @@ import { translateRecipe } from "../services/translationService.js";
 
 const router = Router();
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Resolves name_en / name_tr based on langParam, falls back to name. */
+function resolveLocalizedName(
+  obj: { name?: string | null; name_en?: string | null; name_tr?: string | null } | null | undefined,
+  langParam: string | null
+): string | null {
+  if (!obj) return null;
+  if (!langParam) return obj.name ?? null;
+  const preferred = langParam === "EN" ? obj.name_en : obj.name_tr;
+  const fallback  = langParam === "EN" ? obj.name_tr  : obj.name_en;
+  return preferred ?? fallback ?? obj.name ?? null;
+}
+
 // ─── Zod Schemas ──────────────────────────────────────────────────────────────
 
 const recipeSchema = z.object({
@@ -243,8 +257,8 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
     .select(
       `id, title, story, video_url, serving_size, type, is_published, average_rating, rating_count, allergen_ids, country, city, district, created_at, updated_at,
        creator:profiles!recipes_creator_id_fkey(id, username),
-       dish_variety:dish_varieties(id, name, dish_genre:dish_genres(id, name)),
-       recipe_ingredients(id, quantity, unit, ingredient:ingredients(id, name, ingredient_allergens(allergen:allergens(name)))),
+       dish_variety:dish_varieties(id, name, name_en, name_tr, dish_genre:dish_genres(id, name, name_en, name_tr)),
+       recipe_ingredients(id, quantity, unit, ingredient:ingredients(id, name, name_en, name_tr, ingredient_allergens(allergen:allergens(name)))),
        recipe_steps(id, step_order, description, video_timestamp),
        recipe_tools(id, name),
        recipe_media(id, url, type),
@@ -273,11 +287,13 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
   let resolvedStory: string | null = (data as any).story ?? null;
   let stepTranslationMap: Record<number, string> = {};
   let ingredientUnitMap: Record<number, string> = {};
+  let toolNameMap: Record<number, string> = {};
 
   if (langParam) {
     const ingredientIds = (data.recipe_ingredients ?? []).map((ri: any) => ri.id);
+    const toolIds = (data.recipe_tools ?? []).map((t: any) => t.id);
 
-    const [recipeTransResult, stepTransResult, ingTransResult] = await Promise.all([
+    const [recipeTransResult, stepTransResult, ingTransResult, toolTransResult] = await Promise.all([
       supabase
         .from("recipe_translations")
         .select("title, story")
@@ -296,6 +312,13 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
             .in("recipe_ingredient_id", ingredientIds)
             .eq("language_code", langParam)
         : Promise.resolve({ data: [], error: null }),
+      toolIds.length > 0
+        ? supabase
+            .from("recipe_tool_translations")
+            .select("recipe_tool_id, name")
+            .in("recipe_tool_id", toolIds)
+            .eq("language_code", langParam)
+        : Promise.resolve({ data: [], error: null }),
     ]);
 
     if (recipeTransResult.data) {
@@ -309,6 +332,10 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
 
     for (const row of ingTransResult.data ?? []) {
       ingredientUnitMap[(row as any).recipe_ingredient_id] = (row as any).unit;
+    }
+
+    for (const row of toolTransResult.data ?? []) {
+      toolNameMap[(row as any).recipe_tool_id] = (row as any).name;
     }
   }
 
@@ -351,8 +378,8 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       creatorId: (data.creator as any)?.id ?? null,
       creatorUsername: (data.creator as any)?.username ?? null,
       dishVarietyId: (data.dish_variety as any)?.id ?? null,
-      dishVarietyName: (data.dish_variety as any)?.name ?? null,
-      genreName: (data.dish_variety as any)?.dish_genre?.name ?? null,
+      dishVarietyName: resolveLocalizedName((data.dish_variety as any), langParam),
+      genreName: resolveLocalizedName((data.dish_variety as any)?.dish_genre, langParam),
       title: resolvedTitle,
       story: resolvedStory,
       videoUrl: (data as any).video_url ?? null,
@@ -369,7 +396,7 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       ingredients: (data.recipe_ingredients ?? []).map((ri: any) => ({
         id: ri.id,
         ingredientId: ri.ingredient?.id ?? null,
-        ingredientName: ri.ingredient?.name ?? null,
+        ingredientName: resolveLocalizedName(ri.ingredient, langParam),
         quantity: ri.quantity,
         unit: ingredientUnitMap[ri.id] ?? ri.unit,
         allergens: (ri.ingredient?.ingredient_allergens ?? [])
@@ -384,7 +411,7 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       })),
       tools: (data.recipe_tools ?? []).map((t: any) => ({
         id: t.id,
-        name: t.name,
+        name: toolNameMap[t.id] ?? t.name,
       })),
       media: (data.recipe_media ?? []).map((m: any) => ({
         id: m.id,

--- a/backend/src/services/translationService.ts
+++ b/backend/src/services/translationService.ts
@@ -78,8 +78,8 @@ export async function translateRecipe(recipeId: string): Promise<void> {
 
   const translator = new Translator(apiKey);
 
-  // 1. Fetch recipe fields, steps, and ingredients in parallel
-  const [recipeResult, stepsResult, ingredientsResult] = await Promise.all([
+  // 1. Fetch recipe fields, steps, ingredients, and tools in parallel
+  const [recipeResult, stepsResult, ingredientsResult, toolsResult] = await Promise.all([
     supabase.from("recipes").select("title, story").eq("id", recipeId).single(),
     supabase
       .from("recipe_steps")
@@ -89,6 +89,10 @@ export async function translateRecipe(recipeId: string): Promise<void> {
     supabase
       .from("recipe_ingredients")
       .select("id, unit")
+      .eq("recipe_id", recipeId),
+    supabase
+      .from("recipe_tools")
+      .select("id, name")
       .eq("recipe_id", recipeId),
   ]);
 
@@ -100,6 +104,7 @@ export async function translateRecipe(recipeId: string): Promise<void> {
   const recipe = recipeResult.data;
   const steps = stepsResult.data ?? [];
   const ingredients = ingredientsResult.data ?? [];
+  const tools = toolsResult.data ?? [];
 
   // 2. Detect source language by translating title to EN-US
   let detectedSource: string;
@@ -117,14 +122,16 @@ export async function translateRecipe(recipeId: string): Promise<void> {
   const sourceIsEnglish = detectedSource === "en";
   const langCode: "EN" | "TR" = sourceIsEnglish ? "TR" : "EN";
 
-  // 3. Translate title, story, step descriptions via DeepL
+  // 3. Translate title, story, step descriptions, and tool names via DeepL
   let translatedTitle: string;
   let translatedStory: string | null = null;
   let translatedStepDescriptions: string[] = [];
+  let translatedToolNames: string[] = [];
 
   const extraTexts: string[] = [];
   if (recipe.story) extraTexts.push(recipe.story as string);
   for (const step of steps) extraTexts.push(step.description);
+  for (const tool of tools) extraTexts.push(tool.name);
 
   try {
     if (sourceIsEnglish) {
@@ -133,14 +140,18 @@ export async function translateRecipe(recipeId: string): Promise<void> {
       translatedTitle = results[0]!.text;
       let idx = 1;
       if (recipe.story) translatedStory = results[idx++]!.text;
-      translatedStepDescriptions = results.slice(idx).map((r) => r.text);
+      translatedStepDescriptions = results.slice(idx, idx + steps.length).map((r) => r.text);
+      idx += steps.length;
+      translatedToolNames = results.slice(idx).map((r) => r.text);
     } else {
       translatedTitle = enTitle;
       if (extraTexts.length > 0) {
         const results = (await translator.translateText(extraTexts, null, "en-US")) as TextResult[];
         let idx = 0;
         if (recipe.story) translatedStory = results[idx++]!.text;
-        translatedStepDescriptions = results.slice(idx).map((r) => r.text);
+        translatedStepDescriptions = results.slice(idx, idx + steps.length).map((r) => r.text);
+        idx += steps.length;
+        translatedToolNames = results.slice(idx).map((r) => r.text);
       }
     }
   } catch (err) {
@@ -191,6 +202,23 @@ export async function translateRecipe(recipeId: string): Promise<void> {
 
     if (ingTransError) {
       console.error(`[translation] Failed to store ingredient translations (${langCode}):`, ingTransError);
+    }
+  }
+
+  // 7. Upsert tool name translations
+  if (tools.length > 0 && translatedToolNames.length > 0) {
+    const toolRows = tools.map((tool, i) => ({
+      recipe_tool_id: tool.id,
+      language_code: langCode,
+      name: translatedToolNames[i] ?? tool.name,
+    }));
+
+    const { error: toolTransError } = await supabase
+      .from("recipe_tool_translations")
+      .upsert(toolRows, { onConflict: "recipe_tool_id,language_code" });
+
+    if (toolTransError) {
+      console.error(`[translation] Failed to store tool translations (${langCode}):`, toolTransError);
     }
   }
 


### PR DESCRIPTION
This pull request introduces support for translating recipe tool names between English and Turkish, both in the database schema and in the API. It also improves the localization logic for dish variety, genre, ingredient, and tool names in recipe responses. Comprehensive tests are added to ensure correct translation handling and fallback behaviors.

**Database and Backend API changes:**

* Added a new table `recipe_tool_translations` to store DeepL-generated translations of recipe tool names, following the pattern of existing translation tables.
* Modified the recipe GET endpoint to fetch and return translated tool names when a language is specified, falling back to the original name if no translation exists. Also extended the selection of dish variety, genre, and ingredient fields to include language-specific names. 
* Added a helper function `resolveLocalizedName` to consistently resolve the appropriate name field (`name_en`, `name_tr`, or fallback) for dish varieties, genres, and ingredients based on the requested language.

**Translation Service changes:**

* Updated the `translateRecipe` service to include tool names in DeepL translation batches and upsert translated tool names into the new `recipe_tool_translations` table. 

**Testing improvements:**

* Extended and added tests to cover tool name translation, upsert logic, and API response localization for dish variety, genre, ingredient, and tool names, including fallback scenarios.

These changes ensure that tool names are fully translatable and properly localized in all relevant API responses, providing a more complete multilingual experience.

closes #535 
closes #536 
closes #537 

