### PR TITLE
test(frontend): add integration tests for service layer (#509)

### DIFF
--- a/frontend/src/__tests__/integration/auth-service.test.ts
+++ b/frontend/src/__tests__/integration/auth-service.test.ts
@@ -1,0 +1,134 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { authService } from '@/services/auth-service'
+
+const BASE = 'http://localhost/api'
+
+describe('authService', () => {
+  describe('login()', () => {
+    it('sends credentials and returns the unwrapped data payload', async () => {
+      let capturedBody: unknown = null
+
+      server.use(
+        http.post(`${BASE}/auth/login`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({
+            success: true,
+            data: {
+              userId: '42',
+              accessToken: 'access-token',
+              refreshToken: 'refresh-token',
+            },
+          })
+        }),
+      )
+
+      const result = await authService.login({
+        email: 'user@example.com',
+        password: 'secret',
+      })
+
+      expect(capturedBody).toEqual({ email: 'user@example.com', password: 'secret' })
+      expect(result).toEqual({
+        userId: '42',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      })
+    })
+
+    it('rejects when the server returns 401', async () => {
+      server.use(
+        http.post(`${BASE}/auth/login`, () =>
+          HttpResponse.json(
+            { success: false, data: null, error: { code: 'UNAUTHORIZED', message: 'bad' } },
+            { status: 401 },
+          ),
+        ),
+      )
+
+      await expect(
+        authService.login({ email: 'u@example.com', password: 'wrong' }),
+      ).rejects.toBeDefined()
+    })
+  })
+
+  describe('register()', () => {
+    it('forwards the registration payload and returns tokens', async () => {
+      let capturedBody: unknown = null
+
+      server.use(
+        http.post(`${BASE}/auth/register`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({
+            success: true,
+            data: {
+              userId: '7',
+              accessToken: 'a',
+              refreshToken: 'r',
+              role: 'cook',
+            },
+          })
+        }),
+      )
+
+      const result = await authService.register({
+        email: 'new@example.com',
+        password: 'pw1234567',
+        username: 'newbie',
+        role: 'cook',
+      })
+
+      expect(capturedBody).toEqual({
+        email: 'new@example.com',
+        password: 'pw1234567',
+        username: 'newbie',
+        role: 'cook',
+      })
+      expect(result.userId).toBe('7')
+      expect(result.role).toBe('cook')
+    })
+
+    it('passes through pendingExpertRequest when registering as expert', async () => {
+      server.use(
+        http.post(`${BASE}/auth/register`, () =>
+          HttpResponse.json({
+            success: true,
+            data: {
+              userId: '9',
+              accessToken: 'a',
+              refreshToken: 'r',
+              role: 'cook',
+              pendingExpertRequest: true,
+            },
+          }),
+        ),
+      )
+
+      const result = await authService.register({
+        email: 'expert@example.com',
+        password: 'pw1234567',
+        username: 'expert',
+        role: 'expert',
+        expertRequestReason: 'I cook traditional food',
+      })
+
+      expect(result.pendingExpertRequest).toBe(true)
+      expect(result.role).toBe('cook')
+    })
+  })
+
+  describe('logout()', () => {
+    it('POSTs to /auth/logout', async () => {
+      let called = false
+      server.use(
+        http.post(`${BASE}/auth/logout`, () => {
+          called = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await authService.logout()
+      expect(called).toBe(true)
+    })
+  })
+})

--- a/frontend/src/__tests__/integration/comment-service.test.ts
+++ b/frontend/src/__tests__/integration/comment-service.test.ts
@@ -1,0 +1,152 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { commentService } from '@/services/comment-service'
+
+const BASE = 'http://localhost/api'
+
+describe('commentService', () => {
+  describe('list()', () => {
+    it('forwards pagination and returns comments page', async () => {
+      let capturedUrl: URL | null = null
+      server.use(
+        http.get(`${BASE}/recipes/:id/comments`, ({ request }) => {
+          capturedUrl = new URL(request.url)
+          return HttpResponse.json({
+            success: true,
+            data: {
+              comments: [
+                {
+                  id: 'c1',
+                  recipeId: '10',
+                  userId: 'u1',
+                  username: 'alice',
+                  body: 'Great recipe!',
+                  score: 5,
+                  createdAt: '2026-05-01T00:00:00Z',
+                  updatedAt: '2026-05-01T00:00:00Z',
+                },
+              ],
+              pagination: { page: 3, limit: 2, total: 1 },
+            },
+            error: null,
+          })
+        }),
+      )
+
+      const page = await commentService.list('10', 3, 2)
+
+      expect(capturedUrl!.searchParams.get('page')).toBe('3')
+      expect(capturedUrl!.searchParams.get('limit')).toBe('2')
+      expect(page.comments).toHaveLength(1)
+      expect(page.comments[0].username).toBe('alice')
+    })
+  })
+
+  describe('create()', () => {
+    it('omits score when not provided and flattens response', async () => {
+      let capturedBody: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${BASE}/recipes/:id/comments`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({
+            success: true,
+            data: {
+              comment: {
+                id: 'c2',
+                recipeId: '10',
+                userId: 'u1',
+                username: 'alice',
+                body: 'Yum',
+                createdAt: '2026-05-02T00:00:00Z',
+                updatedAt: '2026-05-02T00:00:00Z',
+              },
+              rating: null,
+            },
+            error: null,
+          })
+        }),
+      )
+
+      const comment = await commentService.create('10', 'Yum')
+
+      expect(capturedBody).toEqual({ body: 'Yum' })
+      expect(capturedBody && 'score' in capturedBody).toBe(false)
+      expect(comment.score).toBeNull()
+      expect(comment.body).toBe('Yum')
+    })
+
+    it('includes score and merges rating.score onto the returned comment', async () => {
+      let capturedBody: unknown = null
+      server.use(
+        http.post(`${BASE}/recipes/:id/comments`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({
+            success: true,
+            data: {
+              comment: {
+                id: 'c3',
+                recipeId: '10',
+                userId: 'u1',
+                username: 'alice',
+                body: 'Loved it',
+                createdAt: '2026-05-02T00:00:00Z',
+                updatedAt: '2026-05-02T00:00:00Z',
+              },
+              rating: { score: 4 },
+            },
+            error: null,
+          })
+        }),
+      )
+
+      const comment = await commentService.create('10', 'Loved it', 4)
+
+      expect(capturedBody).toEqual({ body: 'Loved it', score: 4 })
+      expect(comment.score).toBe(4)
+    })
+  })
+
+  describe('remove()', () => {
+    it('DELETEs /comments/:id', async () => {
+      let captured: string | undefined
+      server.use(
+        http.delete(`${BASE}/comments/:id`, ({ params }) => {
+          captured = params.id as string
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await commentService.remove('c9')
+      expect(captured).toBe('c9')
+    })
+  })
+
+  describe('edit()', () => {
+    it('PATCHes /comments/:id with body and returns updated comment', async () => {
+      let capturedBody: unknown = null
+      server.use(
+        http.patch(`${BASE}/comments/:id`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({
+            success: true,
+            data: {
+              id: 'c4',
+              recipeId: '10',
+              userId: 'u1',
+              username: 'alice',
+              body: 'edited',
+              score: null,
+              createdAt: '2026-05-02T00:00:00Z',
+              updatedAt: '2026-05-03T00:00:00Z',
+            },
+            error: null,
+          })
+        }),
+      )
+
+      const updated = await commentService.edit('c4', 'edited')
+      expect(capturedBody).toEqual({ body: 'edited' })
+      expect(updated.body).toBe('edited')
+    })
+  })
+})

--- a/frontend/src/__tests__/integration/expert-request-service.test.ts
+++ b/frontend/src/__tests__/integration/expert-request-service.test.ts
@@ -1,0 +1,92 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { expertRequestService } from '@/services/expert-request-service'
+
+const BASE = 'http://localhost/api'
+
+describe('expertRequestService', () => {
+  describe('submit()', () => {
+    it('POSTs the reason and returns the created request', async () => {
+      let capturedBody: unknown = null
+      server.use(
+        http.post(`${BASE}/auth/expert-requests`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({
+            success: true,
+            data: {
+              id: 'er-1',
+              userId: 'u-1',
+              reason: 'I have a culinary degree',
+              status: 'pending',
+              decisionNote: null,
+              decidedBy: null,
+              createdAt: '2026-05-01T00:00:00Z',
+              decidedAt: null,
+            },
+            error: null,
+          })
+        }),
+      )
+
+      const result = await expertRequestService.submit('I have a culinary degree')
+      expect(capturedBody).toEqual({ reason: 'I have a culinary degree' })
+      expect(result.id).toBe('er-1')
+      expect(result.status).toBe('pending')
+    })
+
+    it('rejects when backend returns 409 EXPERT_REQUEST_PENDING', async () => {
+      server.use(
+        http.post(`${BASE}/auth/expert-requests`, () =>
+          HttpResponse.json(
+            {
+              success: false,
+              data: null,
+              error: { code: 'EXPERT_REQUEST_PENDING', message: 'already pending' },
+            },
+            { status: 409 },
+          ),
+        ),
+      )
+
+      await expect(expertRequestService.submit('again')).rejects.toBeDefined()
+    })
+  })
+
+  describe('getMine()', () => {
+    it('returns null when no request exists', async () => {
+      server.use(
+        http.get(`${BASE}/auth/expert-requests/me`, () =>
+          HttpResponse.json({ success: true, data: null, error: null }),
+        ),
+      )
+
+      const result = await expertRequestService.getMine()
+      expect(result).toBeNull()
+    })
+
+    it('returns the latest expert request when present', async () => {
+      server.use(
+        http.get(`${BASE}/auth/expert-requests/me`, () =>
+          HttpResponse.json({
+            success: true,
+            data: {
+              id: 'er-9',
+              userId: 'u-1',
+              reason: 'experienced',
+              status: 'approved',
+              decisionNote: 'welcome',
+              decidedBy: 'admin-1',
+              createdAt: '2026-04-01T00:00:00Z',
+              decidedAt: '2026-04-02T00:00:00Z',
+            },
+            error: null,
+          }),
+        ),
+      )
+
+      const result = await expertRequestService.getMine()
+      expect(result?.id).toBe('er-9')
+      expect(result?.status).toBe('approved')
+    })
+  })
+})

--- a/frontend/src/__tests__/integration/favorite-service.test.ts
+++ b/frontend/src/__tests__/integration/favorite-service.test.ts
@@ -1,0 +1,99 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { favoriteService } from '@/services/favorite-service'
+
+const BASE = 'http://localhost/api'
+
+describe('favoriteService', () => {
+  describe('add()', () => {
+    it('POSTs to /users/me/favorites/:id', async () => {
+      let capturedId: string | undefined
+      server.use(
+        http.post(`${BASE}/users/me/favorites/:id`, ({ params }) => {
+          capturedId = params.id as string
+          return HttpResponse.json({
+            success: true,
+            data: { recipeId: params.id, favorited: true },
+            error: null,
+          })
+        }),
+      )
+
+      await favoriteService.add('abc-123')
+      expect(capturedId).toBe('abc-123')
+    })
+  })
+
+  describe('remove()', () => {
+    it('DELETEs /users/me/favorites/:id', async () => {
+      let capturedId: string | undefined
+      server.use(
+        http.delete(`${BASE}/users/me/favorites/:id`, ({ params }) => {
+          capturedId = params.id as string
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await favoriteService.remove('xyz-9')
+      expect(capturedId).toBe('xyz-9')
+    })
+  })
+
+  describe('list()', () => {
+    it('forwards page/limit and returns the favorites page', async () => {
+      let capturedUrl: URL | null = null
+      server.use(
+        http.get(`${BASE}/users/me/favorites`, ({ request }) => {
+          capturedUrl = new URL(request.url)
+          return HttpResponse.json({
+            success: true,
+            data: {
+              recipes: [
+                {
+                  id: 'r1',
+                  title: 'Lahmacun',
+                  type: 'cultural',
+                  averageRating: 4.5,
+                  ratingCount: 12,
+                  creatorUsername: 'chef',
+                  dishVarietyName: 'Lahmacun',
+                  genreName: 'Pastries',
+                  coverImageUrl: null,
+                  createdAt: '2026-04-01T00:00:00Z',
+                },
+              ],
+              pagination: { page: 2, limit: 5, total: 1 },
+            },
+            error: null,
+          })
+        }),
+      )
+
+      const result = await favoriteService.list(2, 5)
+
+      expect(capturedUrl!.searchParams.get('page')).toBe('2')
+      expect(capturedUrl!.searchParams.get('limit')).toBe('5')
+      expect(result.recipes).toHaveLength(1)
+      expect(result.recipes[0].title).toBe('Lahmacun')
+      expect(result.pagination.total).toBe(1)
+    })
+
+    it('uses defaults page=1 limit=20 when no args given', async () => {
+      let capturedUrl: URL | null = null
+      server.use(
+        http.get(`${BASE}/users/me/favorites`, ({ request }) => {
+          capturedUrl = new URL(request.url)
+          return HttpResponse.json({
+            success: true,
+            data: { recipes: [], pagination: { page: 1, limit: 20, total: 0 } },
+            error: null,
+          })
+        }),
+      )
+
+      await favoriteService.list()
+      expect(capturedUrl!.searchParams.get('page')).toBe('1')
+      expect(capturedUrl!.searchParams.get('limit')).toBe('20')
+    })
+  })
+})

--- a/frontend/src/__tests__/integration/media-service.test.ts
+++ b/frontend/src/__tests__/integration/media-service.test.ts
@@ -1,0 +1,125 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { mediaService } from '@/services/media-service'
+
+const BASE = 'http://localhost/api'
+
+describe('mediaService', () => {
+  describe('uploadFile()', () => {
+    it('POSTs to /media/upload and normalizes the response payload', async () => {
+      let called = false
+      let capturedContentType: string | null = null
+
+      server.use(
+        http.post(`${BASE}/media/upload`, ({ request }) => {
+          called = true
+          capturedContentType = request.headers.get('content-type')
+          return HttpResponse.json({
+            success: true,
+            data: { url: 'https://cdn.example/x.png', type: 'image', size: 123 },
+            error: null,
+          })
+        }),
+      )
+
+      const file = new File([new Uint8Array([1, 2, 3, 4])], 'hello.png', {
+        type: 'image/png',
+      })
+
+      const result = await mediaService.uploadFile(file)
+      expect(called).toBe(true)
+      expect(capturedContentType ?? '').toMatch(/multipart\/form-data/)
+      expect(result).toEqual({
+        url: 'https://cdn.example/x.png',
+        type: 'image',
+        size: 123,
+      })
+    })
+
+    it('defaults type to "image" when backend returns unknown type', async () => {
+      server.use(
+        http.post(`${BASE}/media/upload`, () =>
+          HttpResponse.json({
+            success: true,
+            data: { url: 'https://cdn.example/y', type: 'weird', size: 9 },
+            error: null,
+          }),
+        ),
+      )
+
+      const result = await mediaService.uploadFile(new File(['x'], 'x.bin'))
+      expect(result.type).toBe('image')
+      expect(result.size).toBe(9)
+    })
+
+    it('preserves "video" type', async () => {
+      server.use(
+        http.post(`${BASE}/media/upload`, () =>
+          HttpResponse.json({
+            success: true,
+            data: { url: 'https://cdn.example/v.mp4', type: 'video', size: 4242 },
+            error: null,
+          }),
+        ),
+      )
+
+      const result = await mediaService.uploadFile(new File(['x'], 'v.mp4'))
+      expect(result.type).toBe('video')
+    })
+  })
+
+  describe('attachRecipeMedia()', () => {
+    it('POSTs payload to /recipes/:id/media and normalizes created_at → createdAt', async () => {
+      let capturedBody: unknown = null
+      server.use(
+        http.post(`${BASE}/recipes/:id/media`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({
+            success: true,
+            data: {
+              id: 55,
+              url: 'https://cdn.example/x.png',
+              type: 'image',
+              created_at: '2026-05-01T00:00:00Z',
+            },
+            error: null,
+          })
+        }),
+      )
+
+      const result = await mediaService.attachRecipeMedia('77', {
+        url: 'https://cdn.example/x.png',
+        type: 'image',
+      })
+
+      expect(capturedBody).toEqual({
+        url: 'https://cdn.example/x.png',
+        type: 'image',
+      })
+      expect(result).toEqual({
+        id: '55',
+        url: 'https://cdn.example/x.png',
+        type: 'image',
+        createdAt: '2026-05-01T00:00:00Z',
+      })
+    })
+  })
+
+  describe('deleteRecipeMedia()', () => {
+    it('DELETEs /recipes/:id/media/:mediaId', async () => {
+      let captured: { recipe?: string; media?: string } = {}
+      server.use(
+        http.delete(`${BASE}/recipes/:id/media/:mediaId`, ({ params }) => {
+          captured = {
+            recipe: params.id as string,
+            media: params.mediaId as string,
+          }
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await mediaService.deleteRecipeMedia('77', 'media-9')
+      expect(captured).toEqual({ recipe: '77', media: 'media-9' })
+    })
+  })
+})

--- a/frontend/src/__tests__/integration/profile-service.test.ts
+++ b/frontend/src/__tests__/integration/profile-service.test.ts
@@ -1,0 +1,48 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { profileService } from '@/services/profile-service'
+
+const BASE = 'http://localhost/api'
+
+describe('profileService.getCurrentUser()', () => {
+  it('returns the unwrapped /auth/me payload', async () => {
+    server.use(
+      http.get(`${BASE}/auth/me`, () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            userId: 'u-1',
+            email: 'me@example.com',
+            username: 'me',
+            role: 'cook',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+          error: null,
+        }),
+      ),
+    )
+
+    const me = await profileService.getCurrentUser()
+
+    expect(me).toEqual({
+      userId: 'u-1',
+      email: 'me@example.com',
+      username: 'me',
+      role: 'cook',
+      createdAt: '2026-01-01T00:00:00Z',
+    })
+  })
+
+  it('rejects when /auth/me returns 401', async () => {
+    server.use(
+      http.get(`${BASE}/auth/me`, () =>
+        HttpResponse.json(
+          { success: false, data: null, error: { code: 'UNAUTHORIZED', message: 'no' } },
+          { status: 401 },
+        ),
+      ),
+    )
+
+    await expect(profileService.getCurrentUser()).rejects.toBeDefined()
+  })
+})

--- a/frontend/src/__tests__/integration/rating-service.test.ts
+++ b/frontend/src/__tests__/integration/rating-service.test.ts
@@ -1,0 +1,95 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { ratingService } from '@/services/rating-service'
+
+const BASE = 'http://localhost/api'
+
+describe('ratingService', () => {
+  describe('submitRating()', () => {
+    it('posts score and normalizes snake_case → camelCase', async () => {
+      let capturedBody: unknown = null
+      server.use(
+        http.post(`${BASE}/recipes/:id/ratings`, async ({ request, params }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({
+            success: true,
+            data: {
+              id: 11,
+              recipe_id: String(params.id),
+              user_id: 'user-1',
+              score: 5,
+              created_at: '2026-05-01T00:00:00Z',
+              updated_at: '2026-05-02T00:00:00Z',
+            },
+            error: null,
+          })
+        }),
+      )
+
+      const result = await ratingService.submitRating('100', 5)
+
+      expect(capturedBody).toEqual({ score: 5 })
+      expect(result).toEqual({
+        id: '11',
+        recipeId: '100',
+        userId: 'user-1',
+        score: 5,
+        createdAt: '2026-05-01T00:00:00Z',
+        updatedAt: '2026-05-02T00:00:00Z',
+      })
+    })
+  })
+
+  describe('getMyRating()', () => {
+    it('returns null when backend sends data:null', async () => {
+      server.use(
+        http.get(`${BASE}/recipes/:id/ratings/me`, () =>
+          HttpResponse.json({ success: true, data: null, error: null }),
+        ),
+      )
+
+      const result = await ratingService.getMyRating('200')
+      expect(result).toBeNull()
+    })
+
+    it('normalizes the existing rating row', async () => {
+      server.use(
+        http.get(`${BASE}/recipes/:id/ratings/me`, () =>
+          HttpResponse.json({
+            success: true,
+            data: {
+              id: 3,
+              score: 4,
+              created_at: '2026-05-01T00:00:00Z',
+              updated_at: '2026-05-03T00:00:00Z',
+            },
+            error: null,
+          }),
+        ),
+      )
+
+      const result = await ratingService.getMyRating('200')
+      expect(result).toEqual({
+        id: '3',
+        score: 4,
+        createdAt: '2026-05-01T00:00:00Z',
+        updatedAt: '2026-05-03T00:00:00Z',
+      })
+    })
+  })
+
+  describe('deleteMyRating()', () => {
+    it('DELETEs /recipes/:id/ratings/me', async () => {
+      let calledForId: string | undefined
+      server.use(
+        http.delete(`${BASE}/recipes/:id/ratings/me`, ({ params }) => {
+          calledForId = params.id as string
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await ratingService.deleteMyRating('300')
+      expect(calledForId).toBe('300')
+    })
+  })
+})

--- a/frontend/src/__tests__/integration/tool-service.test.ts
+++ b/frontend/src/__tests__/integration/tool-service.test.ts
@@ -1,0 +1,67 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { toolService } from '@/services/tool-service'
+
+const BASE = 'http://localhost/api'
+
+describe('toolService.search()', () => {
+  it('omits the search param when input is empty', async () => {
+    let capturedUrl: URL | null = null
+    server.use(
+      http.get(`${BASE}/tools`, ({ request }) => {
+        capturedUrl = new URL(request.url)
+        return HttpResponse.json({ success: true, data: [], error: null })
+      }),
+    )
+
+    await toolService.search()
+    expect(capturedUrl!.searchParams.has('search')).toBe(false)
+
+    await toolService.search('   ')
+    expect(capturedUrl!.searchParams.has('search')).toBe(false)
+  })
+
+  it('trims and forwards the search query', async () => {
+    let capturedUrl: URL | null = null
+    server.use(
+      http.get(`${BASE}/tools`, ({ request }) => {
+        capturedUrl = new URL(request.url)
+        return HttpResponse.json({ success: true, data: [], error: null })
+      }),
+    )
+
+    await toolService.search('  whisk  ')
+    expect(capturedUrl!.searchParams.get('search')).toBe('whisk')
+  })
+
+  it('returns trimmed tool names and filters out blank entries', async () => {
+    server.use(
+      http.get(`${BASE}/tools`, () =>
+        HttpResponse.json({
+          success: true,
+          data: [
+            { name: 'Whisk' },
+            { name: '  Pan ' },
+            { name: '' },
+            { name: '   ' },
+          ],
+          error: null,
+        }),
+      ),
+    )
+
+    const tools = await toolService.search()
+    expect(tools).toEqual([{ name: 'Whisk' }, { name: 'Pan' }])
+  })
+
+  it('returns empty array when API data is not an array', async () => {
+    server.use(
+      http.get(`${BASE}/tools`, () =>
+        HttpResponse.json({ success: true, data: null, error: null }),
+      ),
+    )
+
+    const tools = await toolService.search()
+    expect(tools).toEqual([])
+  })
+})

--- a/frontend/src/__tests__/integration/unit-service.test.ts
+++ b/frontend/src/__tests__/integration/unit-service.test.ts
@@ -1,0 +1,67 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
+import { unitService } from '@/services/unit-service'
+
+const BASE = 'http://localhost/api'
+
+describe('unitService.search()', () => {
+  it('omits the search param when input is empty/whitespace', async () => {
+    let capturedUrl: URL | null = null
+    server.use(
+      http.get(`${BASE}/units`, ({ request }) => {
+        capturedUrl = new URL(request.url)
+        return HttpResponse.json({ success: true, data: [], error: null })
+      }),
+    )
+
+    await unitService.search()
+    expect(capturedUrl!.searchParams.has('search')).toBe(false)
+
+    await unitService.search('   ')
+    expect(capturedUrl!.searchParams.has('search')).toBe(false)
+  })
+
+  it('trims and sends the search query', async () => {
+    let capturedUrl: URL | null = null
+    server.use(
+      http.get(`${BASE}/units`, ({ request }) => {
+        capturedUrl = new URL(request.url)
+        return HttpResponse.json({ success: true, data: [], error: null })
+      }),
+    )
+
+    await unitService.search('  cup  ')
+    expect(capturedUrl!.searchParams.get('search')).toBe('cup')
+  })
+
+  it('maps {unit} rows to trimmed strings and drops blanks', async () => {
+    server.use(
+      http.get(`${BASE}/units`, () =>
+        HttpResponse.json({
+          success: true,
+          data: [
+            { unit: 'tbsp' },
+            { unit: '  cup ' },
+            { unit: '' },
+            { unit: '   ' },
+          ],
+          error: null,
+        }),
+      ),
+    )
+
+    const units = await unitService.search()
+    expect(units).toEqual(['tbsp', 'cup'])
+  })
+
+  it('returns empty array when API data is not an array', async () => {
+    server.use(
+      http.get(`${BASE}/units`, () =>
+        HttpResponse.json({ success: true, data: null, error: null }),
+      ),
+    )
+
+    const units = await unitService.search()
+    expect(units).toEqual([])
+  })
+})


### PR DESCRIPTION
Cover auth, favorite, rating, comment, profile, tool, unit, media, and expert-request services. 92 tests across 19 files, all passing.