### PR TITLE
[Mobile/Fix] Long recipe title overlaps favorite/share icons

### DIFF
--- a/mobile/src/components/recipe-detail/RecipeHeader.tsx
+++ b/mobile/src/components/recipe-detail/RecipeHeader.tsx
@@ -58,7 +58,26 @@ export function RecipeHeader({
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
+      <View style={styles.titleRow}>
+        <Text style={styles.title} numberOfLines={3}>{title}</Text>
+        <View style={styles.actions}>
+          <IconButton
+            name={isFavorited ? 'heart' : 'heart-outline'}
+            color={isFavorited ? colors.negative : colors.onSurface}
+            onPress={onToggleFavorite}
+            disabled={favoriteBusy}
+            accessibilityLabel={
+              isFavorited
+                ? t('recipeDetail.unfavoriteA11y')
+                : t('recipeDetail.favoriteA11y')
+            }
+          />
+          <IconButton
+            name="share-variant-outline"
+            onPress={() => Alert.alert(t('recipeDetail.share'), t('recipeDetail.shareSoon'))}
+          />
+        </View>
+      </View>
 
       <View style={styles.metaRow}>
         <TouchableOpacity onPress={onAuthorPress} activeOpacity={0.6}>
@@ -109,23 +128,6 @@ export function RecipeHeader({
         </View>
       )}
 
-      <View style={styles.actions}>
-        <IconButton
-          name={isFavorited ? 'heart' : 'heart-outline'}
-          color={isFavorited ? colors.negative : colors.onSurface}
-          onPress={onToggleFavorite}
-          disabled={favoriteBusy}
-          accessibilityLabel={
-            isFavorited
-              ? t('recipeDetail.unfavoriteA11y')
-              : t('recipeDetail.favoriteA11y')
-          }
-        />
-        <IconButton
-          name="share-variant-outline"
-          onPress={() => Alert.alert(t('recipeDetail.share'), t('recipeDetail.shareSoon'))}
-        />
-      </View>
     </View>
   );
 }
@@ -134,7 +136,13 @@ const styles = StyleSheet.create({
   container: {
     marginTop: spacing.lg,
   },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
   title: {
+    flex: 1,
     fontFamily: fonts.serifBold,
     fontSize: fontSizes['3xl'],
     color: colors.onSurface,
@@ -164,8 +172,5 @@ const styles = StyleSheet.create({
   },
   actions: {
     flexDirection: 'row',
-    position: 'absolute',
-    top: 0,
-    right: 0,
   },
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a layout bug on the recipe detail header where long titles render underneath the favorite (heart) and share icons. The `actions` view was `position: 'absolute'` at `top: 0, right: 0` while the title `<Text>` had no width constraint, so the title's italic-serif glyphs ran into the icons. Restructures the header so title + actions live in a real `flexDirection: 'row'` row, the title gets `flex: 1` and `numberOfLines={3}` to wrap/ellipsize gracefully, and the actions drop their absolute positioning.

## How to test

- `cd mobile && npx jest src/__tests__/RecipeHeader.test.tsx` — all 5 existing tests still pass (behavior of the favorite button is unchanged).
- `cd mobile && npm start` and open a recipe whose title is long enough to fill most of the available width (e.g. "Çiğ Köfte for Sıra Gecesi"). The title now wraps cleanly and the heart + share icons sit clearly to its right, no overlap.
- Open a recipe with a short title (one word) and confirm the icons still appear at top-right and the layout looks unchanged.

## Related issue

Closes #544