### PR TITLE
Implement language-aware titles and names for recipe listings

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -424,6 +424,8 @@ Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/r
 
 `GET /recipes/:id` reads `req.lang` instead of parsing `?lang=` directly, converts to uppercase (`'en'` → `'EN'`) for the DB column, and fetches translations from `recipe_translations`, `recipe_step_translations`, and `recipe_ingredient_translations` when `req.lang` is non-null, falling back to original content when no translation row exists.
 
+**Listing endpoints** also honor `req.lang` so cards on home, discovery, library, and profile pages render in the active UI language: `GET /recipes`, `GET /recipes/mine`, `GET /discovery/recipes`, `GET /discovery/recipes/by-ingredients`, `GET /users/me/favorites`, and `GET /users/me/drafts`. They use `fetchRecipeTitleTranslations(recipeIds, langCode)` from `translationService.ts` — a single batch query against `recipe_translations` for the current page — and resolve `dish_variety` / `dish_genre` names via `resolveLocalizedName()` (`src/utils/i18n.ts`) off the `name_en` / `name_tr` columns. Rows without a translation row fall back to the authored title.
+
 Translation is triggered fire-and-forget (`.catch()` swallows errors) after:
 - `POST /recipes` — recipe create
 - `PATCH /recipes/:id` — recipe update

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -8,6 +8,9 @@ import {
   getLocationVariants,
 } from "../utils/locations.js";
 import { buildSearchVariants } from "../utils/text.js";
+import { resolveLocalizedName } from "../utils/i18n.js";
+import { fetchRecipeTitleTranslations } from "../services/translationService.js";
+import type { LanguageRequest } from "../types/index.js";
 
 // Apply a case-insensitive location filter that also expands known aliases
 // (so a filter for "tr"/"Türkiye" still matches recipes stored as "Turkey").
@@ -287,6 +290,9 @@ router.get("/recipes", async (req, res) => {
       return q;
     };
 
+    const lang = (req as LanguageRequest).lang;
+    const langParam: "EN" | "TR" | null = lang === "en" ? "EN" : lang === "tr" ? "TR" : null;
+
     let recipeQuery = supabase
       .from("recipes")
       .select(
@@ -294,8 +300,8 @@ router.get("/recipes", async (req, res) => {
          country, city, district,
          created_at, updated_at,
          dish_variety:dish_varieties!recipes_dish_variety_id_fkey(
-           id, name,
-           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)
+           id, name, name_en, name_tr,
+           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name, name_en, name_tr)
          ),
          profile:profiles!recipes_creator_id_fkey(id, username),
          recipe_media(id, url, type)`,
@@ -317,8 +323,8 @@ router.get("/recipes", async (req, res) => {
       .from("recipes")
       .select(
         `dish_variety:dish_varieties!recipes_dish_variety_id_fkey(
-           id, name,
-           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)
+           id, name, name_en, name_tr,
+           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name, name_en, name_tr)
          )`
       )
       .eq("is_published", true);
@@ -341,17 +347,27 @@ router.get("/recipes", async (req, res) => {
         .json(errorResponse("DB_ERROR", cascadeError.message));
     }
 
-    const varietyMap = new Map<number, { id: number; name: string; dish_genre: any }>();
-    const genreMap = new Map<number, { id: number; name: string }>();
+    const varietyMap = new Map<number, { id: number; name: string | null; dish_genre: any }>();
+    const genreMap = new Map<number, { id: number; name: string | null }>();
 
     for (const r of cascadeRows ?? []) {
       const v = (r as any).dish_variety;
       if (v) {
         if (!varietyMap.has(v.id)) {
-          varietyMap.set(v.id, { id: v.id, name: v.name, dish_genre: v.dish_genre ?? null });
+          const localizedGenre = v.dish_genre
+            ? { id: v.dish_genre.id, name: resolveLocalizedName(v.dish_genre, langParam) }
+            : null;
+          varietyMap.set(v.id, {
+            id: v.id,
+            name: resolveLocalizedName(v, langParam),
+            dish_genre: localizedGenre,
+          });
         }
         if (v.dish_genre && !genreMap.has(v.dish_genre.id)) {
-          genreMap.set(v.dish_genre.id, { id: v.dish_genre.id, name: v.dish_genre.name });
+          genreMap.set(v.dish_genre.id, {
+            id: v.dish_genre.id,
+            name: resolveLocalizedName(v.dish_genre, langParam),
+          });
         }
       }
     }
@@ -372,15 +388,41 @@ router.get("/recipes", async (req, res) => {
       }
     }
 
+    // Batch-fetch translated titles when ?lang= is set; recipes without a
+    // translation row fall back to their authored title.
+    let titleMap = new Map<string, string>();
+    if (langParam) {
+      const ids = (recipes ?? []).map((r: any) => r.id);
+      titleMap = await fetchRecipeTitleTranslations(ids, langParam);
+    }
+
     return res.status(200).json(
       successResponse({
         recipes: (recipes ?? []).map((r: any) => {
           const firstImage = (r.recipe_media ?? []).find((m: any) => m.type === "image");
-          const { recipe_media, allergen_ids, ...rest } = r;
+          const { recipe_media, allergen_ids, dish_variety, title, ...rest } = r;
           const allergens = (allergen_ids ?? [])
             .map((id: number) => ({ id, name: allergenMap.get(id) ?? null }))
             .filter((a: any) => a.name !== null);
-          return { ...rest, image_url: firstImage?.url ?? null, allergens };
+          const localizedVariety = dish_variety
+            ? {
+                id: dish_variety.id,
+                name: resolveLocalizedName(dish_variety, langParam),
+                dish_genre: dish_variety.dish_genre
+                  ? {
+                      id: dish_variety.dish_genre.id,
+                      name: resolveLocalizedName(dish_variety.dish_genre, langParam),
+                    }
+                  : null,
+              }
+            : null;
+          return {
+            ...rest,
+            title: titleMap.get(r.id) ?? title,
+            dish_variety: localizedVariety,
+            image_url: firstImage?.url ?? null,
+            allergens,
+          };
         }),
         varieties: [...varietyMap.values()],
         genres: [...genreMap.values()],
@@ -477,6 +519,9 @@ router.get("/recipes/by-ingredients", async (req, res) => {
       );
     }
 
+    const lang = (req as LanguageRequest).lang;
+    const langParam: "EN" | "TR" | null = lang === "en" ? "EN" : lang === "tr" ? "TR" : null;
+
     // ── Step 3: Fetch full recipe data for eligible IDs ──────────────────────
     let query = supabase
       .from("recipes")
@@ -485,8 +530,8 @@ router.get("/recipes/by-ingredients", async (req, res) => {
          country, city, district,
          created_at, updated_at,
          dish_variety:dish_varieties!recipes_dish_variety_id_fkey(
-           id, name,
-           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name)
+           id, name, name_en, name_tr,
+           dish_genre:dish_genres!dish_varieties_genre_id_fkey(id, name, name_en, name_tr)
          ),
          profile:profiles!recipes_creator_id_fkey(id, username),
          recipe_media(id, url, type)`,
@@ -508,12 +553,35 @@ router.get("/recipes/by-ingredients", async (req, res) => {
         .json(errorResponse("DB_ERROR", recipesError.message));
     }
 
+    let titleMap = new Map<string, string>();
+    if (langParam) {
+      const ids = (recipes ?? []).map((r: any) => r.id);
+      titleMap = await fetchRecipeTitleTranslations(ids, langParam);
+    }
+
     return res.status(200).json(
       successResponse({
         recipes: (recipes ?? []).map((r: any) => {
           const firstImage = (r.recipe_media ?? []).find((m: any) => m.type === "image");
-          const { recipe_media, ...rest } = r;
-          return { ...rest, image_url: firstImage?.url ?? null };
+          const { recipe_media, dish_variety, title, ...rest } = r;
+          const localizedVariety = dish_variety
+            ? {
+                id: dish_variety.id,
+                name: resolveLocalizedName(dish_variety, langParam),
+                dish_genre: dish_variety.dish_genre
+                  ? {
+                      id: dish_variety.dish_genre.id,
+                      name: resolveLocalizedName(dish_variety.dish_genre, langParam),
+                    }
+                  : null,
+              }
+            : null;
+          return {
+            ...rest,
+            title: titleMap.get(r.id) ?? title,
+            dish_variety: localizedVariety,
+            image_url: firstImage?.url ?? null,
+          };
         }),
         pagination: {
           page,

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -7,23 +7,10 @@ import type { AuthenticatedRequest, LanguageRequest } from "../types/index.js";
 import { errorResponse, successResponse } from "../utils/response.js";
 import { canonicalizeLocationForWrite } from "../utils/locations.js";
 import { normalizeText } from "../utils/text.js";
-import { translateRecipe } from "../services/translationService.js";
+import { translateRecipe, fetchRecipeTitleTranslations } from "../services/translationService.js";
+import { resolveLocalizedName } from "../utils/i18n.js";
 
 const router = Router();
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/** Resolves name_en / name_tr based on langParam, falls back to name. */
-function resolveLocalizedName(
-  obj: { name?: string | null; name_en?: string | null; name_tr?: string | null } | null | undefined,
-  langParam: string | null
-): string | null {
-  if (!obj) return null;
-  if (!langParam) return obj.name ?? null;
-  const preferred = langParam === "EN" ? obj.name_en : obj.name_tr;
-  const fallback  = langParam === "EN" ? obj.name_tr  : obj.name_en;
-  return preferred ?? fallback ?? obj.name ?? null;
-}
 
 // ─── Zod Schemas ──────────────────────────────────────────────────────────────
 
@@ -173,6 +160,8 @@ router.get("/:id/scale", async (req: Request, res: Response): Promise<void> => {
 router.get("/mine", requireAuth, async (req: Request, res: Response): Promise<void> => {
   const user = (req as AuthenticatedRequest).user;
   const userClient = createUserClient(user.accessToken);
+  const lang = (req as LanguageRequest).lang;
+  const langParam: "EN" | "TR" | null = lang === "en" ? "EN" : lang === "tr" ? "TR" : null;
 
   const statusParam = req.query["status"];
   const validStatus = statusParam === "published" || statusParam === "draft" ? statusParam : null;
@@ -211,6 +200,12 @@ router.get("/mine", requireAuth, async (req: Request, res: Response): Promise<vo
     }
   }
 
+  let titleMap = new Map<string, string>();
+  if (langParam) {
+    const ids = (data ?? []).map((r: any) => r.id);
+    titleMap = await fetchRecipeTitleTranslations(ids, langParam);
+  }
+
   const recipes = (data ?? []).map((r: any) => {
     const firstImage = (r.recipe_media ?? []).find((m: any) => m.type === "image");
     const allergens = (r.allergen_ids ?? [])
@@ -218,7 +213,7 @@ router.get("/mine", requireAuth, async (req: Request, res: Response): Promise<vo
       .filter((a: any) => a.name !== null);
     return {
       id: r.id,
-      title: r.title,
+      title: titleMap.get(r.id) ?? r.title,
       type: r.type,
       isPublished: r.is_published,
       averageRating: r.average_rating ?? null,
@@ -246,7 +241,7 @@ router.get("/mine", requireAuth, async (req: Request, res: Response): Promise<vo
 router.get("/:id", async (req: Request, res: Response): Promise<void> => {
   const recipeId = (req.params["id"] ?? "") as string;
   const lang = (req as LanguageRequest).lang;
-  const langParam = lang ? lang.toUpperCase() : null;
+  const langParam: "EN" | "TR" | null = lang === "en" ? "EN" : lang === "tr" ? "TR" : null;
 
   const authHeader = req.headers["authorization"];
   const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
@@ -468,6 +463,8 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
   }
 
   const { creatorId, page, limit } = parsed.data;
+  const lang = (req as LanguageRequest).lang;
+  const langParam: "EN" | "TR" | null = lang === "en" ? "EN" : lang === "tr" ? "TR" : null;
   const from = (page - 1) * limit;
   const to = from + limit - 1;
 
@@ -476,7 +473,7 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
     .select(
       `id, title, type, average_rating, rating_count, created_at, updated_at,
        creator:profiles!recipes_creator_id_fkey(id, username),
-       dish_variety:dish_varieties(id, name, dish_genre:dish_genres(id, name)),
+       dish_variety:dish_varieties(id, name, name_en, name_tr, dish_genre:dish_genres(id, name, name_en, name_tr)),
        recipe_media(id, url, type)`,
       { count: "exact" }
     )
@@ -495,19 +492,28 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
     return;
   }
 
+  // Batch-fetch translated titles when ?lang= is set (and the user is asking
+  // for a non-source language). Recipes without a translation row fall back
+  // to the raw title (i.e. the language the recipe was authored in).
+  let titleMap = new Map<string, string>();
+  if (langParam) {
+    const ids = (data ?? []).map((r: any) => r.id);
+    titleMap = await fetchRecipeTitleTranslations(ids, langParam);
+  }
+
   const recipes = (data ?? []).map((r: any) => {
     const firstImage = (r.recipe_media ?? []).find((m: any) => m.type === "image");
     return {
       id: r.id,
-      title: r.title,
+      title: titleMap.get(r.id) ?? r.title,
       type: r.type,
       averageRating: r.average_rating ?? null,
       ratingCount: r.rating_count ?? 0,
       creatorId: r.creator?.id ?? null,
       creatorUsername: r.creator?.username ?? null,
       dishVarietyId: r.dish_variety?.id ?? null,
-      dishVarietyName: r.dish_variety?.name ?? null,
-      genreName: r.dish_variety?.dish_genre?.name ?? null,
+      dishVarietyName: resolveLocalizedName(r.dish_variety, langParam),
+      genreName: resolveLocalizedName(r.dish_variety?.dish_genre, langParam),
       createdAt: r.created_at,
       updatedAt: r.updated_at,
       coverImageUrl: firstImage?.url ?? null,

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -2,8 +2,10 @@ import { Router, type Request, type Response } from "express";
 import { z } from "zod";
 import { supabase, createUserClient } from "../config/supabase.js";
 import { requireAuth } from "../middleware/auth.js";
-import type { AuthenticatedRequest } from "../types/index.js";
+import type { AuthenticatedRequest, LanguageRequest } from "../types/index.js";
 import { errorResponse, successResponse } from "../utils/response.js";
+import { resolveLocalizedName } from "../utils/i18n.js";
+import { fetchRecipeTitleTranslations } from "../services/translationService.js";
 
 const router = Router();
 
@@ -79,6 +81,8 @@ router.delete("/me/favorites/:recipeId", requireAuth, async (req: Request, res: 
 
 router.get("/me/favorites", requireAuth, async (req: Request, res: Response): Promise<void> => {
   const user = (req as AuthenticatedRequest).user;
+  const lang = (req as LanguageRequest).lang;
+  const langParam: "EN" | "TR" | null = lang === "en" ? "EN" : lang === "tr" ? "TR" : null;
 
   const parsed = listFavoritesQuerySchema.safeParse(req.query);
   if (!parsed.success) {
@@ -97,7 +101,7 @@ router.get("/me/favorites", requireAuth, async (req: Request, res: Response): Pr
       `recipe:recipes(
         id, title, type, average_rating, rating_count, allergen_ids, created_at, updated_at,
         creator:profiles!recipes_creator_id_fkey(id, username),
-        dish_variety:dish_varieties(id, name, dish_genre:dish_genres(id, name)),
+        dish_variety:dish_varieties(id, name, name_en, name_tr, dish_genre:dish_genres(id, name, name_en, name_tr)),
         recipe_media(id, url, type)
       )`,
       { count: "exact" }
@@ -126,6 +130,14 @@ router.get("/me/favorites", requireAuth, async (req: Request, res: Response): Pr
     }
   }
 
+  let titleMap = new Map<string, string>();
+  if (langParam) {
+    const ids = (data ?? [])
+      .map((fav: any) => fav.recipe?.id)
+      .filter((id: any): id is string => typeof id === "string");
+    titleMap = await fetchRecipeTitleTranslations(ids, langParam);
+  }
+
   const recipes = (data ?? []).map((fav: any) => {
     const r = fav.recipe;
     const firstImage = (r?.recipe_media ?? []).find((m: any) => m.type === "image");
@@ -134,15 +146,15 @@ router.get("/me/favorites", requireAuth, async (req: Request, res: Response): Pr
       .filter((a: any) => a.name !== null);
     return {
       id: r?.id ?? null,
-      title: r?.title ?? null,
+      title: (r?.id && titleMap.get(r.id)) ?? r?.title ?? null,
       type: r?.type ?? null,
       averageRating: r?.average_rating ?? null,
       ratingCount: r?.rating_count ?? 0,
       creatorId: r?.creator?.id ?? null,
       creatorUsername: r?.creator?.username ?? null,
       dishVarietyId: r?.dish_variety?.id ?? null,
-      dishVarietyName: r?.dish_variety?.name ?? null,
-      genreName: r?.dish_variety?.dish_genre?.name ?? null,
+      dishVarietyName: resolveLocalizedName(r?.dish_variety, langParam),
+      genreName: resolveLocalizedName(r?.dish_variety?.dish_genre, langParam),
       createdAt: r?.created_at ?? null,
       updatedAt: r?.updated_at ?? null,
       coverImageUrl: firstImage?.url ?? null,
@@ -163,6 +175,8 @@ router.get("/me/favorites", requireAuth, async (req: Request, res: Response): Pr
 router.get("/me/drafts", requireAuth, async (req: Request, res: Response): Promise<void> => {
   const user = (req as AuthenticatedRequest).user;
   const userClient = createUserClient(user.accessToken);
+  const lang = (req as LanguageRequest).lang;
+  const langParam: "EN" | "TR" | null = lang === "en" ? "EN" : lang === "tr" ? "TR" : null;
 
   const { data, error } = await userClient
     .from("recipes")
@@ -195,6 +209,12 @@ router.get("/me/drafts", requireAuth, async (req: Request, res: Response): Promi
     }
   }
 
+  let titleMap = new Map<string, string>();
+  if (langParam) {
+    const ids = (data ?? []).map((r: any) => r.id);
+    titleMap = await fetchRecipeTitleTranslations(ids, langParam);
+  }
+
   const recipes = (data ?? []).map((r: any) => {
     const firstImage = (r.recipe_media ?? []).find((m: any) => m.type === "image");
     const allergens = (r.allergen_ids ?? [])
@@ -202,7 +222,7 @@ router.get("/me/drafts", requireAuth, async (req: Request, res: Response): Promi
       .filter((a: any) => a.name !== null);
     return {
       id: r.id,
-      title: r.title,
+      title: titleMap.get(r.id) ?? r.title,
       type: r.type,
       isPublished: r.is_published,
       averageRating: r.average_rating ?? null,

--- a/backend/src/services/translationService.ts
+++ b/backend/src/services/translationService.ts
@@ -225,6 +225,46 @@ export async function translateRecipe(recipeId: string): Promise<void> {
   console.log(`[translation] Recipe ${recipeId} translated to ${langCode}.`);
 }
 
+// ─── Listing Title Translation Lookup ─────────────────────────────────────────
+
+/**
+ * Batch-fetches translated titles for a set of recipe IDs in the requested
+ * language. Used by listing endpoints (home, discovery, library, profile) so
+ * cards show the localized recipe title without an N+1 query per row.
+ *
+ * Returns a `Map<recipeId, translatedTitle>`. Recipes without a translation
+ * row are simply absent from the map — callers should fall back to the
+ * original `recipes.title`.
+ *
+ * Errors are swallowed and resolved as an empty map; the listing must keep
+ * working even if the translations table is unavailable.
+ */
+export async function fetchRecipeTitleTranslations(
+  recipeIds: string[],
+  langCode: "EN" | "TR"
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (recipeIds.length === 0) return out;
+
+  const { data, error } = await supabase
+    .from("recipe_translations")
+    .select("recipe_id, title")
+    .eq("language_code", langCode)
+    .in("recipe_id", recipeIds);
+
+  if (error) {
+    console.error("[translation] Failed to batch-fetch recipe titles:", error);
+    return out;
+  }
+
+  for (const row of data ?? []) {
+    const id = (row as any).recipe_id;
+    const title = (row as any).title;
+    if (id && typeof title === "string" && title.length > 0) out.set(id, title);
+  }
+  return out;
+}
+
 // ─── Ingredient Name Translation ──────────────────────────────────────────────
 
 /**

--- a/backend/src/utils/i18n.ts
+++ b/backend/src/utils/i18n.ts
@@ -24,3 +24,20 @@ export function resolveLang(
   if (lang === "en") return en ?? tr ?? null;
   return tr ?? en ?? null;
 }
+
+/**
+ * Picks the preferred `name_en` / `name_tr` field off an object that may also
+ * carry a legacy `name` column. Used to resolve dish-variety and dish-genre
+ * names on recipe listings when ?lang= is set. Returns `obj.name` (or null)
+ * when `langParam` is null — i.e. no language preference expressed.
+ */
+export function resolveLocalizedName(
+  obj: { name?: string | null; name_en?: string | null; name_tr?: string | null } | null | undefined,
+  langParam: "EN" | "TR" | null
+): string | null {
+  if (!obj) return null;
+  if (!langParam) return obj.name ?? null;
+  const preferred = langParam === "EN" ? obj.name_en : obj.name_tr;
+  const fallback = langParam === "EN" ? obj.name_tr : obj.name_en;
+  return preferred ?? fallback ?? obj.name ?? null;
+}


### PR DESCRIPTION
This pull request adds full support for localized recipe titles and dish variety/genre names across all major recipe listing endpoints. It ensures that when a user requests recipes in a specific language (using `?lang=`), both the recipe titles and related category names are displayed in the active UI language, falling back to the authored/original content when a translation is missing. The implementation uses efficient batch queries for translations and centralizes localization logic.

**Localization of Recipe Listings:**

- All main recipe listing endpoints (`/recipes`, `/recipes/mine`, `/discovery/recipes`, `/discovery/recipes/by-ingredients`, `/users/me/favorites`, `/users/me/drafts`) now honor the `req.lang` property, returning titles and category names in the requested language using batch translation queries and the `resolveLocalizedName()` helper. [[1]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR427-R428) [[2]](diffhunk://#diff-bea9e0d5b886db7bd82be31776e29e2c3f75b9b39e75cfd5ae6b7e14fed6b390R11-R13) [[3]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baL10-L27) [[4]](diffhunk://#diff-b842c9733e2eef1c2259600bbf09044590e37d17244ddaf3de22ce6be74158c2L5-R8)

**Batch Translation Logic:**

- For each endpoint, a batch call to `fetchRecipeTitleTranslations()` retrieves all relevant translated titles for the current page, minimizing database queries and improving performance. Recipes without translation rows fall back to their original titles. [[1]](diffhunk://#diff-bea9e0d5b886db7bd82be31776e29e2c3f75b9b39e75cfd5ae6b7e14fed6b390R391-R425) [[2]](diffhunk://#diff-bea9e0d5b886db7bd82be31776e29e2c3f75b9b39e75cfd5ae6b7e14fed6b390R556-R584) [[3]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baR203-R216) [[4]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baR495-R516) [[5]](diffhunk://#diff-b842c9733e2eef1c2259600bbf09044590e37d17244ddaf3de22ce6be74158c2R133-R140)

**Localized Category Names:**

- Dish variety and genre names are now localized using `resolveLocalizedName()`, which selects the correct language column (`name_en` or `name_tr`) and falls back as needed. This affects both the main recipe objects and the separate lists of varieties/genres returned by the endpoints. [[1]](diffhunk://#diff-bea9e0d5b886db7bd82be31776e29e2c3f75b9b39e75cfd5ae6b7e14fed6b390L344-R370) [[2]](diffhunk://#diff-bea9e0d5b886db7bd82be31776e29e2c3f75b9b39e75cfd5ae6b7e14fed6b390R391-R425) [[3]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baR495-R516) [[4]](diffhunk://#diff-b842c9733e2eef1c2259600bbf09044590e37d17244ddaf3de22ce6be74158c2L137-R157)

**Consistent Language Parameter Handling:**

- The logic for determining the language parameter (`langParam`) is standardized across all endpoints, ensuring only "EN", "TR", or `null` are used, and removing ad-hoc or duplicated code. [[1]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baL249-R244) [[2]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baR163-R164) [[3]](diffhunk://#diff-b842c9733e2eef1c2259600bbf09044590e37d17244ddaf3de22ce6be74158c2R84-R85)

**Code Cleanup and Centralization:**

- The redundant local implementation of `resolveLocalizedName()` is removed from `recipes.ts` in favor of the shared utility in `utils/i18n.ts`, ensuring consistency and maintainability.

These changes collectively ensure that users always see recipe information in their preferred language wherever possible, with efficient backend support and clean, maintainable code. Closes #542 