### PR TITLE
Add i18n support for GET /allergens endpoint

### DIFF
--- a/backend/src/routes/allergens.ts
+++ b/backend/src/routes/allergens.ts
@@ -3,19 +3,37 @@ import { z } from "zod";
 import { supabase } from "../config/supabase.js";
 import { validate } from "../middleware/validate.js";
 import { successResponse, errorResponse } from "../utils/response.js";
+import { parseLangParam, resolveLang } from "../utils/i18n.js";
 
 const router = Router();
 
 // ─── GET /allergens ───────────────────────────────────────────────────────────
+// Query params:
+//   lang — "en" or "tr"; when provided returns a single resolved `name` field
+//           instead of the full name_en / name_tr pair
 
-router.get("/", async (_req, res) => {
+router.get("/", async (req, res) => {
+  const lang = parseLangParam(req.query["lang"]);
+  if (lang === "invalid") {
+    return res.status(400).json(errorResponse("VALIDATION_ERROR", "lang must be 'en' or 'tr'."));
+  }
+
   const { data, error } = await supabase
     .from("allergens")
-    .select("id, name")
+    .select("id, name, name_en, name_tr")
     .order("name");
 
   if (error) {
     return res.status(500).json(errorResponse("DB_ERROR", error.message));
+  }
+
+  if (lang) {
+    return res.status(200).json(successResponse(
+      (data as any[]).map((row) => ({
+        id: row.id,
+        name: resolveLang(row.name_en, row.name_tr, lang) ?? row.name,
+      }))
+    ));
   }
 
   return res.status(200).json(successResponse(data));


### PR DESCRIPTION
This pull request updates the `/allergens` endpoint to support language-specific responses for allergen names. Clients can now provide a `lang` query parameter (`en` or `tr`) to receive the allergen `name` in the requested language, rather than both `name_en` and `name_tr` fields.

Enhancements to language support in the allergens API:

* Added support for a `lang` query parameter (`en` or `tr`) to the `/allergens` route, returning a single resolved `name` field in the requested language instead of the full language pair.
* Updated the database query to select `name_en` and `name_tr` in addition to `id` and `name`, and used the new `resolveLang` utility to determine the correct language for the response.
* Implemented input validation for the `lang` parameter, returning a 400 error if an invalid value is provided

closes #549   