### PR TITLE
[Frontend/Feature] User content suggestion UI for cultural tags, genres, and varieties (#552)

### DIFF
--- a/frontend/src/components/SuggestionModal/SuggestionModal.css
+++ b/frontend/src/components/SuggestionModal/SuggestionModal.css
@@ -1,0 +1,207 @@
+.suggestion-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-md);
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(4px);
+  animation: suggestion-modal-fade 0.2s ease;
+}
+
+.suggestion-modal {
+  width: 100%;
+  max-width: 480px;
+  padding: var(--space-xl);
+  background: var(--surface-card, #fff);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  animation: suggestion-modal-scale 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  max-height: calc(100vh - 2 * var(--space-md));
+  overflow-y: auto;
+}
+
+.suggestion-modal__title {
+  margin: 0 0 var(--space-xs);
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  color: var(--rd-fg, #2a1810);
+}
+
+.suggestion-modal__hint {
+  margin: 0 0 var(--space-lg);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--rd-muted, #6b5d52);
+}
+
+.suggestion-modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.suggestion-modal__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-md);
+}
+
+@media (max-width: 520px) {
+  .suggestion-modal__row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.suggestion-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.suggestion-modal__label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--rd-fg, #2a1810);
+}
+
+.suggestion-modal__input,
+.suggestion-modal__select,
+.suggestion-modal__textarea {
+  width: 100%;
+  padding: 0.55rem 0.8rem;
+  font-size: 0.9375rem;
+  font-family: inherit;
+  background: var(--surface-card, #fff);
+  border: 1px solid rgba(42, 24, 16, 0.18);
+  border-radius: var(--radius-sm);
+  color: var(--rd-fg, #2a1810);
+  transition: border-color var(--transition-fast);
+}
+
+.suggestion-modal__input:focus,
+.suggestion-modal__select:focus,
+.suggestion-modal__textarea:focus {
+  outline: none;
+  border-color: var(--color-main);
+}
+
+.suggestion-modal__textarea {
+  min-height: 60px;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.suggestion-modal__toggle {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-main);
+  cursor: pointer;
+}
+
+.suggestion-modal__toggle:hover {
+  text-decoration: underline;
+}
+
+.suggestion-modal__error {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  background: rgba(180, 35, 24, 0.08);
+  border: 1px solid rgba(180, 35, 24, 0.25);
+  border-radius: var(--radius-sm);
+  color: #b42318;
+  font-size: 0.85rem;
+}
+
+.suggestion-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.suggestion-modal__btn {
+  min-height: 2.5rem;
+  padding: 0.5rem 1.1rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  border: none;
+  transition: opacity var(--transition-fast), filter var(--transition-fast);
+}
+
+.suggestion-modal__btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.suggestion-modal__btn--secondary {
+  background: transparent;
+  color: var(--rd-muted, #6b5d52);
+  border: 1px solid rgba(42, 24, 16, 0.2);
+}
+
+.suggestion-modal__btn--secondary:hover:not(:disabled) {
+  background: rgba(42, 24, 16, 0.05);
+}
+
+.suggestion-modal__btn--primary {
+  background: var(--color-main);
+  color: #fff;
+}
+
+.suggestion-modal__btn--primary:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.suggestion-modal__btn-content {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.suggestion-modal__btn-label {
+  display: inline-block;
+}
+
+.suggestion-modal__btn-label--hidden {
+  visibility: hidden;
+}
+
+.suggestion-modal__btn-spinner-wrap {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.suggestion-modal__btn--primary .suggestion-modal__btn-spinner {
+  border-color: rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
+}
+
+@keyframes suggestion-modal-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes suggestion-modal-scale {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}

--- a/frontend/src/components/SuggestionModal/SuggestionModal.tsx
+++ b/frontend/src/components/SuggestionModal/SuggestionModal.tsx
@@ -1,0 +1,325 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { isAxiosError } from 'axios'
+import {
+  culturalTagRequest,
+  dishGenreRequest,
+  dishVarietyRequest,
+} from '@/services/content-request-service'
+import './SuggestionModal.css'
+
+export type SuggestionKind = 'cultural' | 'genre' | 'variety'
+
+export interface SuggestionModalProps {
+  kind: SuggestionKind
+  isOpen: boolean
+  onClose: () => void
+  /** Fires after a successful submission so the parent can show inline confirmation. */
+  onSuccess: () => void
+  /** For kind='variety': prefilled parent genre id (from the recipe form). */
+  prefillGenreId?: number
+  /** For kind='cultural': country options for the dropdown. */
+  countryOptions?: string[]
+  /** For kind='variety': genre options for the dropdown. */
+  genreOptions?: Array<{ id: string; name: string }>
+}
+
+export function SuggestionModal({
+  kind,
+  isOpen,
+  onClose,
+  onSuccess,
+  prefillGenreId,
+  countryOptions = [],
+  genreOptions = [],
+}: SuggestionModalProps) {
+  const { t } = useTranslation('common')
+  const titleId = useId()
+  const firstInputRef = useRef<HTMLInputElement>(null)
+
+  const [labelEn, setLabelEn] = useState('')
+  const [labelTr, setLabelTr] = useState('')
+  const [country, setCountry] = useState('')
+  const [genreId, setGenreId] = useState<string>('')
+  const [descriptionEn, setDescriptionEn] = useState('')
+  const [descriptionTr, setDescriptionTr] = useState('')
+  const [showMore, setShowMore] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset state every time the modal opens.
+  useEffect(() => {
+    if (!isOpen) return
+    setLabelEn('')
+    setLabelTr('')
+    setCountry('')
+    setGenreId(prefillGenreId != null ? String(prefillGenreId) : '')
+    setDescriptionEn('')
+    setDescriptionTr('')
+    setShowMore(false)
+    setSubmitting(false)
+    setError(null)
+  }, [isOpen, prefillGenreId])
+
+  // Body scroll lock + ESC + focus management.
+  useEffect(() => {
+    if (!isOpen) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const focusTimer = window.setTimeout(() => firstInputRef.current?.focus(), 30)
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = prevOverflow
+      window.removeEventListener('keydown', onKey)
+      window.clearTimeout(focusTimer)
+    }
+  }, [isOpen, onClose, submitting])
+
+  const titleKey = useMemo(() => {
+    if (kind === 'cultural') return 'suggestion.title.cultural'
+    if (kind === 'genre') return 'suggestion.title.genre'
+    return 'suggestion.title.variety'
+  }, [kind])
+
+  const hasAtLeastOneLabel = useMemo(() => {
+    if (kind === 'cultural') return labelEn.trim().length > 0 || labelTr.trim().length > 0
+    return labelEn.trim().length > 0 || labelTr.trim().length > 0
+  }, [kind, labelEn, labelTr])
+
+  // For variety we reuse labelEn/labelTr state as nameEn/nameTr; same fields.
+  const canSubmit = useMemo(() => {
+    if (submitting) return false
+    if (!hasAtLeastOneLabel) return false
+    if (kind === 'variety' && !genreId) return false
+    return true
+  }, [submitting, hasAtLeastOneLabel, kind, genreId])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const en = labelEn.trim() || undefined
+      const tr = labelTr.trim() || undefined
+      const descEn = descriptionEn.trim() || undefined
+      const descTr = descriptionTr.trim() || undefined
+      if (kind === 'cultural') {
+        await culturalTagRequest.create({
+          labelEn: en,
+          labelTr: tr,
+          country: country.trim() || undefined,
+        })
+      } else if (kind === 'genre') {
+        await dishGenreRequest.create({
+          nameEn: en,
+          nameTr: tr,
+          descriptionEn: descEn,
+          descriptionTr: descTr,
+        })
+      } else {
+        await dishVarietyRequest.create({
+          genreId: Number(genreId),
+          nameEn: en,
+          nameTr: tr,
+          descriptionEn: descEn,
+          descriptionTr: descTr,
+        })
+      }
+      onSuccess()
+    } catch (err) {
+      const apiMsg = isAxiosError(err)
+        ? (err.response?.data as { error?: { message?: string } } | undefined)?.error?.message
+        : null
+      setError(apiMsg || t('suggestion.errors.submitFailed'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  const labelLeftKey = kind === 'cultural' ? 'suggestion.fields.labelEn' : 'suggestion.fields.nameEn'
+  const labelRightKey = kind === 'cultural' ? 'suggestion.fields.labelTr' : 'suggestion.fields.nameTr'
+
+  return (
+    <div
+      className="suggestion-modal-overlay"
+      role="presentation"
+      onClick={() => {
+        if (!submitting) onClose()
+      }}
+    >
+      <div
+        className="suggestion-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id={titleId} className="suggestion-modal__title">
+          {t(titleKey)}
+        </h2>
+        <p className="suggestion-modal__hint">{t('suggestion.hint')}</p>
+
+        <form className="suggestion-modal__form" onSubmit={handleSubmit}>
+          <div className="suggestion-modal__row">
+            <div className="suggestion-modal__field">
+              <label className="suggestion-modal__label" htmlFor={`${titleId}-en`}>
+                {t(labelLeftKey)}
+              </label>
+              <input
+                id={`${titleId}-en`}
+                ref={firstInputRef}
+                type="text"
+                className="suggestion-modal__input"
+                value={labelEn}
+                onChange={(e) => setLabelEn(e.target.value)}
+                maxLength={200}
+                disabled={submitting}
+              />
+            </div>
+            <div className="suggestion-modal__field">
+              <label className="suggestion-modal__label" htmlFor={`${titleId}-tr`}>
+                {t(labelRightKey)}
+              </label>
+              <input
+                id={`${titleId}-tr`}
+                type="text"
+                className="suggestion-modal__input"
+                value={labelTr}
+                onChange={(e) => setLabelTr(e.target.value)}
+                maxLength={200}
+                disabled={submitting}
+              />
+            </div>
+          </div>
+
+          {kind === 'cultural' && (
+            <div className="suggestion-modal__field">
+              <label className="suggestion-modal__label" htmlFor={`${titleId}-country`}>
+                {t('suggestion.fields.country')}
+              </label>
+              <select
+                id={`${titleId}-country`}
+                className="suggestion-modal__select"
+                value={country}
+                onChange={(e) => setCountry(e.target.value)}
+                disabled={submitting}
+              >
+                <option value="">{t('suggestion.fields.countryAny')}</option>
+                {countryOptions.map((c) => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {kind === 'variety' && (
+            <div className="suggestion-modal__field">
+              <label className="suggestion-modal__label" htmlFor={`${titleId}-genre`}>
+                {t('suggestion.fields.genre')}
+              </label>
+              <select
+                id={`${titleId}-genre`}
+                className="suggestion-modal__select"
+                value={genreId}
+                onChange={(e) => setGenreId(e.target.value)}
+                disabled={submitting}
+                required
+              >
+                <option value="">{t('suggestion.fields.genrePlaceholder')}</option>
+                {genreOptions.map((g) => (
+                  <option key={g.id} value={g.id}>{g.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {(kind === 'genre' || kind === 'variety') && (
+            <>
+              {!showMore && (
+                <button
+                  type="button"
+                  className="suggestion-modal__toggle"
+                  onClick={() => setShowMore(true)}
+                >
+                  {t('suggestion.showMore')}
+                </button>
+              )}
+              {showMore && (
+                <div className="suggestion-modal__row">
+                  <div className="suggestion-modal__field">
+                    <label className="suggestion-modal__label" htmlFor={`${titleId}-desc-en`}>
+                      {t('suggestion.fields.descriptionEn')}
+                    </label>
+                    <textarea
+                      id={`${titleId}-desc-en`}
+                      className="suggestion-modal__textarea"
+                      value={descriptionEn}
+                      onChange={(e) => setDescriptionEn(e.target.value)}
+                      maxLength={2000}
+                      disabled={submitting}
+                    />
+                  </div>
+                  <div className="suggestion-modal__field">
+                    <label className="suggestion-modal__label" htmlFor={`${titleId}-desc-tr`}>
+                      {t('suggestion.fields.descriptionTr')}
+                    </label>
+                    <textarea
+                      id={`${titleId}-desc-tr`}
+                      className="suggestion-modal__textarea"
+                      value={descriptionTr}
+                      onChange={(e) => setDescriptionTr(e.target.value)}
+                      maxLength={2000}
+                      disabled={submitting}
+                    />
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          {error && <p className="suggestion-modal__error" role="alert">{error}</p>}
+
+          <div className="suggestion-modal__actions">
+            <button
+              type="button"
+              className="suggestion-modal__btn suggestion-modal__btn--secondary"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              {t('suggestion.cancel')}
+            </button>
+            <button
+              type="submit"
+              className="suggestion-modal__btn suggestion-modal__btn--primary"
+              disabled={!canSubmit}
+              aria-busy={submitting}
+            >
+              <span className="suggestion-modal__btn-content">
+                <span
+                  className={
+                    submitting
+                      ? 'suggestion-modal__btn-label suggestion-modal__btn-label--hidden'
+                      : 'suggestion-modal__btn-label'
+                  }
+                >
+                  {t('suggestion.submit')}
+                </span>
+                {submitting && (
+                  <span className="suggestion-modal__btn-spinner-wrap" aria-hidden>
+                    <span className="ui-spinner suggestion-modal__btn-spinner" />
+                  </span>
+                )}
+              </span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -173,7 +173,49 @@
     "draftPublishConfirm": "Publish this recipe? It will be visible to everyone.",
     "draftDeleteConfirm": "Delete this draft? This cannot be undone.",
     "draftPublished": "Recipe published successfully.",
-    "draftDeleted": "Draft deleted."
+    "draftDeleted": "Draft deleted.",
+    "suggestions": {
+      "title": "My Suggestions",
+      "newButton": "New suggestion",
+      "tabCultural": "Cultural Tags",
+      "tabGenre": "Genres",
+      "tabVariety": "Varieties",
+      "emptyCultural": "You haven't suggested any cultural tags yet.",
+      "emptyGenre": "You haven't suggested any genres yet.",
+      "emptyVariety": "You haven't suggested any varieties yet.",
+      "statusPending": "Pending",
+      "statusApproved": "Approved",
+      "statusRejected": "Rejected",
+      "decisionNote": "Admin note:",
+      "submittedOn": "Submitted {{date}}",
+      "decidedOn": "Decided {{date}}"
+    }
+  },
+  "suggestion": {
+    "title": {
+      "cultural": "Suggest a new cultural tag",
+      "genre": "Suggest a new genre",
+      "variety": "Suggest a new variety"
+    },
+    "fields": {
+      "labelEn": "English label",
+      "labelTr": "Turkish label",
+      "nameEn": "English name",
+      "nameTr": "Turkish name",
+      "country": "Country (optional)",
+      "countryAny": "Any region (global tag)",
+      "genre": "Parent genre",
+      "genrePlaceholder": "Select a genre",
+      "descriptionEn": "English description (optional)",
+      "descriptionTr": "Turkish description (optional)"
+    },
+    "showMore": "Show description fields",
+    "hint": "Provide at least one language label. We'll auto-translate the other if missing. An admin will review your suggestion.",
+    "submit": "Send suggestion",
+    "cancel": "Cancel",
+    "errors": {
+      "submitFailed": "Could not send suggestion. Please try again."
+    }
   },
   "home": {
     "featured": "Featured Recipe",
@@ -361,6 +403,9 @@
       "culturalTags": "Cultural tags",
       "culturalTagsHint": "Tag the occasions this recipe belongs to. Pick a country above to see region-specific tags alongside global ones.",
       "culturalTagsEmpty": "No cultural tags available for the selected country yet.",
+      "suggestNewGenre": "Don't see your genre? Suggest a new one →",
+      "suggestNewVariety": "Don't see your dish? Suggest a new variety →",
+      "suggestNewCulturalTag": "Don't see your occasion? Suggest a new tag →",
       "allergenTags": "Allergens in this recipe",
       "allergenTagsHint": "Select all allergens present in the ingredients.",
       "detectedAllergens": "Detected Allergens",
@@ -438,6 +483,7 @@
     "successDraft": "Recipe saved as draft!",
     "successPublished": "Recipe published!",
     "errorCreate": "Failed to create recipe. Please try again.",
+    "suggestionSent": "Suggestion sent. We'll add it once an admin approves.",
     "media": {
       "title": "Photos & video (optional)",
       "hint": "JPEG, PNG, or WebP images (max 10 MB each) and MP4 video (max 100 MB). Files are uploaded after the recipe is created.",

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -173,7 +173,49 @@
     "draftPublishConfirm": "Bu tarif yayınlansın mı? Herkese görünür olacak.",
     "draftDeleteConfirm": "Bu taslak silinsin mi? Bu işlem geri alınamaz.",
     "draftPublished": "Tarif başarıyla yayınlandı.",
-    "draftDeleted": "Taslak silindi."
+    "draftDeleted": "Taslak silindi.",
+    "suggestions": {
+      "title": "Önerilerim",
+      "newButton": "Yeni öneri",
+      "tabCultural": "Kültürel Etiketler",
+      "tabGenre": "Türler",
+      "tabVariety": "Çeşitler",
+      "emptyCultural": "Henüz kültürel etiket önermediniz.",
+      "emptyGenre": "Henüz tür önermediniz.",
+      "emptyVariety": "Henüz çeşit önermediniz.",
+      "statusPending": "Beklemede",
+      "statusApproved": "Onaylandı",
+      "statusRejected": "Reddedildi",
+      "decisionNote": "Yönetici notu:",
+      "submittedOn": "Gönderildi: {{date}}",
+      "decidedOn": "Karar: {{date}}"
+    }
+  },
+  "suggestion": {
+    "title": {
+      "cultural": "Yeni kültürel etiket öner",
+      "genre": "Yeni tür öner",
+      "variety": "Yeni çeşit öner"
+    },
+    "fields": {
+      "labelEn": "İngilizce etiket",
+      "labelTr": "Türkçe etiket",
+      "nameEn": "İngilizce ad",
+      "nameTr": "Türkçe ad",
+      "country": "Ülke (isteğe bağlı)",
+      "countryAny": "Tüm bölgeler (küresel etiket)",
+      "genre": "Üst tür",
+      "genrePlaceholder": "Bir tür seçin",
+      "descriptionEn": "İngilizce açıklama (isteğe bağlı)",
+      "descriptionTr": "Türkçe açıklama (isteğe bağlı)"
+    },
+    "showMore": "Açıklama alanlarını göster",
+    "hint": "En az bir dilde etiket girin. Diğer dilin çevirisini biz yapacağız. Öneriniz yönetici onayına sunulacak.",
+    "submit": "Öneriyi gönder",
+    "cancel": "İptal",
+    "errors": {
+      "submitFailed": "Öneri gönderilemedi. Lütfen tekrar deneyin."
+    }
   },
   "home": {
     "featured": "Öne Çıkan Tarif",
@@ -361,6 +403,9 @@
       "culturalTags": "Kültürel etiketler",
       "culturalTagsHint": "Bu tarifin ait olduğu vesileleri etiketleyin. Yukarıdan bir ülke seçerseniz o bölgeye özel etiketler ile küresel etiketler birlikte görünür.",
       "culturalTagsEmpty": "Seçili ülke için henüz kültürel etiket bulunmuyor.",
+      "suggestNewGenre": "Türü bulamadın mı? Yeni bir tür öner →",
+      "suggestNewVariety": "Yemeği bulamadın mı? Yeni bir çeşit öner →",
+      "suggestNewCulturalTag": "Vesileyi bulamadın mı? Yeni bir etiket öner →",
       "allergenTags": "Bu tarifte bulunan alerjenler",
       "allergenTagsHint": "Malzemelerde bulunan tüm alerjenleri seçin.",
       "detectedAllergens": "Tespit Edilen Alerjenler",
@@ -438,6 +483,7 @@
     "successDraft": "Tarif taslak olarak kaydedildi!",
     "successPublished": "Tarif yayınlandı!",
     "errorCreate": "Tarif oluşturulamadı. Lütfen tekrar deneyin.",
+    "suggestionSent": "Öneriniz gönderildi. Yönetici onayladıktan sonra eklenecek.",
     "media": {
       "title": "Fotoğraf ve video (isteğe bağlı)",
       "hint": "JPEG, PNG veya WebP görseller (dosya başına en fazla 10 MB) ve MP4 video (en fazla 100 MB). Dosyalar tarif oluşturulduktan sonra yüklenir.",

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.css
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.css
@@ -922,3 +922,33 @@
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
 }
+
+/* ── Suggest-new inline link (expert role only) ─────────────────────────── */
+.cr-suggest-link {
+  align-self: flex-start;
+  margin-top: 0.35rem;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-main);
+  cursor: pointer;
+  text-align: left;
+}
+
+.cr-suggest-link:hover {
+  text-decoration: underline;
+}
+
+/* ── Suggestion sent banner ─────────────────────────────────────────────── */
+.cr-suggest-success-banner {
+  padding: 0.6rem 0.9rem;
+  margin-bottom: var(--space-md);
+  background: rgba(34, 139, 80, 0.1);
+  border: 1px solid rgba(34, 139, 80, 0.3);
+  border-radius: var(--radius-md);
+  color: #1a7a4a;
+  font-size: 0.9rem;
+  font-weight: 500;
+}

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
@@ -17,6 +17,7 @@ import { ToolPicker } from '@/components/CreateRecipe/ToolPicker'
 import { UnitPicker } from '@/components/CreateRecipe/UnitPicker'
 import { mediaService } from '@/services/media-service'
 import { useUserRole } from '@/hooks/useUserRole'
+import { SuggestionModal, type SuggestionKind } from '@/components/SuggestionModal/SuggestionModal'
 import './CreateRecipePage.css'
 
 /** Aligned with backend `media.ts` */
@@ -236,14 +237,45 @@ export function CreateRecipePage() {
   const [recording, setRecording] = useState(false)
   const [voiceLanguage, setVoiceLanguage] = useState<'auto' | 'en' | 'tr'>('auto')
   const [culturalTags, setCulturalTags] = useState<CulturalTag[]>([])
+  /** Country options for the cultural-tag suggestion modal — populated lazily. */
+  const [countryOptions, setCountryOptions] = useState<string[]>([])
+  /** Active suggestion modal kind (null = closed). Only experts can open it. */
+  const [suggestModal, setSuggestModal] = useState<SuggestionKind | null>(null)
+  /** Inline confirmation banner shown briefly after a suggestion is submitted. */
+  const [suggestSent, setSuggestSent] = useState(false)
   // Cook can only create community; expert can create both
   const canCreateCultural = role === 'expert'
+  const canSuggestContent = role === 'expert'
 
   useEffect(() => {
     discoveryService.getGenres().then(setGenres).catch(() => setGenres([]))
     discoveryService.getDietaryTags().then(setAllTags).catch(() => setAllTags([]))
     allergenService.list().then(setAllAllergens).catch(() => setAllAllergens([]))
   }, [])
+
+  /** Fetch country list once when the user has the expert role — the cultural-tag
+   * suggestion modal needs it for its dropdown. */
+  useEffect(() => {
+    if (!canSuggestContent) return
+    let cancelled = false
+    discoveryService
+      .getLocations()
+      .then((opts) => {
+        if (!cancelled) setCountryOptions(opts.countries)
+      })
+      .catch(() => {
+        if (!cancelled) setCountryOptions([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [canSuggestContent])
+
+  function handleSuggestSuccess() {
+    setSuggestModal(null)
+    setSuggestSent(true)
+    window.setTimeout(() => setSuggestSent(false), 4000)
+  }
 
   /** Fetch cultural tags scoped to the recipe's country (global tags always included).
    * Available for both community and cultural recipes (mirrors mobile). Drops
@@ -704,6 +736,11 @@ export function CreateRecipePage() {
         {/* ── STEP 1: Basic Info ──────────────────────────────────────────── */}
         {step === 1 && (
           <div className="cr-section">
+            {suggestSent && (
+              <div className="cr-suggest-success-banner" role="status" aria-live="polite">
+                ✓ {t('create.suggestionSent')}
+              </div>
+            )}
             <div className="cr-field cr-parse">
               <label className="cr-label" htmlFor="cr-parse-text">
                 {t('create.parse.label')}
@@ -869,6 +906,15 @@ export function CreateRecipePage() {
                   })}
                 </div>
               )}
+              {canSuggestContent && (
+                <button
+                  type="button"
+                  className="cr-suggest-link"
+                  onClick={() => setSuggestModal('cultural')}
+                >
+                  {t('create.fields.suggestNewCulturalTag')}
+                </button>
+              )}
             </div>
 
             {/* Genre → Variety (two-step; varieties loaded per genre) */}
@@ -891,6 +937,15 @@ export function CreateRecipePage() {
                   </option>
                 ))}
               </select>
+              {canSuggestContent && (
+                <button
+                  type="button"
+                  className="cr-suggest-link"
+                  onClick={() => setSuggestModal('genre')}
+                >
+                  {t('create.fields.suggestNewGenre')}
+                </button>
+              )}
             </div>
 
             <div className="cr-field">
@@ -918,6 +973,15 @@ export function CreateRecipePage() {
                   </option>
                 ))}
               </select>
+              {canSuggestContent && draft.genreId && (
+                <button
+                  type="button"
+                  className="cr-suggest-link"
+                  onClick={() => setSuggestModal('variety')}
+                >
+                  {t('create.fields.suggestNewVariety')}
+                </button>
+              )}
             </div>
 
             {/* Serving Size */}
@@ -1430,6 +1494,17 @@ export function CreateRecipePage() {
         )}
       </div>
 
+      {canSuggestContent && (
+        <SuggestionModal
+          kind={suggestModal ?? 'cultural'}
+          isOpen={suggestModal !== null}
+          onClose={() => setSuggestModal(null)}
+          onSuccess={handleSuggestSuccess}
+          prefillGenreId={draft.genreId ? Number(draft.genreId) : undefined}
+          countryOptions={countryOptions}
+          genreOptions={genres.map((g) => ({ id: g.id, name: g.name }))}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/Profile/MySuggestions.css
+++ b/frontend/src/pages/Profile/MySuggestions.css
@@ -1,0 +1,154 @@
+.my-suggestions__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-sm);
+}
+
+.my-suggestions__new-btn {
+  background: var(--color-main);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-pill);
+  padding: 0.45rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter var(--transition-fast);
+}
+
+.my-suggestions__new-btn:hover {
+  filter: brightness(1.05);
+}
+
+.my-suggestions__success-banner {
+  padding: 0.6rem 0.9rem;
+  margin-bottom: var(--space-md);
+  background: rgba(34, 139, 80, 0.1);
+  border: 1px solid rgba(34, 139, 80, 0.3);
+  border-radius: var(--radius-md);
+  color: #1a7a4a;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.my-suggestions__tabs {
+  display: flex;
+  gap: var(--space-md);
+  border-bottom: 1px solid rgba(42, 24, 16, 0.12);
+  margin-bottom: var(--space-md);
+}
+
+.my-suggestions__tab {
+  background: transparent;
+  border: none;
+  padding: 0.5rem 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--rd-muted, #6b5d52);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.my-suggestions__tab:hover {
+  color: var(--rd-fg, #2a1810);
+}
+
+.my-suggestions__tab--active {
+  color: var(--rd-fg, #2a1810);
+  border-bottom-color: var(--color-accent, #d4860a);
+}
+
+.my-suggestions__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.my-suggestions__empty {
+  margin: 0;
+  padding: var(--space-md);
+  color: var(--rd-muted, #6b5d52);
+  font-size: 0.9rem;
+  text-align: center;
+  background: rgba(42, 24, 16, 0.03);
+  border-radius: var(--radius-md);
+}
+
+.my-suggestions__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: var(--space-md);
+  background: var(--surface-card, #fff);
+  border: 1px solid rgba(42, 24, 16, 0.1);
+  border-radius: var(--radius-md);
+}
+
+.my-suggestions__item-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+  justify-content: space-between;
+}
+
+.my-suggestions__item-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--rd-fg, #2a1810);
+}
+
+.my-suggestions__item-meta {
+  font-size: 0.8rem;
+  color: var(--rd-muted, #6b5d52);
+}
+
+.my-suggestions__status {
+  display: inline-block;
+  padding: 0.18rem 0.55rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.my-suggestions__status--pending {
+  background: rgba(212, 134, 10, 0.12);
+  color: #a16207;
+}
+
+.my-suggestions__status--approved {
+  background: rgba(34, 139, 80, 0.12);
+  color: #1a7a4a;
+}
+
+.my-suggestions__status--rejected {
+  background: rgba(180, 35, 24, 0.12);
+  color: #b42318;
+}
+
+.my-suggestions__note {
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  background: rgba(42, 24, 16, 0.04);
+  border-left: 3px solid rgba(42, 24, 16, 0.2);
+  border-radius: var(--radius-sm);
+}
+
+.my-suggestions__note-label {
+  font-weight: 600;
+  color: var(--rd-fg, #2a1810);
+}
+
+.my-suggestions__loading {
+  padding: var(--space-md);
+  color: var(--rd-muted, #6b5d52);
+  font-size: 0.9rem;
+  text-align: center;
+}

--- a/frontend/src/pages/Profile/MySuggestions.tsx
+++ b/frontend/src/pages/Profile/MySuggestions.tsx
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  culturalTagRequest,
+  dishGenreRequest,
+  dishVarietyRequest,
+  type MyCulturalTagRequest,
+  type MyDishGenreRequest,
+  type MyDishVarietyRequest,
+} from '@/services/content-request-service'
+import { discoveryService, type Genre } from '@/services/discovery-service'
+import { SuggestionModal, type SuggestionKind } from '@/components/SuggestionModal/SuggestionModal'
+import './MySuggestions.css'
+
+type TabKey = 'cultural' | 'genre' | 'variety'
+
+function formatDate(iso: string | null | undefined, locale: string): string {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleDateString(locale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  } catch {
+    return ''
+  }
+}
+
+function pickLabel(en: string | null, tr: string | null, lang: string): string {
+  if (lang.startsWith('tr')) return tr ?? en ?? ''
+  return en ?? tr ?? ''
+}
+
+export function MySuggestions() {
+  const { t, i18n } = useTranslation('common')
+  const [activeTab, setActiveTab] = useState<TabKey>('cultural')
+  const [cultural, setCultural] = useState<MyCulturalTagRequest[] | null>(null)
+  const [genres, setGenres] = useState<MyDishGenreRequest[] | null>(null)
+  const [varieties, setVarieties] = useState<MyDishVarietyRequest[] | null>(null)
+  /** Modal state — null = closed; otherwise the kind to render. */
+  const [suggestModal, setSuggestModal] = useState<SuggestionKind | null>(null)
+  /** Inline confirmation shown briefly after a suggestion is submitted. */
+  const [suggestSent, setSuggestSent] = useState(false)
+  /** Options needed by the modal (lazy-fetched once). */
+  const [genreOptions, setGenreOptions] = useState<Genre[]>([])
+  const [countryOptions, setCountryOptions] = useState<string[]>([])
+
+  const refreshActiveTab = useCallback(async (tab: TabKey) => {
+    try {
+      if (tab === 'cultural') setCultural(await culturalTagRequest.listMine())
+      else if (tab === 'genre') setGenres(await dishGenreRequest.listMine())
+      else setVarieties(await dishVarietyRequest.listMine())
+    } catch {
+      /* keep existing data on transient failure */
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.allSettled([
+      culturalTagRequest.listMine(),
+      dishGenreRequest.listMine(),
+      dishVarietyRequest.listMine(),
+      discoveryService.getGenres(),
+      discoveryService.getLocations(),
+    ]).then((results) => {
+      if (cancelled) return
+      setCultural(results[0].status === 'fulfilled' ? results[0].value : [])
+      setGenres(results[1].status === 'fulfilled' ? results[1].value : [])
+      setVarieties(results[2].status === 'fulfilled' ? results[2].value : [])
+      setGenreOptions(results[3].status === 'fulfilled' ? results[3].value : [])
+      setCountryOptions(
+        results[4].status === 'fulfilled' ? results[4].value.countries : [],
+      )
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  function handleSuggestSuccess() {
+    const tab = suggestModal
+    setSuggestModal(null)
+    setSuggestSent(true)
+    window.setTimeout(() => setSuggestSent(false), 4000)
+    if (tab) void refreshActiveTab(tab)
+  }
+
+  const tabs: Array<{ key: TabKey; label: string; count: number | null }> = useMemo(
+    () => [
+      { key: 'cultural', label: t('profileScreen.suggestions.tabCultural'), count: cultural?.length ?? null },
+      { key: 'genre', label: t('profileScreen.suggestions.tabGenre'), count: genres?.length ?? null },
+      { key: 'variety', label: t('profileScreen.suggestions.tabVariety'), count: varieties?.length ?? null },
+    ],
+    [t, cultural, genres, varieties],
+  )
+
+  const lang = i18n.language
+
+  function renderStatus(status: 'pending' | 'approved' | 'rejected') {
+    return (
+      <span className={`my-suggestions__status my-suggestions__status--${status}`}>
+        {t(`profileScreen.suggestions.status${status[0].toUpperCase()}${status.slice(1)}`)}
+      </span>
+    )
+  }
+
+  function renderNote(note: string | null) {
+    if (!note) return null
+    return (
+      <p className="my-suggestions__note">
+        <span className="my-suggestions__note-label">
+          {t('profileScreen.suggestions.decisionNote')}
+        </span>{' '}
+        {note}
+      </p>
+    )
+  }
+
+  function renderMeta(item: { createdAt: string; decidedAt: string | null }) {
+    const dateIso = item.decidedAt ?? item.createdAt
+    const key = item.decidedAt ? 'profileScreen.suggestions.decidedOn' : 'profileScreen.suggestions.submittedOn'
+    return (
+      <span className="my-suggestions__item-meta">
+        {t(key, { date: formatDate(dateIso, lang) })}
+      </span>
+    )
+  }
+
+  return (
+    <section className="profile-page__section">
+      <div className="my-suggestions__header">
+        <h2 className="profile-page__section-title">{t('profileScreen.suggestions.title')}</h2>
+        <button
+          type="button"
+          className="my-suggestions__new-btn"
+          onClick={() => setSuggestModal(activeTab)}
+        >
+          + {t('profileScreen.suggestions.newButton')}
+        </button>
+      </div>
+
+      {suggestSent && (
+        <div className="my-suggestions__success-banner" role="status" aria-live="polite">
+          ✓ {t('create.suggestionSent')}
+        </div>
+      )}
+
+      <div className="my-suggestions__tabs" role="tablist">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.key}
+            className={`my-suggestions__tab${activeTab === tab.key ? ' my-suggestions__tab--active' : ''}`}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+            {tab.count != null && tab.count > 0 && ` (${tab.count})`}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'cultural' && (
+        cultural == null ? (
+          <p className="my-suggestions__loading">{t('common.loading')}</p>
+        ) : cultural.length === 0 ? (
+          <p className="my-suggestions__empty">{t('profileScreen.suggestions.emptyCultural')}</p>
+        ) : (
+          <div className="my-suggestions__list">
+            {cultural.map((r) => (
+              <article key={r.id} className="my-suggestions__item">
+                <div className="my-suggestions__item-header">
+                  <h3 className="my-suggestions__item-name">
+                    {pickLabel(r.labelEn, r.labelTr, lang)}
+                    {r.country && ` · ${r.country}`}
+                  </h3>
+                  {renderStatus(r.status)}
+                </div>
+                {renderMeta(r)}
+                {renderNote(r.decisionNote)}
+              </article>
+            ))}
+          </div>
+        )
+      )}
+
+      {activeTab === 'genre' && (
+        genres == null ? (
+          <p className="my-suggestions__loading">{t('common.loading')}</p>
+        ) : genres.length === 0 ? (
+          <p className="my-suggestions__empty">{t('profileScreen.suggestions.emptyGenre')}</p>
+        ) : (
+          <div className="my-suggestions__list">
+            {genres.map((r) => (
+              <article key={r.id} className="my-suggestions__item">
+                <div className="my-suggestions__item-header">
+                  <h3 className="my-suggestions__item-name">
+                    {pickLabel(r.nameEn, r.nameTr, lang)}
+                  </h3>
+                  {renderStatus(r.status)}
+                </div>
+                {renderMeta(r)}
+                {renderNote(r.decisionNote)}
+              </article>
+            ))}
+          </div>
+        )
+      )}
+
+      {activeTab === 'variety' && (
+        varieties == null ? (
+          <p className="my-suggestions__loading">{t('common.loading')}</p>
+        ) : varieties.length === 0 ? (
+          <p className="my-suggestions__empty">{t('profileScreen.suggestions.emptyVariety')}</p>
+        ) : (
+          <div className="my-suggestions__list">
+            {varieties.map((r) => (
+              <article key={r.id} className="my-suggestions__item">
+                <div className="my-suggestions__item-header">
+                  <h3 className="my-suggestions__item-name">
+                    {pickLabel(r.nameEn, r.nameTr, lang)}
+                  </h3>
+                  {renderStatus(r.status)}
+                </div>
+                {renderMeta(r)}
+                {renderNote(r.decisionNote)}
+              </article>
+            ))}
+          </div>
+        )
+      )}
+
+      <SuggestionModal
+        kind={suggestModal ?? 'cultural'}
+        isOpen={suggestModal !== null}
+        onClose={() => setSuggestModal(null)}
+        onSuccess={handleSuggestSuccess}
+        countryOptions={countryOptions}
+        genreOptions={genreOptions.map((g) => ({ id: g.id, name: g.name }))}
+      />
+    </section>
+  )
+}

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -5,6 +5,7 @@ import { isAxiosError } from 'axios'
 import { useAppSelector } from '@/store/hooks'
 import { recipeService, type MyRecipeSummary } from '@/services/recipe-service'
 import { favoriteService, type FavoriteRecipe } from '@/services/favorite-service'
+import { MySuggestions } from '@/pages/Profile/MySuggestions'
 import './ProfilePage.css'
 
 function StarIcon() {
@@ -299,6 +300,8 @@ export function ProfilePage() {
       {!favoritesLoading && favorites.length === 0 && (
         <p className="profile-page__empty">{t('profileScreen.noFavorites')}</p>
       )}
+
+      {profile.role === 'expert' && <MySuggestions />}
     </div>
   )
 }

--- a/frontend/src/services/content-request-service.ts
+++ b/frontend/src/services/content-request-service.ts
@@ -1,0 +1,150 @@
+import { httpClient } from '@/lib/http-client'
+import type {
+  CulturalTagRequest,
+  DishGenreRequest,
+  DishVarietyRequest,
+} from '@/services/types/admin'
+
+interface ApiEnvelope<T> {
+  success: boolean
+  data: T
+  error: null
+}
+
+/** Shape returned by `/<resource>/requests/me` — same as the admin types but
+ * `requester` is not joined back to the caller (we already know it's us). */
+type MyCulturalTagRequest = Omit<CulturalTagRequest, 'requester'>
+type MyDishGenreRequest = Omit<DishGenreRequest, 'requester'>
+type MyDishVarietyRequest = Omit<DishVarietyRequest, 'requester'>
+
+// ── Cultural tag suggestions ────────────────────────────────────────────────
+
+export interface CreateCulturalTagRequestPayload {
+  labelEn?: string
+  labelTr?: string
+  country?: string
+}
+
+function normalizeCulturalTagRequest(row: any): MyCulturalTagRequest {
+  return {
+    id: Number(row.id),
+    labelEn: row.labelEn ?? null,
+    labelTr: row.labelTr ?? null,
+    country: row.country ?? null,
+    status: row.status,
+    decisionNote: row.decisionNote ?? null,
+    decidedBy: row.decidedBy ?? null,
+    createdAt: row.createdAt ?? '',
+    decidedAt: row.decidedAt ?? null,
+  }
+}
+
+export const culturalTagRequest = {
+  create: async (
+    payload: CreateCulturalTagRequestPayload,
+  ): Promise<MyCulturalTagRequest> => {
+    const { data } = await httpClient.post<ApiEnvelope<MyCulturalTagRequest>>(
+      '/cultural-tags/requests',
+      payload,
+    )
+    return normalizeCulturalTagRequest(data.data)
+  },
+  listMine: async (): Promise<MyCulturalTagRequest[]> => {
+    const { data } = await httpClient.get<ApiEnvelope<MyCulturalTagRequest[]>>(
+      '/cultural-tags/requests/me',
+    )
+    return (Array.isArray(data.data) ? data.data : []).map(normalizeCulturalTagRequest)
+  },
+}
+
+// ── Dish genre suggestions ──────────────────────────────────────────────────
+
+export interface CreateDishGenreRequestPayload {
+  nameEn?: string
+  nameTr?: string
+  descriptionEn?: string
+  descriptionTr?: string
+}
+
+function normalizeDishGenreRequest(row: any): MyDishGenreRequest {
+  return {
+    id: Number(row.id),
+    nameEn: row.nameEn ?? null,
+    nameTr: row.nameTr ?? null,
+    descriptionEn: row.descriptionEn ?? null,
+    descriptionTr: row.descriptionTr ?? null,
+    status: row.status,
+    decisionNote: row.decisionNote ?? null,
+    decidedBy: row.decidedBy ?? null,
+    createdAt: row.createdAt ?? '',
+    decidedAt: row.decidedAt ?? null,
+  }
+}
+
+export const dishGenreRequest = {
+  create: async (
+    payload: CreateDishGenreRequestPayload,
+  ): Promise<MyDishGenreRequest> => {
+    const { data } = await httpClient.post<ApiEnvelope<MyDishGenreRequest>>(
+      '/dish-genres/requests',
+      payload,
+    )
+    return normalizeDishGenreRequest(data.data)
+  },
+  listMine: async (): Promise<MyDishGenreRequest[]> => {
+    const { data } = await httpClient.get<ApiEnvelope<MyDishGenreRequest[]>>(
+      '/dish-genres/requests/me',
+    )
+    return (Array.isArray(data.data) ? data.data : []).map(normalizeDishGenreRequest)
+  },
+}
+
+// ── Dish variety suggestions ────────────────────────────────────────────────
+
+export interface CreateDishVarietyRequestPayload {
+  genreId: number
+  nameEn?: string
+  nameTr?: string
+  descriptionEn?: string
+  descriptionTr?: string
+}
+
+function normalizeDishVarietyRequest(row: any): MyDishVarietyRequest {
+  return {
+    id: Number(row.id),
+    genreId: Number(row.genreId),
+    nameEn: row.nameEn ?? null,
+    nameTr: row.nameTr ?? null,
+    descriptionEn: row.descriptionEn ?? null,
+    descriptionTr: row.descriptionTr ?? null,
+    status: row.status,
+    decisionNote: row.decisionNote ?? null,
+    decidedBy: row.decidedBy ?? null,
+    createdAt: row.createdAt ?? '',
+    decidedAt: row.decidedAt ?? null,
+  }
+}
+
+export const dishVarietyRequest = {
+  create: async (
+    payload: CreateDishVarietyRequestPayload,
+  ): Promise<MyDishVarietyRequest> => {
+    const { data } = await httpClient.post<ApiEnvelope<MyDishVarietyRequest>>(
+      '/dish-varieties/requests',
+      payload,
+    )
+    return normalizeDishVarietyRequest(data.data)
+  },
+  listMine: async (): Promise<MyDishVarietyRequest[]> => {
+    const { data } = await httpClient.get<ApiEnvelope<MyDishVarietyRequest[]>>(
+      '/dish-varieties/requests/me',
+    )
+    return (Array.isArray(data.data) ? data.data : []).map(normalizeDishVarietyRequest)
+  },
+}
+
+export type {
+  MyCulturalTagRequest,
+  MyDishGenreRequest,
+  MyDishVarietyRequest,
+}


### PR DESCRIPTION
## What does this PR do?
Adds the expert-only UI for submitting and tracking content suggestions (cultural tags, dish genres, dish varieties). Backend admin review pipeline is already in place (#498/#509/#517); this PR wires the user side: inline suggest triggers on the recipe creation form, a generic 3-variant modal, and a tabbed "My Suggestions" section on the profile page that doubles as another entry point for new suggestions.

## Changes
- `services/content-request-service.ts` — three namespaces (`culturalTagRequest`, `dishGenreRequest`, `dishVarietyRequest`) each with `create()` and `listMine()`; types reuse `services/types/admin.ts` shape with `requester` stripped
- `components/SuggestionModal` — generic form modal parameterized by `kind: 'cultural' | 'genre' | 'variety'`. ConfirmModal CSS pattern mirrored. Description fields hidden behind a "Show more" toggle. Cultural tag country picker uses a dropdown sourced from `discoveryService.getLocations().countries`. Variety modal preselects the parent genre when triggered from the recipe form
- `pages/CreateRecipe/CreateRecipePage.tsx` — three inline "Suggest new …" links below genre, variety, and cultural tag pickers (visible only when `role === 'expert'`); variety link additionally requires a genre to be selected. Modal mounted at the root with shared options. 4-second inline success banner shown above step 1 after submission; recipe draft state is preserved across the flow
- `pages/Profile/MySuggestions.{tsx,css}` — type-tabbed section (Cultural Tags / Genres / Varieties) with status badges (pending/approved/rejected), submitted/decided dates, and admin decision notes. Includes a "New suggestion" button that opens the same modal scoped to the active tab and refreshes that tab on success
- `pages/Profile/ProfilePage.tsx` — renders `MySuggestions` only when `profile.role === 'expert'`
- EN/TR locale strings under `create.fields.suggestNew*`, `create.suggestionSent`, `profileScreen.suggestions.*`, and a top-level `suggestion.*` block for the modal

## How to test
- [ ] Log in as an expert. Open `/create`. "Suggest new …" links appear below the cultural tag picker and the genre dropdown; the variety link appears only after a genre is chosen
- [ ] Open the cultural tag modal: country dropdown is populated, submit fails without at least one label, succeeds with EN or TR alone, closes on success, and the recipe form keeps its state. A green confirmation banner shows briefly at the top of step 1
- [ ] Open the genre modal: "Show description fields" toggles the description textareas
- [ ] Open the variety modal from the form: the parent genre dropdown is preselected
- [ ] Log in as a cook or learner: no inline links anywhere; the "My Suggestions" section on `/profile` is hidden
- [ ] As an expert, open `/profile`. "My Suggestions" section appears after Favorites with three tabs and a "New suggestion" button. Submitting from a tab refreshes its list with the new pending item at the top
- [ ] Decision-note rendering: have an admin approve or reject a request, then revisit `/profile`; the corresponding item shows the green/red badge and the admin note when present
- [ ] EN/TR locale switch updates all new strings
- [ ] `npm run build` passes

## Related issue
Closes #552