### PR TITLE
[Mobile/Fix] Fetch allergens from dynamic backend list in search filter

### DIFF
--- a/mobile/src/__tests__/FilterModal.test.tsx
+++ b/mobile/src/__tests__/FilterModal.test.tsx
@@ -14,6 +14,10 @@ jest.mock('../api/search', () => ({
   fetchLocations: jest.fn(),
 }));
 
+jest.mock('../api/allergens', () => ({
+  getAllergens: jest.fn(),
+}));
+
 jest.mock('../api/cultural-tags', () => {
   const actual = jest.requireActual('../api/cultural-tags');
   return {
@@ -24,6 +28,9 @@ jest.mock('../api/cultural-tags', () => {
 
 const { getCulturalTags } = jest.requireMock('../api/cultural-tags') as {
   getCulturalTags: jest.Mock;
+};
+const { getAllergens } = jest.requireMock('../api/allergens') as {
+  getAllergens: jest.Mock;
 };
 
 const mockFetchTags = fetchDietaryTags as jest.MockedFunction<typeof fetchDietaryTags>;
@@ -51,9 +58,9 @@ describe('FilterModal', () => {
     jest.clearAllMocks();
     mockFetchTags.mockResolvedValue([
       { id: 1, name: 'Vegetarian', category: 'dietary' },
-      { id: 2, name: 'Peanuts', category: 'allergen' },
     ]);
     mockFetchLocations.mockResolvedValue(['Turkey', 'Italy']);
+    getAllergens.mockResolvedValue([{ id: 2, name: 'Peanuts' }]);
     getCulturalTags.mockImplementation(async (country?: string | null) => {
       const all = [
         { id: 1, key: 'wedding', labelEn: 'Wedding', labelTr: 'Düğün', country: null },

--- a/mobile/src/api/allergens.ts
+++ b/mobile/src/api/allergens.ts
@@ -6,7 +6,12 @@ export interface AllergenItem {
 }
 
 export async function getAllergens(): Promise<AllergenItem[]> {
-  return fetchApi<AllergenItem[]>('/allergens');
+  try {
+    return await fetchApi<AllergenItem[]>('/allergens');
+  } catch (error) {
+    console.error('getAllergens error:', error);
+    return [];
+  }
 }
 
 export async function detectAllergens(ingredientIds: number[]): Promise<AllergenItem[]> {

--- a/mobile/src/components/search/FilterModal.tsx
+++ b/mobile/src/components/search/FilterModal.tsx
@@ -13,6 +13,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { fetchDietaryTags, fetchLocations, type DietaryTag } from '../../api/search';
 import { getCulturalTags, pickCulturalTagLabel, type CulturalTagItem } from '../../api/cultural-tags';
+import { getAllergens, type AllergenItem } from '../../api/allergens';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
 import type { ActiveFilters } from '../../navigation/types';
 
@@ -46,6 +47,7 @@ export function FilterModal({ visible, onClose, onApply, onClear, appliedFilters
     cultural: false,
     location: false,
   });
+  const [allergens, setAllergens] = useState<AllergenItem[]>([]);
   const [tags, setTags] = useState<DietaryTag[]>([]);
   const [culturalTags, setCulturalTags] = useState<CulturalTagItem[]>([]);
   const [countries, setCountries] = useState<string[]>([]);
@@ -65,14 +67,15 @@ export function FilterModal({ visible, onClose, onApply, onClear, appliedFilters
     setFilters(appliedFilters ?? EMPTY_FILTERS);
   }, [appliedFilters]);
 
-  // Load dietary tags + countries when modal opens
+  // Load allergens, dietary tags and countries when modal opens
   useEffect(() => {
     if (!visible) return;
     setLoading(true);
-    Promise.all([fetchDietaryTags(), fetchLocations()])
-      .then(([tagData, countryData]) => {
+    Promise.all([fetchDietaryTags(), fetchLocations(), getAllergens()])
+      .then(([tagData, countryData, allergenData]) => {
         setTags(tagData);
         setCountries(countryData);
+        setAllergens(allergenData);
       })
       .finally(() => setLoading(false));
   }, [visible, i18n.language]);
@@ -102,7 +105,6 @@ export function FilterModal({ visible, onClose, onApply, onClear, appliedFilters
     fetchLocations(filters.country).then(setCities);
   }, [filters.country]);
 
-  const allergenTags = tags.filter((t) => t.category === 'allergen');
   const dietaryTags = tags.filter((t) => t.category === 'dietary');
 
   const toggleAllergen = (id: number, name: string) => {
@@ -243,7 +245,7 @@ export function FilterModal({ visible, onClose, onApply, onClear, appliedFilters
             )}
 
             {/* ── Exclude Allergens ── */}
-            {allergenTags.length > 0 && (
+            {allergens.length > 0 && (
               <View style={styles.filterSection}>
                 <TouchableOpacity
                   style={styles.sectionHeader}
@@ -259,7 +261,7 @@ export function FilterModal({ visible, onClose, onApply, onClear, appliedFilters
 
                 {expandedSections.allergens && (
                   <View style={styles.sectionContent}>
-                    {allergenTags.map((tag) => (
+                    {allergens.map((tag) => (
                       <TouchableOpacity
                         key={tag.id}
                         style={styles.checkboxRow}


### PR DESCRIPTION
## What does this PR do?
Fixes the allergen filter in the search screen's FilterModal. Previously, allergens were sourced from `/dietary-tags` (filtered by `category === 'allergen'`), but the backend's `excludeAllergens` discovery param expects IDs from the separate `allergens` table. FilterModal now fetches allergens via `GET /allergens` (same endpoint used by CreateAllergensScreen), so selected allergen IDs correctly map to what the backend expects — excluding recipes that contain those allergens via `ingredient_allergens`.

`getAllergens()` also gains an error fallback (`[]` on failure) to match the pattern of other API helpers.

## How to test
1. Open the Search screen and tap the filter icon
2. Expand "Exclude Allergens" — the list should now match the full allergen list from the backend (e.g. Gluten, Dairy, Eggs, Peanuts…)
3. Select one or more allergens and apply filters
4. Verify that returned recipes do not contain the selected allergens

## Related issue
Closes #532