### PR TITLE
[Mobile/Feature] Implement persistent recipe draft saving (#429)

### DIFF
--- a/mobile/src/__tests__/CreateScreensDraft.test.tsx
+++ b/mobile/src/__tests__/CreateScreensDraft.test.tsx
@@ -15,6 +15,19 @@ jest.mock('@expo/vector-icons', () => ({
   FontAwesome: 'FontAwesome',
 }));
 
+jest.mock('expo-av', () => ({
+  Audio: {
+    requestPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+    setAudioModeAsync: jest.fn().mockResolvedValue(undefined),
+    Recording: jest.fn().mockImplementation(() => ({
+      prepareToRecordAsync: jest.fn().mockResolvedValue(undefined),
+      startAsync: jest.fn().mockResolvedValue(undefined),
+      stopAndUnloadAsync: jest.fn().mockResolvedValue(undefined),
+      getURI: jest.fn().mockReturnValue(null),
+    })),
+  },
+}));
+
 // Mock navigation
 jest.mock('@react-navigation/native', () => {
   return {

--- a/mobile/src/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/__tests__/ProfileScreen.test.tsx
@@ -8,6 +8,15 @@ jest.mock('@expo/vector-icons', () => ({
   MaterialCommunityIcons: 'MaterialCommunityIcons',
 }));
 
+jest.mock('../context/RecipeFormContext', () => ({
+  useRecipeForm: () => ({
+    draft: {},
+    updateDraft: jest.fn(),
+    resetDraft: jest.fn(),
+    saveDraft: jest.fn(),
+  }),
+}));
+
 jest.mock('expo-secure-store', () => ({
   setItemAsync: jest.fn().mockResolvedValue(undefined),
   getItemAsync: jest.fn().mockResolvedValue(null),

--- a/mobile/src/components/create-steps/CreateStepsScreen.tsx
+++ b/mobile/src/components/create-steps/CreateStepsScreen.tsx
@@ -165,6 +165,8 @@ export function CreateStepsScreen() {
           description: s.description,
           timestamp: s.timestamp,
         })),
+        videoUrl: uploadedUrl,
+        videoFileName,
       });
       Alert.alert(t("create.draftSaved"), t("create.draftSavedMsg2"), [
         {


### PR DESCRIPTION
## What does this PR do?

Adds end-to-end persistent draft saving to the recipe creation wizard. Users can save their progress at any step, resume from My Library, and publish without creating duplicates. Also resolves all merge conflicts with main and fixes draft-flow bugs introduced by the allergen detection PR.

**Core feature (original commits):**
- Save Draft button on every create step (Basic Info, Ingredients, Allergens, Steps, Review) — calls `POST /recipes` on first save, `PATCH` on subsequent saves
- My Library Drafts tab: tap a draft to resume with all fields pre-filled
- Publish from Review correctly updates the existing draft instead of creating a duplicate
- Local filter for Published/Drafts/All tabs (no extra network round-trip on tab switch)
- Empty ingredients and steps are stripped before saving

**Merge conflict resolutions:**
- `CreateStack.tsx` — took main's version (RecipeFormProvider scoped to stack + allergens step added)
- `MyLibraryScreen.tsx` — took main's i18n-aware `useCallback` dependency array
- `buildRecipePayload.ts` — separate `tagIds` (dietary) and `allergenIds` per backend schema

**Bug fixes after merge:**
- Remove nested `RecipeFormProvider` from `CreateStack` — `App.tsx` already wraps the app; the duplicate provider caused `MyLibraryScreen.updateDraft()` and wizard screens to use separate context instances, so resumed drafts always appeared empty
- `draftHelpers.mapBackendToDraft` now reads allergens from `recipe.allergens` (top-level field) instead of `recipe.tags` — backend stores them in `allergen_ids` column, not the dietary tags join table
- Fix `ReferenceError: allergenChipOptions` in `CreateBasicInfoScreen.handleSaveDraft` — allergen selection moved to its own step, draft save now reads from context
- Implement `handleSaveDraft` in `CreateAllergensScreen` — was showing an alert only, now calls `saveDraft`, resets context, and navigates to HomeTab
- `CreateStepsScreen.handleSaveDraft` now includes `videoUrl` and `videoFileName`
- CI fixes: add `RecipeFormContext` mock to `ProfileScreen` tests, `expo-av` mock to `CreateScreensDraft` tests

## How to test
1. Fill in Basic Info → press **Save Draft** → confirm it saves and returns to Home.
2. Go to **My Library → Drafts**, tap the draft → verify all fields are pre-filled.
3. Continue through all steps, press **Publish** → verify no duplicate is created.
4. On the Allergens screen, press **Save Draft** → verify it saves and returns to Home.
5. `cd mobile && npm test` — 35 suites, 410 tests, all green.

## Related issue
Closes #429