### PR TITLE
Frontend/feature video guide

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -350,6 +350,9 @@
     "videoAnnotations": {
       "seekAria": "Jump to {{start}}: {{note}}"
     },
+    "videoStepMarkers": {
+      "seekAria": "Jump to step {{n}} ({{start}})"
+    },
     "videoGuide": {
       "title": "Step-by-step video guide",
       "openAria": "Open step-by-step video guide",

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -474,7 +474,9 @@
       "title": "Instructions",
       "stepPlaceholder": "Describe this step...",
       "addStep": "Add Step",
-      "removeAria": "Remove step"
+      "removeAria": "Remove step",
+      "timestampPlaceholder": "MM:SS",
+      "timestampAria": "Video timestamp for step {{n}} (optional, MM:SS)"
     },
     "review": {
       "title": "Review & Publish",

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -349,6 +349,15 @@
     "substituteConfidence": "Confidence: {{pct}}%",
     "videoAnnotations": {
       "seekAria": "Jump to {{start}}: {{note}}"
+    },
+    "videoGuide": {
+      "title": "Step-by-step video guide",
+      "openAria": "Open step-by-step video guide",
+      "closeAria": "Close video guide",
+      "previous": "Previous",
+      "next": "Next",
+      "finish": "Finish",
+      "noVideo": "No video available"
     }
   },
   "dishVariety": {

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -350,6 +350,9 @@
     "videoAnnotations": {
       "seekAria": "{{start}} zamanına git: {{note}}"
     },
+    "videoStepMarkers": {
+      "seekAria": "{{n}}. adıma git ({{start}})"
+    },
     "videoGuide": {
       "title": "Adım adım video rehberi",
       "openAria": "Adım adım video rehberini aç",

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -349,6 +349,15 @@
     "substituteConfidence": "Güven: %{{pct}}",
     "videoAnnotations": {
       "seekAria": "{{start}} zamanına git: {{note}}"
+    },
+    "videoGuide": {
+      "title": "Adım adım video rehberi",
+      "openAria": "Adım adım video rehberini aç",
+      "closeAria": "Video rehberini kapat",
+      "previous": "Önceki",
+      "next": "Sonraki",
+      "finish": "Bitir",
+      "noVideo": "Video bulunmuyor"
     }
   },
   "dishVariety": {

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -474,7 +474,9 @@
       "title": "Talimatlar",
       "stepPlaceholder": "Bu adımı açıklayın...",
       "addStep": "Adım Ekle",
-      "removeAria": "Adımı kaldır"
+      "removeAria": "Adımı kaldır",
+      "timestampPlaceholder": "DD:SS",
+      "timestampAria": "Adım {{n}} için video zaman damgası (opsiyonel, DD:SS)"
     },
     "review": {
       "title": "İncele ve Yayınla",

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.css
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.css
@@ -445,6 +445,46 @@
   flex-shrink: 0;
 }
 
+.cr-step-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  flex: 1;
+  min-width: 0;
+}
+
+.cr-step-ts {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  align-self: flex-start;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.cr-step-ts__icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.cr-step-ts__input {
+  width: 5rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid rgba(134, 69, 42, 0.25);
+  border-radius: var(--radius-sm);
+  background: var(--surface-card);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.cr-step-ts__input:focus {
+  outline: none;
+  border-color: var(--color-main);
+}
+
 /* ── Review step ────────────────────────────────────────────────────────── */
 
 .cr-review-card {

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
@@ -56,7 +56,25 @@ interface IngredientRow {
   unit: string
 }
 
-interface StepItem { text: string }
+interface StepItem { text: string; videoTimestamp: string }
+
+/** Parse a "MM:SS" / "M:SS" / "SS" string into seconds. Empty/invalid → null. */
+function parseStepTimestamp(raw: string): number | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  const parts = trimmed.split(':')
+  if (parts.length === 1) {
+    const s = Number(parts[0])
+    return Number.isFinite(s) && s >= 0 ? Math.floor(s) : null
+  }
+  if (parts.length === 2) {
+    const m = Number(parts[0])
+    const s = Number(parts[1])
+    if (!Number.isFinite(m) || !Number.isFinite(s) || m < 0 || s < 0 || s >= 60) return null
+    return Math.floor(m * 60 + s)
+  }
+  return null
+}
 
 function parseQuantityValue(quantity: string): number | null {
   const q = parseFloat(String(quantity).replace(',', '.'))
@@ -148,7 +166,7 @@ const INITIAL_DRAFT: RecipeDraft = {
   district: '',
   ingredients: [{ ingredientId: null, name: '', searchQuery: '', quantity: '', unit: '' }],
   tools: [''],
-  steps: [{ text: '' }],
+  steps: [{ text: '', videoTimestamp: '' }],
   dietaryTagIds: [],
   allergenIds: [],
   culturalTagIds: [],
@@ -372,10 +390,17 @@ export function CreateRecipePage() {
   const updateStep = (idx: number, value: string) =>
     setDraft((d) => {
       const list = [...d.steps]
-      list[idx] = { text: value }
+      list[idx] = { ...list[idx], text: value }
       return { ...d, steps: list }
     })
-  const addStep = () => setDraft((d) => ({ ...d, steps: [...d.steps, { text: '' }] }))
+  const updateStepTimestamp = (idx: number, value: string) =>
+    setDraft((d) => {
+      const list = [...d.steps]
+      list[idx] = { ...list[idx], videoTimestamp: value }
+      return { ...d, steps: list }
+    })
+  const addStep = () =>
+    setDraft((d) => ({ ...d, steps: [...d.steps, { text: '', videoTimestamp: '' }] }))
   const removeStep = (idx: number) =>
     setDraft((d) => ({ ...d, steps: d.steps.filter((_, i) => i !== idx) }))
 
@@ -430,7 +455,11 @@ export function CreateRecipePage() {
         ingredients: ingredientsPayload,
         steps: draft.steps
           .filter((s) => s.text.trim())
-          .map((s, i) => ({ stepOrder: i + 1, description: s.text.trim() })),
+          .map((s, i) => ({
+            stepOrder: i + 1,
+            description: s.text.trim(),
+            videoTimestamp: parseStepTimestamp(s.videoTimestamp),
+          })),
         tools: draft.tools
           .filter((t) => t.trim())
           .map((t) => ({ name: t.trim() })),
@@ -520,7 +549,7 @@ export function CreateRecipePage() {
       tools: parsed.tools.length > 0 ? parsed.tools : current.tools,
       steps:
         parsed.steps.length > 0
-          ? parsed.steps.map((step) => ({ text: step.description }))
+          ? parsed.steps.map((step) => ({ text: step.description, videoTimestamp: '' }))
           : current.steps,
       ingredients: matchedRows.length > 0 ? matchedRows : current.ingredients,
     }))
@@ -1321,13 +1350,29 @@ export function CreateRecipePage() {
                   <div key={idx} className="cr-step-row">
                     <div className="cr-step-card">
                       <div className="cr-step-card__num">{idx + 1}</div>
-                      <textarea
-                        className="cr-textarea cr-textarea--inline"
-                        value={s.text}
-                        onChange={(e) => updateStep(idx, e.target.value)}
-                        placeholder={t('create.instructions.stepPlaceholder')}
-                        rows={3}
-                      />
+                      <div className="cr-step-card__body">
+                        <textarea
+                          className="cr-textarea cr-textarea--inline"
+                          value={s.text}
+                          onChange={(e) => updateStep(idx, e.target.value)}
+                          placeholder={t('create.instructions.stepPlaceholder')}
+                          rows={3}
+                        />
+                        <label className="cr-step-ts">
+                          <span className="cr-step-ts__icon" aria-hidden>⏱</span>
+                          <input
+                            type="text"
+                            className="cr-step-ts__input"
+                            value={s.videoTimestamp}
+                            onChange={(e) => updateStepTimestamp(idx, e.target.value)}
+                            placeholder={t('create.instructions.timestampPlaceholder')}
+                            inputMode="numeric"
+                            pattern="[0-9:]*"
+                            maxLength={6}
+                            aria-label={t('create.instructions.timestampAria', { n: idx + 1 })}
+                          />
+                        </label>
+                      </div>
                     </div>
                     {draft.steps.length > 1 && (
                       <button

--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
@@ -626,6 +626,17 @@ export function CreateRecipePage() {
       return
     }
     await sendAudioForParsing(file)
+
+    // Video files uploaded for parsing also become recipe media so they appear
+    // on the detail page. Silently skipped if the file isn't an accepted media
+    // type (e.g. mov/mkv) or the media slot cap is full.
+    if (file.type.startsWith('video/') && validateMediaFile(file) === null) {
+      setPendingMediaFiles((list) => {
+        if (list.some((f) => f.name === file.name && f.size === file.size)) return list
+        if (list.length >= MAX_MEDIA_FILES) return list
+        return [...list, file]
+      })
+    }
   }
 
   // Cleanup on unmount: stop any running recorder + tracks

--- a/frontend/src/pages/EditRecipe/EditRecipePage.css
+++ b/frontend/src/pages/EditRecipe/EditRecipePage.css
@@ -249,6 +249,46 @@
 
 .edit-recipe__step-row .edit-recipe__textarea { flex: 1; }
 
+.edit-recipe__step-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  flex: 1;
+  min-width: 0;
+}
+
+.edit-recipe__step-ts {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  align-self: flex-start;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.edit-recipe__step-ts-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.edit-recipe__step-ts-input {
+  width: 5rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid rgba(134, 69, 42, 0.25);
+  border-radius: var(--radius-sm);
+  background: var(--surface-card);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.edit-recipe__step-ts-input:focus {
+  outline: none;
+  border-color: var(--color-main);
+}
+
 /* ── Tools ───────────────────────────────────────────────────────────────────── */
 
 .edit-recipe__tool-list {

--- a/frontend/src/pages/EditRecipe/EditRecipePage.tsx
+++ b/frontend/src/pages/EditRecipe/EditRecipePage.tsx
@@ -17,11 +17,37 @@ interface IngredientRow {
   unit: string
 }
 
-interface StepItem { text: string }
+interface StepItem { text: string; videoTimestamp: string }
 
 function parseQty(v: string): number | null {
   const n = parseFloat(String(v).replace(',', '.'))
   return Number.isFinite(n) && n > 0 ? n : null
+}
+
+/** Parse a "MM:SS" / "M:SS" / "SS" string into seconds. Empty/invalid → null. */
+function parseStepTimestamp(raw: string): number | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  const parts = trimmed.split(':')
+  if (parts.length === 1) {
+    const s = Number(parts[0])
+    return Number.isFinite(s) && s >= 0 ? Math.floor(s) : null
+  }
+  if (parts.length === 2) {
+    const m = Number(parts[0])
+    const s = Number(parts[1])
+    if (!Number.isFinite(m) || !Number.isFinite(s) || m < 0 || s < 0 || s >= 60) return null
+    return Math.floor(m * 60 + s)
+  }
+  return null
+}
+
+/** Format seconds → "MM:SS" string for display in the input. Null/invalid → "". */
+function formatStepTimestamp(seconds: number | null | undefined): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return ''
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
 }
 
 function rowComplete(r: IngredientRow) {
@@ -76,7 +102,7 @@ export function EditRecipePage() {
   const [ingredients, setIngredients] = useState<IngredientRow[]>([
     { ingredientId: null, name: '', searchQuery: '', quantity: '', unit: '' },
   ])
-  const [steps, setSteps] = useState<StepItem[]>([{ text: '' }])
+  const [steps, setSteps] = useState<StepItem[]>([{ text: '', videoTimestamp: '' }])
   const [tools, setTools] = useState<string[]>([''])
 
   // Dropdown data
@@ -130,7 +156,12 @@ export function EditRecipePage() {
 
         // Pre-fill steps
         if (recipe.steps.length > 0) {
-          setSteps(recipe.steps.map((s) => ({ text: s.description })))
+          setSteps(
+            recipe.steps.map((s) => ({
+              text: s.description,
+              videoTimestamp: formatStepTimestamp(s.videoTimestamp),
+            }))
+          )
         }
 
         // Pre-fill tools
@@ -163,7 +194,11 @@ export function EditRecipePage() {
 
     const stepsPayload = steps
       .filter((s) => s.text.trim())
-      .map((s, i) => ({ stepOrder: i + 1, description: s.text.trim() }))
+      .map((s, i) => ({
+        stepOrder: i + 1,
+        description: s.text.trim(),
+        videoTimestamp: parseStepTimestamp(s.videoTimestamp),
+      }))
 
     const toolsPayload = tools
       .filter((t) => t.trim())
@@ -434,17 +469,39 @@ export function EditRecipePage() {
           {steps.map((step, idx) => (
             <div key={idx} className="edit-recipe__step-row">
               <span className="edit-recipe__step-num">{idx + 1}</span>
-              <textarea
-                className="edit-recipe__textarea"
-                value={step.text}
-                onChange={(e) =>
-                  setSteps((prev) =>
-                    prev.map((s, i) => (i === idx ? { text: e.target.value } : s))
-                  )
-                }
-                rows={2}
-                placeholder={t('create.instructions.stepPlaceholder')}
-              />
+              <div className="edit-recipe__step-body">
+                <textarea
+                  className="edit-recipe__textarea"
+                  value={step.text}
+                  onChange={(e) =>
+                    setSteps((prev) =>
+                      prev.map((s, i) => (i === idx ? { ...s, text: e.target.value } : s))
+                    )
+                  }
+                  rows={2}
+                  placeholder={t('create.instructions.stepPlaceholder')}
+                />
+                <label className="edit-recipe__step-ts">
+                  <span className="edit-recipe__step-ts-icon" aria-hidden>⏱</span>
+                  <input
+                    type="text"
+                    className="edit-recipe__step-ts-input"
+                    value={step.videoTimestamp}
+                    onChange={(e) =>
+                      setSteps((prev) =>
+                        prev.map((s, i) =>
+                          i === idx ? { ...s, videoTimestamp: e.target.value } : s
+                        )
+                      )
+                    }
+                    placeholder={t('create.instructions.timestampPlaceholder')}
+                    inputMode="numeric"
+                    pattern="[0-9:]*"
+                    maxLength={6}
+                    aria-label={t('create.instructions.timestampAria', { n: idx + 1 })}
+                  />
+                </label>
+              </div>
               <button
                 type="button"
                 className="edit-recipe__remove-btn"
@@ -460,7 +517,7 @@ export function EditRecipePage() {
         <button
           type="button"
           className="edit-recipe__add-btn"
-          onClick={() => setSteps((prev) => [...prev, { text: '' }])}
+          onClick={() => setSteps((prev) => [...prev, { text: '', videoTimestamp: '' }])}
         >
           <PlusIcon /> {t('create.instructions.addStep')}
         </button>

--- a/frontend/src/pages/RecipeDetail/RecipeDetailPage.css
+++ b/frontend/src/pages/RecipeDetail/RecipeDetailPage.css
@@ -863,6 +863,42 @@
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.4);
 }
 
+/* Step jump markers — sit just above the annotation marker row */
+.rd-video-player__step-markers {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 52px;
+  height: 18px;
+  pointer-events: none;
+}
+
+.rd-video-player__step-marker {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border: 2px solid #fff;
+  border-radius: 9px;
+  background: #1f3a5f;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 14px;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  pointer-events: auto;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.rd-video-player__step-marker:hover {
+  transform: translateX(-50%) scale(1.15);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
+}
+
 .rd-video-player__annotation-list {
   list-style: none;
   margin: 0;

--- a/frontend/src/pages/RecipeDetail/RecipeDetailPage.css
+++ b/frontend/src/pages/RecipeDetail/RecipeDetailPage.css
@@ -923,3 +923,191 @@
 .rd-video-player__annotation-note {
   color: var(--text-primary);
 }
+
+/* ── Cooking-mode (video guide) button ─────────────────────────────────────── */
+
+.recipe-detail__cooking-mode-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  width: 100%;
+  margin-top: var(--space-lg);
+  padding: var(--space-md) var(--space-lg);
+  background: var(--color-main);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.recipe-detail__cooking-mode-btn:hover {
+  background: var(--color-main-dark, var(--color-main));
+  transform: translateY(-1px);
+}
+
+.recipe-detail__cooking-mode-btn:active {
+  transform: translateY(0);
+}
+
+/* ── Video guide modal (mobile-style fullscreen step-by-step) ──────────────── */
+
+.vg-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: #000;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.vg-modal__progress {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+}
+
+.vg-modal__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-pill);
+  color: #fff;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.15s;
+}
+
+.vg-modal__close:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.vg-modal__bar {
+  flex: 1;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.vg-modal__bar-fill {
+  height: 100%;
+  background: var(--color-main);
+  border-radius: 2px;
+  transition: width 0.25s ease;
+}
+
+.vg-modal__counter {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.85);
+  min-width: 3rem;
+  text-align: right;
+}
+
+.vg-modal__stage {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  overflow: hidden;
+}
+
+.vg-modal__video {
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  background: #000;
+}
+
+.vg-modal__placeholder {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 1rem;
+}
+
+.vg-modal__step-info {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: var(--space-lg);
+  padding-bottom: calc(var(--space-lg) + 56px); /* leave room above native controls */
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.85), transparent);
+  pointer-events: none;
+}
+
+.vg-modal__step-num {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  margin-bottom: var(--space-sm);
+  background: var(--color-main);
+  color: #fff;
+  font-weight: 700;
+  border-radius: 50%;
+}
+
+.vg-modal__step-desc {
+  margin: 0;
+  color: #fff;
+  font-size: 1.05rem;
+  line-height: 1.4;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  max-width: 60ch;
+}
+
+.vg-modal__nav {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+}
+
+.vg-modal__nav-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-lg);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.vg-modal__nav-btn--prev {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.vg-modal__nav-btn--prev:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.vg-modal__nav-btn--next {
+  background: var(--color-main);
+}
+
+.vg-modal__nav-btn--next:hover {
+  background: var(--color-main-dark, var(--color-main));
+}
+
+.vg-modal__nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
+++ b/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
@@ -10,6 +10,7 @@ import { RecipeRating } from '@/components/RecipeRating/RecipeRating'
 import { ConfirmModal } from '@/components/ConfirmModal/ConfirmModal'
 import { CommentsSection } from '@/components/Comments/CommentsSection'
 import { VideoPlayerWithAnnotations } from '@/pages/RecipeDetail/VideoPlayerWithAnnotations'
+import { VideoGuideModal } from '@/pages/RecipeDetail/VideoGuideModal'
 import { useAppSelector } from '@/store/hooks'
 import './RecipeDetailPage.css'
 
@@ -87,6 +88,7 @@ export function RecipeDetailPage() {
   const [ratingBusy, setRatingBusy] = useState(false)
   const [ratingError, setRatingError] = useState<string | null>(null)
   const [showRemoveRatingModal, setShowRemoveRatingModal] = useState(false)
+  const [showVideoGuide, setShowVideoGuide] = useState(false)
 
   // Serving scaling
   const [scaledIngredients, setScaledIngredients] = useState<ScaledRecipeIngredient[] | null>(null)
@@ -590,6 +592,19 @@ export function RecipeDetailPage() {
                 />
               ))}
             </div>
+            {recipe.steps.length > 0 && (
+              <button
+                type="button"
+                className="recipe-detail__cooking-mode-btn"
+                onClick={() => setShowVideoGuide(true)}
+                aria-label={t('recipeDetail.videoGuide.openAria')}
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                  <polygon points="5 3 19 12 5 21 5 3" />
+                </svg>
+                <span>{t('recipeDetail.watchVideo')}</span>
+              </button>
+            )}
           </section>
         )}
 
@@ -606,6 +621,14 @@ export function RecipeDetailPage() {
           />
         </section>
       </div>
+
+      {showVideoGuide && uploadedVideos[0] && (
+        <VideoGuideModal
+          videoUrl={uploadedVideos[0].url}
+          steps={recipe.steps}
+          onClose={() => setShowVideoGuide(false)}
+        />
+      )}
 
       <ConfirmModal
         isOpen={showRemoveRatingModal}

--- a/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
+++ b/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
@@ -586,8 +586,10 @@ export function RecipeDetailPage() {
                 <VideoPlayerWithAnnotations
                   key={m.id}
                   src={m.url}
-                  // attach annotations only to the first video — backend ties annotations to recipe, not media item
+                  // attach annotations and step markers only to the first video —
+                  // backend ties both to the recipe, not to a particular media item
                   annotations={idx === 0 ? recipe.videoAnnotations : []}
+                  steps={idx === 0 ? recipe.steps : []}
                   ariaLabel={t('recipeDetail.videoPlayerAria')}
                 />
               ))}

--- a/frontend/src/pages/RecipeDetail/VideoGuideModal.tsx
+++ b/frontend/src/pages/RecipeDetail/VideoGuideModal.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { RecipeStep } from '@/services/recipe-service'
+
+export interface VideoGuideModalProps {
+  videoUrl: string
+  steps: RecipeStep[]
+  onClose: () => void
+}
+
+function IconClose() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  )
+}
+
+function IconChevronLeft() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <polyline points="15 18 9 12 15 6" />
+    </svg>
+  )
+}
+
+function IconChevronRight() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  )
+}
+
+export function VideoGuideModal({ videoUrl, steps, onClose }: VideoGuideModalProps) {
+  const { t } = useTranslation('common')
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const videoRef = useRef<HTMLVideoElement>(null)
+
+  const totalSteps = steps.length
+  const currentStep = steps[currentIndex]
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+      else if (e.key === 'ArrowRight') goNext()
+      else if (e.key === 'ArrowLeft') goPrevious()
+    }
+    window.addEventListener('keydown', handleKey)
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = prev
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex, totalSteps])
+
+  // Seek the video to the per-step timestamp whenever the step changes.
+  useEffect(() => {
+    const v = videoRef.current
+    if (!v || !currentStep) return
+    const ts = currentStep.videoTimestamp
+    if (typeof ts === 'number' && Number.isFinite(ts) && ts >= 0) {
+      const apply = () => {
+        try {
+          v.currentTime = ts
+          void v.play()
+        } catch {
+          /* user-gesture restriction; ignore */
+        }
+      }
+      if (v.readyState >= 1) apply()
+      else v.addEventListener('loadedmetadata', apply, { once: true })
+    }
+  }, [currentStep])
+
+  function goNext() {
+    if (currentIndex < totalSteps - 1) setCurrentIndex((i) => i + 1)
+    else onClose()
+  }
+
+  function goPrevious() {
+    if (currentIndex > 0) setCurrentIndex((i) => i - 1)
+  }
+
+  const isFirst = currentIndex === 0
+  const isLast = currentIndex === totalSteps - 1
+  const progressPct = totalSteps > 0 ? ((currentIndex + 1) / totalSteps) * 100 : 0
+
+  return (
+    <div
+      className="vg-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('recipeDetail.videoGuide.title')}
+    >
+      <div className="vg-modal__progress">
+        <button
+          type="button"
+          className="vg-modal__close"
+          onClick={onClose}
+          aria-label={t('recipeDetail.videoGuide.closeAria')}
+        >
+          <IconClose />
+        </button>
+        <div className="vg-modal__bar">
+          <div className="vg-modal__bar-fill" style={{ width: `${progressPct}%` }} />
+        </div>
+        <span className="vg-modal__counter">
+          {currentIndex + 1}/{totalSteps}
+        </span>
+      </div>
+
+      <div className="vg-modal__stage">
+        {videoUrl ? (
+          <video
+            ref={videoRef}
+            className="vg-modal__video"
+            src={videoUrl}
+            controls
+            playsInline
+            preload="metadata"
+            aria-label={t('recipeDetail.videoPlayerAria')}
+          />
+        ) : (
+          <div className="vg-modal__placeholder">
+            {t('recipeDetail.videoGuide.noVideo')}
+          </div>
+        )}
+
+        {currentStep && (
+          <div className="vg-modal__step-info">
+            <div className="vg-modal__step-num">{currentStep.stepOrder}</div>
+            <p className="vg-modal__step-desc">{currentStep.description}</p>
+          </div>
+        )}
+      </div>
+
+      <div className="vg-modal__nav">
+        <button
+          type="button"
+          className="vg-modal__nav-btn vg-modal__nav-btn--prev"
+          onClick={goPrevious}
+          disabled={isFirst}
+        >
+          <IconChevronLeft />
+          <span>{t('recipeDetail.videoGuide.previous')}</span>
+        </button>
+        <button
+          type="button"
+          className="vg-modal__nav-btn vg-modal__nav-btn--next"
+          onClick={goNext}
+        >
+          <span>
+            {isLast ? t('recipeDetail.videoGuide.finish') : t('recipeDetail.videoGuide.next')}
+          </span>
+          <IconChevronRight />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/RecipeDetail/VideoPlayerWithAnnotations.tsx
+++ b/frontend/src/pages/RecipeDetail/VideoPlayerWithAnnotations.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { VideoAnnotation } from '@/services/recipe-service'
+import type { RecipeStep, VideoAnnotation } from '@/services/recipe-service'
 
 export interface VideoPlayerWithAnnotationsProps {
   src: string
   annotations: VideoAnnotation[]
   ariaLabel: string
+  /** Recipe steps. Steps with a non-null videoTimestamp render as numbered jump markers on the timeline. */
+  steps?: RecipeStep[]
 }
 
 function formatTime(seconds: number): string {
@@ -19,6 +21,7 @@ export function VideoPlayerWithAnnotations({
   src,
   annotations,
   ariaLabel,
+  steps = [],
 }: VideoPlayerWithAnnotationsProps) {
   const { t } = useTranslation('common')
   const videoRef = useRef<HTMLVideoElement>(null)
@@ -50,6 +53,9 @@ export function VideoPlayerWithAnnotations({
   }, [src])
 
   const sortedAnnotations = [...annotations].sort((a, b) => a.startTime - b.startTime)
+  const stepMarkers = steps
+    .filter((s): s is RecipeStep & { videoTimestamp: number } => typeof s.videoTimestamp === 'number' && s.videoTimestamp >= 0)
+    .sort((a, b) => a.videoTimestamp - b.videoTimestamp)
 
   return (
     <div className="rd-video-player">
@@ -82,6 +88,32 @@ export function VideoPlayerWithAnnotations({
                   title={`${formatTime(a.startTime)} — ${a.note}`}
                   aria-label={`${formatTime(a.startTime)} ${a.note}`}
                 />
+              )
+            })}
+          </div>
+        )}
+        {duration > 0 && stepMarkers.length > 0 && (
+          <div className="rd-video-player__step-markers">
+            {stepMarkers.map((s) => {
+              const left = Math.max(0, Math.min(100, (s.videoTimestamp / duration) * 100))
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  className="rd-video-player__step-marker"
+                  style={{ left: `${left}%` }}
+                  onClick={() => seekTo(s.videoTimestamp)}
+                  title={t('recipeDetail.videoStepMarkers.seekAria', {
+                    n: s.stepOrder,
+                    start: formatTime(s.videoTimestamp),
+                  })}
+                  aria-label={t('recipeDetail.videoStepMarkers.seekAria', {
+                    n: s.stepOrder,
+                    start: formatTime(s.videoTimestamp),
+                  })}
+                >
+                  {s.stepOrder}
+                </button>
               )
             })}
           </div>

--- a/frontend/src/services/recipe-service.ts
+++ b/frontend/src/services/recipe-service.ts
@@ -25,6 +25,7 @@ export interface RecipeStep {
   id: string
   stepOrder: number
   description: string
+  videoTimestamp: number | null
 }
 
 export interface RecipeTool {
@@ -190,6 +191,7 @@ export const recipeService = {
         id: String(s.id),
         stepOrder: s.stepOrder,
         description: s.description,
+        videoTimestamp: typeof s.videoTimestamp === 'number' ? s.videoTimestamp : null,
       })),
       tools: (d.tools ?? []).map((t: any) => ({
         id: String(t.id),

--- a/frontend/src/services/recipe-service.ts
+++ b/frontend/src/services/recipe-service.ts
@@ -89,7 +89,7 @@ export interface UpdateRecipePayload {
   city?: string
   district?: string
   ingredients?: CreateRecipeIngredient[]
-  steps?: { stepOrder: number; description: string }[]
+  steps?: { stepOrder: number; description: string; videoTimestamp?: number | null }[]
   tools?: { name: string }[]
   /** Cultural tag IDs from GET /cultural-tags (cultural recipes only). */
   culturalTagIds?: number[]
@@ -109,8 +109,8 @@ export interface CreateRecipePayload {
   servingSize?: number
   /** Backend: recipe_ingredients rows with FK to ingredients.id */
   ingredients?: CreateRecipeIngredient[]
-  /** Backend requires {stepOrder, description}[]; sent directly. */
-  steps: { stepOrder: number; description: string }[]
+  /** Backend requires {stepOrder, description}[]; sent directly. videoTimestamp is optional seconds-into-video. */
+  steps: { stepOrder: number; description: string; videoTimestamp?: number | null }[]
   /** Backend requires {name}[]. */
   tools: { name: string }[]
   /**

--- a/frontend/src/test/mocks/data.ts
+++ b/frontend/src/test/mocks/data.ts
@@ -65,8 +65,8 @@ export const mockRecipeDetail = {
     { id: '3', ingredientId: '12', ingredientName: 'Butter', quantity: 30, unit: 'g', allergens: ['Dairy'] },
   ],
   steps: [
-    { id: '1', stepOrder: 1, description: 'Wash and drain the lentils.' },
-    { id: '2', stepOrder: 2, description: 'Saute onion in butter until translucent.' },
+    { id: '1', stepOrder: 1, description: 'Wash and drain the lentils.', videoTimestamp: null },
+    { id: '2', stepOrder: 2, description: 'Saute onion in butter until translucent.', videoTimestamp: null },
   ],
   tools: [{ id: '1', name: 'Large pot' }],
   media: [{ id: '1', url: '/img/soup.jpg', type: 'image' }],


### PR DESCRIPTION
## What does this PR do?

Lands the web side of the per-step video timestamp story end-to-end and
adds a mobile-style fullscreen cooking-mode guide. Three threads:

### 1. Fullscreen Video Guide modal (mobile parity)
Ports the mobile `VideoGuideScreen` to web. A "Watch video" button under
the uploaded-videos block opens a fullscreen modal that walks through
the recipe's ordered steps, seeking the recipe video to each step's
`videoTimestamp` and overlaying a numbered badge + description. Esc /
arrow-key navigation, body-scroll lock. Existing recipe-level
`VideoPlayerWithAnnotations` is unchanged.

### 2. Per-step `videoTimestamp` — round-trip
Wires the field that the backend has already been persisting (#186, #422)
through the entire web stack:
- `RecipeStep` type + service mapper expose it on `GET /recipes/:id`
- `CreateRecipePayload` / `UpdateRecipePayload` step items accept it
- Minimalist ⏱ MM:SS input on each step row in **create** and **edit**
  wizards, with parser + payload wiring (M:SS or bare seconds → integer
  seconds, empty → null)
- Numbered jump markers on the inline video timeline on the detail page
  — click to seek without opening the modal

### 3. Auto-attach parsed video as recipe media
When a video file is uploaded to `/parse/recipe-audio` for transcription,
the same file is also queued in `pendingMediaFiles` so it gets attached
as recipe media after creation and surfaces on the detail page. Skips
non-mp4 videos the media uploader cannot accept, dedupes by name+size,
respects `MAX_MEDIA_FILES`.

## How to test

1. Create a recipe, upload an mp4 (either via parse-audio or via the
   "Photos & video" picker). Set `00:30` and `01:15` MM:SS values on a
   couple of steps. Save & publish.
2. Open the recipe detail page.
   - The inline video player should show small numbered chips on the
     timeline at 0:30 and 1:15 — clicking one seeks the video.
   - "Watch video" opens the fullscreen guide; Previous / Next (or ←/→)
     walks through the steps and the video seeks to each timestamp;
     Esc closes.
3. Open the recipe in the edit page — the MM:SS inputs should be
   pre-filled. Change one and save; reload the detail page to confirm.
4. Toggle EN ↔ TR — every new string is localized.

## Related issues

Closes #161
Refs #114, #392, #414
