### PR TITLE
feat(frontend/discovery): add available ingredients filter (#173)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -263,6 +263,12 @@
     "dietaryTags": "Dietary Preferences",
     "selectDietaryTags": "Select dietary preferences",
     "culturalTags": "Cultural Tags",
+    "availableIngredients": {
+      "label": "Available Ingredients",
+      "hint": "Only show recipes you can make with these ingredients.",
+      "placeholder": "Add an ingredient…",
+      "remove": "Remove {{name}}"
+    },
     "clearFilters": "Clear all filters",
     "noRegionSelected": "All regions",
     "noAllergenSelected": "None",

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -263,6 +263,12 @@
     "dietaryTags": "Beslenme Tercihleri",
     "selectDietaryTags": "Beslenme tercihlerini seçin",
     "culturalTags": "Kültürel Etiketler",
+    "availableIngredients": {
+      "label": "Elimdeki Malzemeler",
+      "hint": "Sadece bu malzemelerle yapabileceğiniz tarifleri gösterir.",
+      "placeholder": "Malzeme ekle…",
+      "remove": "{{name}} kaldır"
+    },
     "clearFilters": "Tüm filtreleri temizle",
     "noRegionSelected": "Tüm bölgeler",
     "noAllergenSelected": "Hiçbiri",

--- a/frontend/src/pages/Discovery/DiscoveryPage.css
+++ b/frontend/src/pages/Discovery/DiscoveryPage.css
@@ -468,6 +468,118 @@
   color: #fff;
 }
 
+.discovery-page__filter-group-hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.discovery-page__ing-input {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.discovery-page__ing-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.discovery-page__ing-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem 0.3rem 0.8rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-main);
+  color: #fff;
+  font-size: 0.8125rem;
+}
+
+.discovery-page__ing-chip-remove {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  border-radius: 50%;
+}
+
+.discovery-page__ing-chip-remove:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.discovery-page__ing-search {
+  position: relative;
+}
+
+.discovery-page__ing-search-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-neutral-darker);
+  background: var(--surface-bg);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.875rem;
+}
+
+.discovery-page__ing-search-input:focus {
+  outline: none;
+  border-color: var(--color-main);
+}
+
+.discovery-page__ing-options {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin: 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  background: var(--surface-bg);
+  border: 1px solid var(--color-neutral-darker);
+  border-radius: var(--radius-sm);
+  max-height: 240px;
+  overflow-y: auto;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+}
+
+.discovery-page__ing-option {
+  padding: 0;
+}
+
+.discovery-page__ing-option--muted {
+  padding: 0.5rem 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+}
+
+.discovery-page__ing-option-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: 0;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.discovery-page__ing-option-btn:hover,
+.discovery-page__ing-option-btn:focus {
+  background: var(--surface-overlay);
+  outline: none;
+}
+
 .discovery-page__filter-location {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/frontend/src/pages/Discovery/DiscoveryPage.tsx
+++ b/frontend/src/pages/Discovery/DiscoveryPage.tsx
@@ -18,6 +18,8 @@ import {
   culturalTagLabel,
   type CulturalTag,
 } from '@/services/cultural-tag-service'
+import { type IngredientOption } from '@/services/ingredient-service'
+import { AvailableIngredientsInput } from './Parts/AvailableIngredientsInput'
 import './DiscoveryPage.css'
 
 const SEARCH_DEBOUNCE_MS = 300
@@ -60,6 +62,11 @@ export function DiscoveryPage() {
   const [locationOptions, setLocationOptions] = useState<LocationOptions>({ countries: [], citiesByCountry: {} })
   const [culturalTags, setCulturalTags] = useState<CulturalTag[]>([])
   const [selectedCulturalTagIds, setSelectedCulturalTagIds] = useState<number[]>([])
+  /** "Available ingredients" filter — when non-empty, recipes are fetched via
+   * `/discovery/recipes/by-ingredients` instead of `/discovery/recipes`. Other
+   * filters (origin/tags/allergens/search) are not honored by that endpoint,
+   * so the UI hides those groups while this filter is active. */
+  const [availableIngredients, setAvailableIngredients] = useState<IngredientOption[]>([])
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
@@ -125,32 +132,44 @@ export function DiscoveryPage() {
   /** Arama metni veya filtreler değişince sayfa 1'e dönsün. */
   useLayoutEffect(() => {
     setRecipePage(1)
-  }, [debouncedSearch, selectedTagIds, excludedAllergenIds, selectedCountry, selectedCity, selectedCulturalTagIds])
+  }, [debouncedSearch, selectedTagIds, excludedAllergenIds, selectedCountry, selectedCity, selectedCulturalTagIds, availableIngredients])
 
   const recipeSearchQuery = debouncedSearch.trim() || undefined
+  const availableIngredientIds = availableIngredients.map((ing) => ing.id)
+  const useByIngredientsEndpoint = availableIngredientIds.length > 0
 
   useEffect(() => {
     let cancelled = false
     setRecipeLoading(true)
 
-    discoveryService
-      .getRecipeResults({
-        genreId: selectedGenreId ?? undefined,
-        search: recipeSearchQuery,
-        tagIds: selectedTagIds.length > 0 ? selectedTagIds.join(',') : undefined,
-        culturalTagIds: selectedCulturalTagIds.length > 0 ? selectedCulturalTagIds.join(',') : undefined,
-        excludeAllergens: excludedAllergenIds.length > 0 ? excludedAllergenIds.join(',') : undefined,
-        country: selectedCountry || undefined,
-        city: selectedCity || undefined,
-        page: recipePage,
-        limit: RECIPES_PER_PAGE,
-      })
+    const fetcher = useByIngredientsEndpoint
+      ? discoveryService.getByIngredients(availableIngredientIds, recipePage, RECIPES_PER_PAGE)
+      : discoveryService.getRecipeResults({
+          genreId: selectedGenreId ?? undefined,
+          search: recipeSearchQuery,
+          tagIds: selectedTagIds.length > 0 ? selectedTagIds.join(',') : undefined,
+          culturalTagIds: selectedCulturalTagIds.length > 0 ? selectedCulturalTagIds.join(',') : undefined,
+          excludeAllergens: excludedAllergenIds.length > 0 ? excludedAllergenIds.join(',') : undefined,
+          country: selectedCountry || undefined,
+          city: selectedCity || undefined,
+          page: recipePage,
+          limit: RECIPES_PER_PAGE,
+        })
+
+    fetcher
       .then(({ recipes: recipeData, pagination, cascadeGenres, cascadeVarieties }) => {
         if (!cancelled) {
           setRecipes(recipeData)
           setRecipeTotal(pagination.total)
-          setCascadeGenreIds(new Set(cascadeGenres.map((g) => g.id)))
-          setCascadeVarietyIds(new Set(cascadeVarieties.map((v) => v.id)))
+          // The by-ingredients endpoint does not return cascade arrays, so
+          // disable cascade narrowing while it's the active source.
+          if (useByIngredientsEndpoint) {
+            setCascadeGenreIds(null)
+            setCascadeVarietyIds(null)
+          } else {
+            setCascadeGenreIds(new Set(cascadeGenres.map((g) => g.id)))
+            setCascadeVarietyIds(new Set(cascadeVarieties.map((v) => v.id)))
+          }
         }
       })
       .catch(() => {
@@ -168,7 +187,8 @@ export function DiscoveryPage() {
     return () => {
       cancelled = true
     }
-  }, [selectedGenreId, recipePage, recipeSearchQuery, selectedTagIds, selectedCulturalTagIds, excludedAllergenIds, selectedCountry, selectedCity])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedGenreId, recipePage, recipeSearchQuery, selectedTagIds, selectedCulturalTagIds, excludedAllergenIds, selectedCountry, selectedCity, useByIngredientsEndpoint, availableIngredientIds.join(',')])
 
   const normalizedSearch = debouncedSearch.trim().toLowerCase()
 
@@ -238,7 +258,8 @@ export function DiscoveryPage() {
     selectedCulturalTagIds.length +
     excludedAllergenIds.length +
     (selectedCountry ? 1 : 0) +
-    (selectedCity ? 1 : 0)
+    (selectedCity ? 1 : 0) +
+    availableIngredients.length
 
   const hasAnyFilters =
     selectedGenreId !== null ||
@@ -268,6 +289,7 @@ export function DiscoveryPage() {
     setExcludedAllergenIds([])
     setSelectedCountry('')
     setSelectedCity('')
+    setAvailableIngredients([])
     setRecipePage(1)
   }
 
@@ -334,6 +356,18 @@ export function DiscoveryPage() {
 
       {filtersOpen && (
         <div className="discovery-page__filter-panel" data-testid="filter-panel">
+          <div className="discovery-page__filter-group">
+            <p className="discovery-page__filter-group-label">
+              {t('discovery.availableIngredients.label')}
+            </p>
+            <p className="discovery-page__filter-group-hint">
+              {t('discovery.availableIngredients.hint')}
+            </p>
+            <AvailableIngredientsInput
+              selected={availableIngredients}
+              onChange={setAvailableIngredients}
+            />
+          </div>
           <div className="discovery-page__filter-group">
             <p className="discovery-page__filter-group-label">{t('discovery.location')}</p>
             <div className="discovery-page__filter-location">
@@ -435,6 +469,7 @@ export function DiscoveryPage() {
                 setExcludedAllergenIds([])
                 setSelectedCountry('')
                 setSelectedCity('')
+                setAvailableIngredients([])
               }}
             >
               {t('discovery.clearFilters')}

--- a/frontend/src/pages/Discovery/Parts/AvailableIngredientsInput.tsx
+++ b/frontend/src/pages/Discovery/Parts/AvailableIngredientsInput.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ingredientService, type IngredientOption } from '@/services/ingredient-service'
+
+const SEARCH_DEBOUNCE_MS = 250
+const MIN_SEARCH_LEN = 1
+
+export interface AvailableIngredientsInputProps {
+  selected: IngredientOption[]
+  onChange: (next: IngredientOption[]) => void
+}
+
+/**
+ * Compact multi-select autocomplete for the Discovery filter panel.
+ *
+ * Powers the "available ingredients" filter (`GET /discovery/recipes/by-ingredients`):
+ * picks ingredients from `/ingredients?search=`, renders them as removable chips.
+ */
+export function AvailableIngredientsInput({ selected, onChange }: AvailableIngredientsInputProps) {
+  const { t } = useTranslation('common')
+  const baseId = useId()
+  const listId = `${baseId}-list`
+  const containerRef = useRef<HTMLDivElement>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const [query, setQuery] = useState('')
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [options, setOptions] = useState<IngredientOption[]>([])
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    const trimmed = query.trim()
+    if (trimmed.length < MIN_SEARCH_LEN) {
+      setOptions([])
+      return
+    }
+    debounceRef.current = setTimeout(() => {
+      setLoading(true)
+      ingredientService
+        .search(trimmed)
+        .then((results) => {
+          const selectedIds = new Set(selected.map((s) => s.id))
+          setOptions(results.filter((r) => !selectedIds.has(r.id)))
+        })
+        .catch(() => setOptions([]))
+        .finally(() => setLoading(false))
+    }, SEARCH_DEBOUNCE_MS)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [query, selected])
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  function handleSelect(option: IngredientOption) {
+    onChange([...selected, option])
+    setQuery('')
+    setOptions([])
+  }
+
+  function handleRemove(id: number) {
+    onChange(selected.filter((s) => s.id !== id))
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="discovery-page__ing-input"
+      data-testid="available-ingredients-input"
+    >
+      {selected.length > 0 && (
+        <div className="discovery-page__ing-chips">
+          {selected.map((ing) => (
+            <span key={ing.id} className="discovery-page__ing-chip">
+              {ing.name}
+              <button
+                type="button"
+                className="discovery-page__ing-chip-remove"
+                aria-label={t('discovery.availableIngredients.remove', { name: ing.name })}
+                onClick={() => handleRemove(ing.id)}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="discovery-page__ing-search">
+        <input
+          type="text"
+          className="discovery-page__ing-search-input"
+          value={query}
+          placeholder={t('discovery.availableIngredients.placeholder')}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          aria-controls={listId}
+          aria-expanded={open && options.length > 0}
+        />
+        {open && (loading || options.length > 0) && (
+          <ul id={listId} className="discovery-page__ing-options" role="listbox">
+            {loading && (
+              <li className="discovery-page__ing-option discovery-page__ing-option--muted">
+                {t('common.loading')}
+              </li>
+            )}
+            {!loading &&
+              options.map((option) => (
+                <li
+                  key={option.id}
+                  className="discovery-page__ing-option"
+                  role="option"
+                  aria-selected="false"
+                >
+                  <button
+                    type="button"
+                    className="discovery-page__ing-option-btn"
+                    onClick={() => handleSelect(option)}
+                  >
+                    {option.name}
+                  </button>
+                </li>
+              ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/discovery-service.ts
+++ b/frontend/src/services/discovery-service.ts
@@ -197,6 +197,42 @@ export const discoveryService = {
     return raw.map(normalizeTag)
   },
 
+  /**
+   * GET /discovery/recipes/by-ingredients — recipes whose every ingredient is
+   * in the provided list (partial matches excluded). Backend returns the same
+   * envelope shape as /discovery/recipes (`{ recipes, pagination }`) but
+   * without cascade arrays — we leave those empty.
+   */
+  getByIngredients: async (
+    ingredientIds: number[],
+    page?: number,
+    limit?: number,
+  ): Promise<DiscoveryRecipeResults> => {
+    const params: Record<string, string | number> = {
+      ingredientIds: ingredientIds.join(','),
+    }
+    if (page) params.page = page
+    if (limit) params.limit = limit
+    const res = await httpClient.get('/discovery/recipes/by-ingredients', { params })
+    const payload = res.data?.data
+    const rawRecipes: unknown[] = Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload?.recipes)
+        ? payload.recipes
+        : []
+    const pagination = payload?.pagination ?? {}
+    return {
+      recipes: rawRecipes.map(normalizeRecipe),
+      pagination: {
+        page: Number(pagination.page ?? page ?? 1),
+        limit: Number(pagination.limit ?? limit ?? 20),
+        total: Number(pagination.total ?? rawRecipes.length),
+      },
+      cascadeGenres: [],
+      cascadeVarieties: [],
+    }
+  },
+
   getRecipeResults: async (params?: DiscoveryParams): Promise<DiscoveryRecipeResults> => {
     const res = await httpClient.get('/discovery/recipes', { params })
     const payload = res.data?.data


### PR DESCRIPTION
Adds a multi-select autocomplete to the Discovery filter panel that lets users pick ingredients they have on hand. When at least one is selected the recipe list switches to GET /discovery/recipes/by-ingredients, returning only recipes whose every ingredient is in the selection (cascade narrowing is disabled while this filter is active because the endpoint does not return cascade arrays).