### PR TITLE
eat(frontend/profile): add profile edit form (#558)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -150,6 +150,33 @@
     "deleteConfirm": "Delete",
     "deleteCancel": "Cancel"
   },
+  "profileEdit": {
+    "openButton": "Edit profile",
+    "title": "Edit profile",
+    "hint": "Leave a field empty to keep its current value.",
+    "usernameLabel": "Username",
+    "usernameInvalid": "Only letters, numbers, and underscores are allowed.",
+    "usernameLength": "Username must be 3–30 characters.",
+    "usernameTaken": "This username is already taken.",
+    "bioLabel": "Bio",
+    "bioLength": "Bio must be at most 500 characters.",
+    "regionLabel": "Region",
+    "regionPlaceholder": "e.g. Istanbul, Turkey",
+    "languageLabel": "Preferred language",
+    "languageNone": "Not set",
+    "languages": {
+      "en": "English",
+      "tr": "Türkçe"
+    },
+    "changeAvatar": "Change photo",
+    "removeAvatar": "Remove photo",
+    "avatarTypeError": "Please choose an image file.",
+    "avatarSizeError": "Image must be 10 MB or smaller.",
+    "avatarUploadError": "Could not upload the image. Please try again.",
+    "save": "Save",
+    "cancel": "Cancel",
+    "genericError": "Could not update profile. Please try again."
+  },
   "profileScreen": {
     "title": "Profile",
     "loading": "Loading profile…",

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -150,6 +150,33 @@
     "deleteConfirm": "Sil",
     "deleteCancel": "Vazgeç"
   },
+  "profileEdit": {
+    "openButton": "Profili düzenle",
+    "title": "Profili düzenle",
+    "hint": "Bir alanı boş bırakırsanız mevcut değeri korunur.",
+    "usernameLabel": "Kullanıcı adı",
+    "usernameInvalid": "Yalnızca harf, rakam ve alt çizgi kullanabilirsiniz.",
+    "usernameLength": "Kullanıcı adı 3–30 karakter olmalıdır.",
+    "usernameTaken": "Bu kullanıcı adı zaten kullanımda.",
+    "bioLabel": "Hakkımda",
+    "bioLength": "Hakkımda alanı en fazla 500 karakter olmalı.",
+    "regionLabel": "Bölge",
+    "regionPlaceholder": "ör. İstanbul, Türkiye",
+    "languageLabel": "Tercih edilen dil",
+    "languageNone": "Belirtilmedi",
+    "languages": {
+      "en": "English",
+      "tr": "Türkçe"
+    },
+    "changeAvatar": "Fotoğrafı değiştir",
+    "removeAvatar": "Fotoğrafı kaldır",
+    "avatarTypeError": "Lütfen bir görsel dosyası seçin.",
+    "avatarSizeError": "Görsel 10 MB veya daha küçük olmalı.",
+    "avatarUploadError": "Görsel yüklenemedi. Lütfen tekrar deneyin.",
+    "save": "Kaydet",
+    "cancel": "İptal",
+    "genericError": "Profil güncellenemedi. Lütfen tekrar deneyin."
+  },
   "profileScreen": {
     "title": "Profil",
     "loading": "Profil yükleniyor…",

--- a/frontend/src/pages/Profile/ProfileEditForm.tsx
+++ b/frontend/src/pages/Profile/ProfileEditForm.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAppDispatch, useAppSelector } from '@/store/hooks'
+import { updateProfileAsync } from '@/store/slices/profile-slice'
+import { mediaService } from '@/services/media-service'
+import type { ProfileUpdatePayload } from '@/services/profile-service'
+
+interface Props {
+  onClose: () => void
+}
+
+const LANGUAGES = ['en', 'tr'] as const
+type SupportedLanguage = (typeof LANGUAGES)[number]
+
+interface FormState {
+  username: string
+  bio: string
+  region: string
+  preferredLanguage: '' | SupportedLanguage
+  avatarUrl: string
+}
+
+/**
+ * Inline profile editor. Backend `GET /auth/me` does not return bio / avatar
+ * / region / preferred_language, so fields are pre-filled from any values
+ * already in the profile slice (populated by previous PATCH responses in
+ * this session). A hint near the title explains that blank fields are left
+ * unchanged.
+ */
+export function ProfileEditForm({ onClose }: Props) {
+  const { t } = useTranslation('common')
+  const dispatch = useAppDispatch()
+  const profile = useAppSelector((s) => s.profile)
+  const formId = useId()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [form, setForm] = useState<FormState>({
+    username: profile.username ?? '',
+    bio: profile.bio ?? '',
+    region: profile.region ?? '',
+    preferredLanguage: (profile.preferredLanguage as SupportedLanguage | null) ?? '',
+    avatarUrl: profile.avatarUrl ?? '',
+  })
+  const [saving, setSaving] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [fieldError, setFieldError] = useState<{ field: string; message: string } | null>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !saving && !uploading) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose, saving, uploading])
+
+  function buildPayload(): ProfileUpdatePayload {
+    const out: ProfileUpdatePayload = {}
+    const username = form.username.trim()
+    if (username && username !== (profile.username ?? '')) {
+      out.username = username
+    }
+    if (form.bio !== (profile.bio ?? '')) {
+      out.bio = form.bio
+    }
+    if (form.region !== (profile.region ?? '')) {
+      out.region = form.region
+    }
+    const lang = form.preferredLanguage
+    if (lang !== (profile.preferredLanguage ?? '')) {
+      out.preferredLanguage = lang
+    }
+    if (form.avatarUrl && form.avatarUrl !== (profile.avatarUrl ?? '')) {
+      out.avatarUrl = form.avatarUrl
+    }
+    return out
+  }
+
+  async function handleAvatarPick(file: File) {
+    setUploadError(null)
+    if (!file.type.startsWith('image/')) {
+      setUploadError(t('profileEdit.avatarTypeError'))
+      return
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      setUploadError(t('profileEdit.avatarSizeError'))
+      return
+    }
+    setUploading(true)
+    try {
+      const result = await mediaService.uploadFile(file)
+      setForm((f) => ({ ...f, avatarUrl: result.url }))
+    } catch {
+      setUploadError(t('profileEdit.avatarUploadError'))
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setFieldError(null)
+
+    const username = form.username.trim()
+    if (username && !/^[a-zA-Z0-9_]+$/.test(username)) {
+      setFieldError({ field: 'username', message: t('profileEdit.usernameInvalid') })
+      return
+    }
+    if (username && (username.length < 3 || username.length > 30)) {
+      setFieldError({ field: 'username', message: t('profileEdit.usernameLength') })
+      return
+    }
+    if (form.bio.length > 500) {
+      setFieldError({ field: 'bio', message: t('profileEdit.bioLength') })
+      return
+    }
+
+    const payload = buildPayload()
+    if (Object.keys(payload).length === 0) {
+      onClose()
+      return
+    }
+
+    setSaving(true)
+    const result = await dispatch(updateProfileAsync(payload))
+    setSaving(false)
+
+    if (updateProfileAsync.fulfilled.match(result)) {
+      onClose()
+      return
+    }
+    const rejected = result.payload as { code?: string; message: string } | undefined
+    if (rejected?.code === 'CONFLICT') {
+      setFieldError({ field: 'username', message: t('profileEdit.usernameTaken') })
+    } else {
+      setError(rejected?.message ?? t('profileEdit.genericError'))
+    }
+  }
+
+  const initials = form.username
+    ? form.username.slice(0, 2).toUpperCase()
+    : (profile.username ?? '??').slice(0, 2).toUpperCase()
+
+  return (
+    <form
+      id={formId}
+      className="profile-edit"
+      onSubmit={handleSubmit}
+      aria-busy={saving || uploading}
+    >
+      <div className="profile-edit__header">
+        <h2 className="profile-edit__title">{t('profileEdit.title')}</h2>
+        <p className="profile-edit__hint">{t('profileEdit.hint')}</p>
+      </div>
+
+      <div className="profile-edit__avatar-row">
+        <div className="profile-edit__avatar-preview">
+          {form.avatarUrl ? (
+            <img src={form.avatarUrl} alt="" />
+          ) : (
+            <span>{initials}</span>
+          )}
+        </div>
+        <div className="profile-edit__avatar-controls">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="profile-edit__avatar-input"
+            onChange={(e) => {
+              const f = e.target.files?.[0]
+              if (f) void handleAvatarPick(f)
+              e.target.value = ''
+            }}
+          />
+          <button
+            type="button"
+            className="profile-edit__btn profile-edit__btn--ghost"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading || saving}
+          >
+            {uploading
+              ? <span className="ui-spinner" aria-hidden />
+              : t('profileEdit.changeAvatar')}
+          </button>
+          {form.avatarUrl && (
+            <button
+              type="button"
+              className="profile-edit__btn profile-edit__btn--link"
+              onClick={() => setForm((f) => ({ ...f, avatarUrl: '' }))}
+              disabled={uploading || saving}
+            >
+              {t('profileEdit.removeAvatar')}
+            </button>
+          )}
+          {uploadError && <p className="profile-edit__error">{uploadError}</p>}
+        </div>
+      </div>
+
+      <label className="profile-edit__field">
+        <span className="profile-edit__label">{t('profileEdit.usernameLabel')}</span>
+        <input
+          type="text"
+          className="profile-edit__input"
+          value={form.username}
+          onChange={(e) => setForm((f) => ({ ...f, username: e.target.value }))}
+          maxLength={30}
+          disabled={saving}
+          autoComplete="username"
+        />
+        {fieldError?.field === 'username' && (
+          <span className="profile-edit__error">{fieldError.message}</span>
+        )}
+      </label>
+
+      <label className="profile-edit__field">
+        <span className="profile-edit__label">{t('profileEdit.bioLabel')}</span>
+        <textarea
+          className="profile-edit__textarea"
+          value={form.bio}
+          onChange={(e) => setForm((f) => ({ ...f, bio: e.target.value }))}
+          maxLength={500}
+          rows={3}
+          disabled={saving}
+        />
+        <span className="profile-edit__hint-line">{form.bio.length}/500</span>
+        {fieldError?.field === 'bio' && (
+          <span className="profile-edit__error">{fieldError.message}</span>
+        )}
+      </label>
+
+      <label className="profile-edit__field">
+        <span className="profile-edit__label">{t('profileEdit.regionLabel')}</span>
+        <input
+          type="text"
+          className="profile-edit__input"
+          value={form.region}
+          onChange={(e) => setForm((f) => ({ ...f, region: e.target.value }))}
+          maxLength={100}
+          disabled={saving}
+          placeholder={t('profileEdit.regionPlaceholder')}
+        />
+      </label>
+
+      <label className="profile-edit__field">
+        <span className="profile-edit__label">{t('profileEdit.languageLabel')}</span>
+        <select
+          className="profile-edit__input"
+          value={form.preferredLanguage}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              preferredLanguage: e.target.value as '' | SupportedLanguage,
+            }))
+          }
+          disabled={saving}
+        >
+          <option value="">{t('profileEdit.languageNone')}</option>
+          {LANGUAGES.map((code) => (
+            <option key={code} value={code}>
+              {t(`profileEdit.languages.${code}`)}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {error && <p className="profile-edit__error profile-edit__error--global">{error}</p>}
+
+      <div className="profile-edit__actions">
+        <button
+          type="button"
+          className="profile-edit__btn profile-edit__btn--ghost"
+          onClick={onClose}
+          disabled={saving}
+        >
+          {t('profileEdit.cancel')}
+        </button>
+        <button
+          type="submit"
+          className="profile-edit__btn profile-edit__btn--primary"
+          disabled={saving || uploading}
+          aria-busy={saving}
+        >
+          {saving ? <span className="ui-spinner" aria-hidden /> : t('profileEdit.save')}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/pages/Profile/ProfilePage.css
+++ b/frontend/src/pages/Profile/ProfilePage.css
@@ -52,6 +52,51 @@
   font-size: 1.25rem;
   font-weight: 700;
   letter-spacing: 0.03em;
+  overflow: hidden;
+}
+
+.profile-page__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-page__bio {
+  margin: var(--space-xs) 0 0;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.profile-page__region {
+  margin: 2px 0 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.profile-page__edit-btn {
+  align-self: flex-start;
+  margin-left: auto;
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-neutral-darker);
+  background: var(--surface-bg);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.profile-page__edit-btn:hover {
+  background: var(--surface-overlay);
+  border-color: var(--color-main);
+  color: var(--color-main);
+}
+
+.profile-page__edit-wrapper {
+  margin-top: var(--space-md);
 }
 
 .profile-page__info {
@@ -372,4 +417,186 @@
   color: var(--color-error, #e53e3e);
   border-radius: var(--radius-sm);
   font-size: 0.875rem;
+}
+
+/* ── Profile edit form ─────────────────────────────────────────────────────── */
+
+.profile-edit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.profile-edit__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile-edit__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.profile-edit__hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.profile-edit__avatar-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.profile-edit__avatar-preview {
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--color-main);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.profile-edit__avatar-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-edit__avatar-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.profile-edit__avatar-input {
+  display: none;
+}
+
+.profile-edit__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile-edit__label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.profile-edit__input,
+.profile-edit__textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-neutral-darker);
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.9rem;
+}
+
+.profile-edit__textarea {
+  resize: vertical;
+  min-height: 4.5rem;
+}
+
+.profile-edit__input:focus,
+.profile-edit__textarea:focus {
+  outline: none;
+  border-color: var(--color-main);
+}
+
+.profile-edit__hint-line {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  align-self: flex-end;
+}
+
+.profile-edit__error {
+  font-size: 0.8125rem;
+  color: var(--color-error, #e53e3e);
+}
+
+.profile-edit__error--global {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-error-bg, #fff5f5);
+  border-radius: var(--radius-sm);
+  margin: 0;
+}
+
+.profile-edit__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+}
+
+.profile-edit__btn {
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.profile-edit__btn--primary {
+  background: var(--color-main);
+  border-color: var(--color-main);
+  color: #fff;
+  font-weight: 600;
+}
+
+.profile-edit__btn--primary:hover:not(:disabled) {
+  background: var(--color-main-dark);
+  border-color: var(--color-main-dark);
+}
+
+.profile-edit__btn--ghost {
+  background: var(--surface-bg);
+  border-color: var(--color-neutral-darker);
+  color: var(--text-primary);
+}
+
+.profile-edit__btn--ghost:hover:not(:disabled) {
+  background: var(--surface-overlay);
+  border-color: var(--color-main);
+  color: var(--color-main);
+}
+
+.profile-edit__btn--link {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-secondary);
+  text-decoration: underline;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8125rem;
+}
+
+.profile-edit__btn--link:hover:not(:disabled) {
+  color: var(--color-error, #e53e3e);
+}
+
+.profile-edit__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -6,6 +6,7 @@ import { useAppSelector } from '@/store/hooks'
 import { recipeService, type MyRecipeSummary } from '@/services/recipe-service'
 import { favoriteService, type FavoriteRecipe } from '@/services/favorite-service'
 import { MySuggestions } from '@/pages/Profile/MySuggestions'
+import { ProfileEditForm } from '@/pages/Profile/ProfileEditForm'
 import './ProfilePage.css'
 
 function StarIcon() {
@@ -29,6 +30,7 @@ export function ProfilePage() {
   const [favorites, setFavorites] = useState<FavoriteRecipe[]>([])
   const [favoritesTotal, setFavoritesTotal] = useState(0)
   const [favoritesLoading, setFavoritesLoading] = useState(true)
+  const [editing, setEditing] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -114,15 +116,40 @@ export function ProfilePage() {
 
       {/* ── User card ── */}
       <div className="profile-page__card">
-        <div className="profile-page__avatar">{initials}</div>
+        <div className="profile-page__avatar">
+          {profile.avatarUrl ? (
+            <img src={profile.avatarUrl} alt="" />
+          ) : (
+            initials
+          )}
+        </div>
         <div className="profile-page__info">
           <h1 className="profile-page__username">{profile.username ?? '—'}</h1>
           <p className="profile-page__email">{profile.email ?? '—'}</p>
           <span className={`profile-page__role-badge profile-page__role-badge--${profile.role ?? 'learner'}`}>
             {roleLabel}
           </span>
+          {profile.bio && (
+            <p className="profile-page__bio">{profile.bio}</p>
+          )}
+          {profile.region && (
+            <p className="profile-page__region">{profile.region}</p>
+          )}
         </div>
+        <button
+          type="button"
+          className="profile-page__edit-btn"
+          onClick={() => setEditing(true)}
+        >
+          {t('profileEdit.openButton')}
+        </button>
       </div>
+
+      {editing && (
+        <div className="profile-page__edit-wrapper">
+          <ProfileEditForm onClose={() => setEditing(false)} />
+        </div>
+      )}
 
       {/* ── Stats ── */}
       {!recipesLoading && !draftsLoading && (

--- a/frontend/src/services/profile-service.ts
+++ b/frontend/src/services/profile-service.ts
@@ -1,15 +1,70 @@
 import { httpClient } from '@/lib/http-client'
 import type { MeResponse } from '@/services/types/auth'
 
-interface ApiEnvelope {
+interface ApiEnvelope<T> {
   success: boolean
-  data: MeResponse
+  data: T
   error: null
+}
+
+/** Fields the user can edit on their own profile. All optional — only sent
+ *  fields are updated. `avatarUrl` is a fully-qualified URL returned from
+ *  `POST /media/upload`. */
+export interface ProfileUpdatePayload {
+  username?: string
+  bio?: string
+  avatarUrl?: string
+  region?: string
+  preferredLanguage?: string
+}
+
+/** Shape of the row PATCH /auth/profile returns. Backend uses snake_case;
+ *  we normalize to camelCase on the way out. */
+export interface UpdatedProfile {
+  id: string
+  username: string
+  bio: string | null
+  avatarUrl: string | null
+  region: string | null
+  preferredLanguage: string | null
+  updatedAt: string
+}
+
+interface UpdatedProfileRow {
+  id: string | number
+  username: string
+  bio: string | null
+  avatar_url: string | null
+  region: string | null
+  preferred_language: string | null
+  updated_at: string
 }
 
 export const profileService = {
   async getCurrentUser(): Promise<MeResponse> {
-    const { data } = await httpClient.get<ApiEnvelope>('/auth/me')
+    const { data } = await httpClient.get<ApiEnvelope<MeResponse>>('/auth/me')
     return data.data
+  },
+
+  /** PATCH /auth/profile — partial update. Returns 409 if username taken. */
+  async updateProfile(payload: ProfileUpdatePayload): Promise<UpdatedProfile> {
+    const body: Record<string, string> = {}
+    if (payload.username !== undefined) body.username = payload.username
+    if (payload.bio !== undefined) body.bio = payload.bio
+    if (payload.avatarUrl !== undefined) body.avatar_url = payload.avatarUrl
+    if (payload.region !== undefined) body.region = payload.region
+    if (payload.preferredLanguage !== undefined) body.preferred_language = payload.preferredLanguage
+
+    const { data } = await httpClient.patch<ApiEnvelope<UpdatedProfileRow>>('/auth/profile', body)
+    const row = data.data
+    return {
+      id: String(row.id),
+      username: row.username,
+      bio: row.bio,
+      avatarUrl: row.avatar_url,
+      region: row.region,
+      preferredLanguage: row.preferred_language,
+      updatedAt: row.updated_at,
+    }
   },
 }

--- a/frontend/src/store/slices/profile-slice.ts
+++ b/frontend/src/store/slices/profile-slice.ts
@@ -1,6 +1,10 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import { isAxiosError } from 'axios'
-import { profileService } from '@/services/profile-service'
+import {
+  profileService,
+  type ProfileUpdatePayload,
+  type UpdatedProfile,
+} from '@/services/profile-service'
 import type { MeResponse, UserRole } from '@/services/types/auth'
 import { logout } from '@/store/slices/auth-slice'
 
@@ -11,6 +15,13 @@ interface ProfileState {
   username: string | null
   email: string | null
   role: UserRole | null
+  /** Backend does NOT return these on GET /auth/me. They are populated by
+   *  PATCH /auth/profile responses during a session and reset to null on
+   *  refresh until the user edits again. */
+  bio: string | null
+  avatarUrl: string | null
+  region: string | null
+  preferredLanguage: string | null
   status: ProfileStatus
   error: string | null
 }
@@ -20,6 +31,10 @@ const initialState: ProfileState = {
   username: null,
   email: null,
   role: null,
+  bio: null,
+  avatarUrl: null,
+  region: null,
+  preferredLanguage: null,
   status: 'idle',
   error: null,
 }
@@ -39,6 +54,26 @@ export const fetchProfileAsync = createAsyncThunk<
           ? err.message
           : 'Could not load profile.'
     return rejectWithValue(message || 'Could not load profile.')
+  }
+})
+
+export const updateProfileAsync = createAsyncThunk<
+  UpdatedProfile,
+  ProfileUpdatePayload,
+  { rejectValue: { code?: string; message: string } }
+>('profile/updateProfile', async (payload, { rejectWithValue }) => {
+  try {
+    return await profileService.updateProfile(payload)
+  } catch (err: unknown) {
+    if (isAxiosError(err) && err.response?.data) {
+      const body = err.response.data as { error?: { code?: string; message?: string } }
+      return rejectWithValue({
+        code: body.error?.code,
+        message: body.error?.message ?? 'Could not update profile.',
+      })
+    }
+    const message = err instanceof Error ? err.message : 'Could not update profile.'
+    return rejectWithValue({ message })
   }
 })
 
@@ -71,6 +106,13 @@ const profileSlice = createSlice({
       state.username = null
       state.email = null
       state.role = null
+    })
+    builder.addCase(updateProfileAsync.fulfilled, (state, action) => {
+      state.username = action.payload.username
+      state.bio = action.payload.bio
+      state.avatarUrl = action.payload.avatarUrl
+      state.region = action.payload.region
+      state.preferredLanguage = action.payload.preferredLanguage
     })
     builder.addCase(logout, () => initialState)
   },


### PR DESCRIPTION
Wires PATCH /auth/profile into the Profile page with an inline form for username, bio, avatar, region, and preferred language. Username validation matches the backend regex; 409 CONFLICT surfaces as a "username already taken" field error. Avatar upload reuses POST /media/upload. Only changed fields are sent.

Note: GET /auth/me does not return bio/avatar/region/preferred_language, so these are seeded from the Redux slice (populated by prior PATCH responses in the current session) and reset on refresh. A hint near the title tells the user that empty fields keep their current value.