### PR TITLE
[Frontend/Refactor] Use GET /discovery/locations for filter dropdowns (#562)

### DIFF
--- a/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipe/CreateRecipePage.tsx
@@ -284,9 +284,9 @@ export function CreateRecipePage() {
     if (!canSuggestContent) return
     let cancelled = false
     discoveryService
-      .getLocations()
+      .getCountries()
       .then((opts) => {
-        if (!cancelled) setCountryOptions(opts.countries)
+        if (!cancelled) setCountryOptions(opts)
       })
       .catch(() => {
         if (!cancelled) setCountryOptions([])

--- a/frontend/src/pages/Discovery/DiscoveryPage.tsx
+++ b/frontend/src/pages/Discovery/DiscoveryPage.tsx
@@ -9,7 +9,6 @@ import {
   type DietaryTag,
   type DishVariety,
   type Genre,
-  type LocationOptions,
   type RecipeSummary,
 } from '@/services/discovery-service'
 import { allergenService, type Allergen } from '@/services/allergen-service'
@@ -59,7 +58,9 @@ export function DiscoveryPage() {
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [selectedCountry, setSelectedCountry] = useState('')
   const [selectedCity, setSelectedCity] = useState('')
-  const [locationOptions, setLocationOptions] = useState<LocationOptions>({ countries: [], citiesByCountry: {} })
+  const [countries, setCountries] = useState<string[]>([])
+  /** Cached city lists keyed by country — populated lazily on country change. */
+  const [citiesByCountry, setCitiesByCountry] = useState<Record<string, string[]>>({})
   const [culturalTags, setCulturalTags] = useState<CulturalTag[]>([])
   const [selectedCulturalTagIds, setSelectedCulturalTagIds] = useState<number[]>([])
   /** "Available ingredients" filter — when non-empty, recipes are fetched via
@@ -83,15 +84,15 @@ export function DiscoveryPage() {
       discoveryService.getGenres(),
       discoveryService.getVarieties(),
       discoveryService.getDietaryTags(),
-      discoveryService.getLocations(),
+      discoveryService.getCountries(),
       allergenService.list(),
     ])
-      .then(([genreData, varietyData, tagData, locationData, allergenData]) => {
+      .then(([genreData, varietyData, tagData, countryData, allergenData]) => {
         if (!cancelled) {
           setGenres(genreData)
           setAllVarieties(varietyData)
           setAllTags(tagData)
-          setLocationOptions(locationData)
+          setCountries(countryData)
           setAllergens(allergenData)
         }
       })
@@ -128,6 +129,25 @@ export function DiscoveryPage() {
       cancelled = true
     }
   }, [selectedCountry])
+
+  /** Lazy-fetch cities when a country is selected; cache per country. */
+  useEffect(() => {
+    if (!selectedCountry) return
+    if (citiesByCountry[selectedCountry] !== undefined) return
+    let cancelled = false
+    discoveryService.getCities(selectedCountry)
+      .then((cities) => {
+        if (cancelled) return
+        setCitiesByCountry((prev) => ({ ...prev, [selectedCountry]: cities }))
+      })
+      .catch(() => {
+        if (cancelled) return
+        setCitiesByCountry((prev) => ({ ...prev, [selectedCountry]: [] }))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedCountry, citiesByCountry])
 
   /** Arama metni veya filtreler değişince sayfa 1'e dönsün. */
   useLayoutEffect(() => {
@@ -381,7 +401,7 @@ export function DiscoveryPage() {
                 aria-label={t('discovery.countryPlaceholder')}
               >
                 <option value="">{t('discovery.countryPlaceholder')}</option>
-                {locationOptions.countries.map((c) => (
+                {countries.map((c) => (
                   <option key={c} value={c}>{c}</option>
                 ))}
               </select>
@@ -391,9 +411,10 @@ export function DiscoveryPage() {
                 value={selectedCity}
                 onChange={(e) => setSelectedCity(e.target.value)}
                 aria-label={t('discovery.cityPlaceholder')}
+                disabled={!selectedCountry}
               >
                 <option value="">{t('discovery.cityPlaceholder')}</option>
-                {(locationOptions.citiesByCountry[selectedCountry] ?? []).map((c) => (
+                {(citiesByCountry[selectedCountry] ?? []).map((c) => (
                   <option key={c} value={c}>{c}</option>
                 ))}
               </select>

--- a/frontend/src/pages/Profile/MySuggestions.tsx
+++ b/frontend/src/pages/Profile/MySuggestions.tsx
@@ -63,16 +63,14 @@ export function MySuggestions() {
       dishGenreRequest.listMine(),
       dishVarietyRequest.listMine(),
       discoveryService.getGenres(),
-      discoveryService.getLocations(),
+      discoveryService.getCountries(),
     ]).then((results) => {
       if (cancelled) return
       setCultural(results[0].status === 'fulfilled' ? results[0].value : [])
       setGenres(results[1].status === 'fulfilled' ? results[1].value : [])
       setVarieties(results[2].status === 'fulfilled' ? results[2].value : [])
       setGenreOptions(results[3].status === 'fulfilled' ? results[3].value : [])
-      setCountryOptions(
-        results[4].status === 'fulfilled' ? results[4].value.countries : [],
-      )
+      setCountryOptions(results[4].status === 'fulfilled' ? results[4].value : [])
     })
     return () => {
       cancelled = true

--- a/frontend/src/services/discovery-service.ts
+++ b/frontend/src/services/discovery-service.ts
@@ -54,11 +54,6 @@ export interface RecipeSummary {
   allergens?: { id: number; name: string }[]
 }
 
-export interface LocationOptions {
-  countries: string[]
-  citiesByCountry: Record<string, string[]>
-}
-
 export interface DiscoveryParams {
   region?: string
   excludeAllergens?: string
@@ -300,37 +295,32 @@ export const discoveryService = {
   },
 
   /**
-   * Fetch unique country/city values across all recipes for use in filter dropdowns.
-   * Calls /discovery/recipes with a high limit and no filters.
+   * GET /discovery/locations — distinct countries that have at least one
+   * published recipe. Backend returns alias-aware deduped values (e.g.
+   * "Turkey" / "Türkiye" / "TR" collapse into a single canonical entry).
    */
-  getLocations: async (): Promise<LocationOptions> => {
+  getCountries: async (): Promise<string[]> => {
     try {
-      const res = await httpClient.get('/discovery/recipes', { params: { limit: 100, page: 1 } })
-      const payload = res.data?.data
-      const raw: any[] = Array.isArray(payload)
-        ? payload
-        : Array.isArray(payload?.recipes)
-          ? payload.recipes
-          : []
-
-      const citiesByCountry: Record<string, Set<string>> = {}
-      for (const r of raw) {
-        const country: string | undefined = r.country ?? undefined
-        const city: string | undefined = r.city ?? undefined
-        if (country) {
-          if (!citiesByCountry[country]) citiesByCountry[country] = new Set()
-          if (city) citiesByCountry[country].add(city)
-        }
-      }
-
-      const countries = Object.keys(citiesByCountry).sort()
-      const result: Record<string, string[]> = {}
-      for (const c of countries) {
-        result[c] = [...citiesByCountry[c]].sort()
-      }
-      return { countries, citiesByCountry: result }
+      const res = await httpClient.get('/discovery/locations')
+      const raw = res.data?.data?.results
+      return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : []
     } catch {
-      return { countries: [], citiesByCountry: {} }
+      return []
+    }
+  },
+
+  /**
+   * GET /discovery/locations?country=X — distinct cities within a given
+   * country that have at least one published recipe.
+   */
+  getCities: async (country: string): Promise<string[]> => {
+    if (!country) return []
+    try {
+      const res = await httpClient.get('/discovery/locations', { params: { country } })
+      const raw = res.data?.data?.results
+      return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : []
+    } catch {
+      return []
     }
   },
 


### PR DESCRIPTION
## What does this PR do?
Replaces the client-side `getLocations()` helper (which scraped country/city values from the first 100 recipes) with two endpoint-backed helpers that hit the dedicated `/discovery/locations` route. The new helpers leverage the backend's alias-aware deduplication (e.g. `"Turkey"` / `"Türkiye"` / `"TR"` collapse to one canonical entry) and remove the implicit 100-recipe truncation.

## Changes
- `services/discovery-service.ts`
  - Removed `getLocations()` and the `LocationOptions` type
  - Added `getCountries()` → calls `GET /discovery/locations`, returns `string[]`
  - Added `getCities(country)` → calls `GET /discovery/locations?country=X`, returns `string[]`
- `pages/Discovery/DiscoveryPage.tsx`
  - Bootstraps with countries only
  - Lazy-fetches cities on country change and caches them per-country in `citiesByCountry` state
  - City `<select>` is disabled until a country is chosen
- `pages/Profile/MySuggestions.tsx`
  - Cultural-tag suggestion modal sources its country dropdown from `getCountries()`
- `pages/CreateRecipe/CreateRecipePage.tsx`
  - Cultural-tag suggestion modal sources its country dropdown from `getCountries()`

## How to test
- [ ] Discovery filter → country dropdown lists every distinct country with a published recipe (no 100-recipe cap)
- [ ] Selecting a country fetches and renders its cities; selecting another country lazy-fetches again (cached on revisit)
- [ ] City `<select>` is disabled when no country is chosen
- [ ] Alias-named recipes (`"Türkiye"` / `"TR"`) appear under a single canonical "Turkey" entry
- [ ] Cultural tag suggestion modal (Profile and CreateRecipe) shows the same country list
- [ ] `npm run build` passes

## Related issue
Closes #562