### PR TITLE
[Mobile/Fix] Remove empty image placeholders and refactor search card styles

### DIFF
--- a/mobile/src/__tests__/DishVarietyCard.test.tsx
+++ b/mobile/src/__tests__/DishVarietyCard.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { DishVarietyCard } from '../components/search/DishVarietyCard';
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+const baseVariety = {
+  id: 1,
+  name: 'Adana Kebabı',
+  description: 'Acılı kıyma kebabı',
+  genreId: 2,
+  genreName: 'Kebap',
+};
+
+describe('DishVarietyCard', () => {
+  it('renders variety name', () => {
+    const { getByText } = render(<DishVarietyCard variety={baseVariety} />);
+    expect(getByText('Adana Kebabı')).toBeTruthy();
+  });
+
+  it('renders description when provided', () => {
+    const { getByText } = render(<DishVarietyCard variety={baseVariety} />);
+    expect(getByText('Acılı kıyma kebabı')).toBeTruthy();
+  });
+
+  it('renders genre tag when provided', () => {
+    const { getByText } = render(<DishVarietyCard variety={baseVariety} />);
+    expect(getByText('Kebap')).toBeTruthy();
+  });
+
+  it('does not render description when absent', () => {
+    const variety = { ...baseVariety, description: undefined };
+    const { queryByText } = render(<DishVarietyCard variety={variety as any} />);
+    expect(queryByText('Acılı kıyma kebabı')).toBeNull();
+  });
+
+  it('does not render genre tag when absent', () => {
+    const variety = { ...baseVariety, genreName: undefined };
+    const { queryByText } = render(<DishVarietyCard variety={variety as any} />);
+    expect(queryByText('Kebap')).toBeNull();
+  });
+
+  it('calls onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<DishVarietyCard variety={baseVariety} onPress={onPress} />);
+    fireEvent.press(getByText('Adana Kebabı'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render an image placeholder', () => {
+    const { UNSAFE_queryAllByProps } = render(<DishVarietyCard variety={baseVariety} />);
+    const imagePlaceholders = UNSAFE_queryAllByProps({ testID: 'variety-image-placeholder' });
+    expect(imagePlaceholders).toHaveLength(0);
+  });
+});

--- a/mobile/src/__tests__/GenreBentoGrid.test.tsx
+++ b/mobile/src/__tests__/GenreBentoGrid.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { GenreBentoGrid } from '../components/search/GenreBentoGrid';
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+const mockGenres = [
+  { id: 1, name: 'Kebap', description: '', varieties: [] },
+  { id: 2, name: 'Çorbalar', description: '', varieties: [] },
+  { id: 3, name: 'Tatlılar', description: '', varieties: [] },
+];
+
+describe('GenreBentoGrid', () => {
+  it('renders all genre names', () => {
+    const { getByText } = render(
+      <GenreBentoGrid genres={mockGenres} onGenrePress={jest.fn()} />
+    );
+    expect(getByText('Kebap')).toBeTruthy();
+    expect(getByText('Çorbalar')).toBeTruthy();
+    expect(getByText('Tatlılar')).toBeTruthy();
+  });
+
+  it('returns null when genres list is empty', () => {
+    const { toJSON } = render(
+      <GenreBentoGrid genres={[]} onGenrePress={jest.fn()} />
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('calls onGenrePress with the correct genre when a row is pressed', () => {
+    const onGenrePress = jest.fn();
+    const { getByText } = render(
+      <GenreBentoGrid genres={mockGenres} onGenrePress={onGenrePress} />
+    );
+    fireEvent.press(getByText('Çorbalar'));
+    expect(onGenrePress).toHaveBeenCalledWith(mockGenres[1]);
+  });
+
+  it('applies active style to the active genre row', () => {
+    const { getByText } = render(
+      <GenreBentoGrid genres={mockGenres} onGenrePress={jest.fn()} activeGenreId={2} />
+    );
+    expect(getByText('Çorbalar')).toBeTruthy();
+  });
+});

--- a/mobile/src/components/search/DishVarietyCard.tsx
+++ b/mobile/src/components/search/DishVarietyCard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
 import type { DishVarietyResult } from '../../api/search';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
 
@@ -12,14 +11,10 @@ interface DishVarietyCardProps {
 export function DishVarietyCard({ variety, onPress }: DishVarietyCardProps) {
   return (
     <TouchableOpacity onPress={onPress} style={styles.container} activeOpacity={0.7}>
-      <View style={styles.image} />
       <View style={styles.info}>
-        <View style={styles.titleRow}>
-          <Text style={styles.name} numberOfLines={1}>
-            {variety.name}
-          </Text>
-          <MaterialCommunityIcons name="bookmark-outline" size={20} color={colors.tertiary} />
-        </View>
+        <Text style={styles.name} numberOfLines={1}>
+          {variety.name}
+        </Text>
         {variety.description && (
           <Text style={styles.description} numberOfLines={2}>
             {variety.description}
@@ -37,39 +32,21 @@ export function DishVarietyCard({ variety, onPress }: DishVarietyCardProps) {
 
 const styles = StyleSheet.create({
   container: {
-    flexDirection: 'row',
     backgroundColor: colors.white,
     borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.outline,
     overflow: 'hidden',
     marginBottom: spacing.md,
-    elevation: 2,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.08,
-    shadowRadius: 3,
-  },
-  image: {
-    width: 88,
-    height: 88,
-    backgroundColor: colors.surfaceContainer,
   },
   info: {
-    flex: 1,
     padding: spacing.md,
-    justifyContent: 'center',
     gap: spacing.xs,
   },
-  titleRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-  },
   name: {
-    flex: 1,
     fontFamily: fonts.serifBold,
     fontSize: fontSizes.lg,
     color: colors.onSurface,
-    marginRight: spacing.sm,
   },
   description: {
     fontFamily: fonts.sans,

--- a/mobile/src/components/search/GenreBentoGrid.tsx
+++ b/mobile/src/components/search/GenreBentoGrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import type { DishGenre } from '../../api/dish-genres';
 import { colors, fonts, fontSizes, spacing } from '../../theme';
 
@@ -9,46 +10,31 @@ interface GenreBentoGridProps {
   activeGenreId?: number | null;
 }
 
-interface GenreTileProps {
-  genre: DishGenre;
-  onPress: () => void;
-  tall?: boolean;
-  active?: boolean;
-}
-
-function GenreTile({ genre, onPress, tall = false, active = false }: GenreTileProps) {
-  return (
-    <TouchableOpacity
-      onPress={onPress}
-      activeOpacity={0.8}
-      style={[styles.tile, tall && styles.tileTall, active && styles.tileActive]}
-    >
-      <View style={styles.tileImage}>
-        <View style={[styles.tileOverlay, active && styles.tileOverlayActive]} />
-        <View style={styles.tileLabel}>
-          <Text style={styles.tileName}>{genre.name}</Text>
-        </View>
-      </View>
-    </TouchableOpacity>
-  );
-}
-
 export function GenreBentoGrid({ genres, onGenrePress, activeGenreId }: GenreBentoGridProps) {
   if (genres.length === 0) return null;
 
-  // First genre is large (spans full row), rest fill 2-column grid
-  const [first, ...rest] = genres;
-
   return (
     <View style={styles.container}>
-      {first && (
-        <GenreTile genre={first} onPress={() => onGenrePress(first)} tall active={activeGenreId === first.id} />
-      )}
-      <View style={styles.grid}>
-        {rest.map((genre) => (
-          <GenreTile key={genre.id} genre={genre} onPress={() => onGenrePress(genre)} active={activeGenreId === genre.id} />
-        ))}
-      </View>
+      {genres.map((genre) => {
+        const active = activeGenreId === genre.id;
+        return (
+          <TouchableOpacity
+            key={genre.id}
+            onPress={() => onGenrePress(genre)}
+            activeOpacity={0.7}
+            style={[styles.row, active && styles.rowActive]}
+          >
+            <Text style={[styles.name, active && styles.nameActive]} numberOfLines={1}>
+              {genre.name}
+            </Text>
+            <MaterialCommunityIcons
+              name="chevron-right"
+              size={20}
+              color={active ? colors.primary : colors.onSurfaceVariant}
+            />
+          </TouchableOpacity>
+        );
+      })}
     </View>
   );
 }
@@ -57,44 +43,29 @@ const styles = StyleSheet.create({
   container: {
     gap: spacing.sm,
   },
-  tile: {
-    flex: 1,
-    height: 130,
-    borderRadius: 20,
-    overflow: 'hidden',
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.outline,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
   },
-  tileTall: {
-    height: 180,
-  },
-  tileImage: {
-    flex: 1,
-    justifyContent: 'flex-end',
+  rowActive: {
     backgroundColor: colors.surfaceContainer,
-  },
-  tileActive: {
-    borderWidth: 3,
     borderColor: colors.primary,
   },
-  tileOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: colors.primary,
-    opacity: 0.6,
-    borderRadius: 20,
-  },
-  tileOverlayActive: {
-    opacity: 0.8,
-  },
-  tileLabel: {
-    padding: spacing.md,
-  },
-  tileName: {
+  name: {
+    flex: 1,
     fontFamily: fonts.serifBold,
-    fontSize: fontSizes.xl,
-    color: colors.white,
+    fontSize: fontSizes.md,
+    color: colors.onSurface,
+    marginRight: spacing.sm,
   },
-  grid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: spacing.sm,
+  nameActive: {
+    color: colors.primary,
   },
 });

--- a/mobile/src/components/search/RecipeCard.tsx
+++ b/mobile/src/components/search/RecipeCard.tsx
@@ -23,7 +23,13 @@ export function RecipeCard({ recipe, onPress }: RecipeCardProps) {
             style={styles.image}
           />
         ) : (
-          <View style={styles.image} />
+          <View style={[styles.image, styles.imagePlaceholder]}>
+            <MaterialCommunityIcons
+              name="silverware-fork-knife"
+              size={40}
+              color={colors.outline}
+            />
+          </View>
         )}
         {/* Recipe type badge — top-right, like the example image */}
         <View style={[styles.badge, isCultural ? styles.badgeCultural : styles.badgeCommunity]}>
@@ -68,13 +74,10 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.white,
     borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.outline,
     overflow: 'hidden',
     marginBottom: spacing.md,
-    elevation: 2,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.08,
-    shadowRadius: 3,
   },
   imageWrapper: {
     position: 'relative',
@@ -83,6 +86,10 @@ const styles = StyleSheet.create({
     width: '100%',
     height: 180,
     backgroundColor: colors.surfaceContainer,
+  },
+  imagePlaceholder: {
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   badge: {
     position: 'absolute',

--- a/mobile/src/screens/SearchScreen.tsx
+++ b/mobile/src/screens/SearchScreen.tsx
@@ -347,7 +347,7 @@ export function SearchScreen() {
                   )
                 ) : (
                   <GenreBentoGrid
-                    genres={allGenres}
+                    genres={allGenres.slice(0, PREVIEW_COUNT)}
                     onGenrePress={handleGenrePress}
                     activeGenreId={selectedGenreId}
                   />
@@ -424,7 +424,7 @@ function SectionBox({ title, count, query, onSeeAll, children }: SectionBoxProps
           <MaterialCommunityIcons
             name="chevron-right"
             size={18}
-            color={colors.primary}
+            color={colors.white}
           />
         </View>
       </TouchableOpacity>
@@ -485,14 +485,9 @@ const styles = StyleSheet.create({
   },
   // ── Section Box ──────────────────────────────────────────────────────────
   sectionBox: {
-    backgroundColor: colors.white,
+    backgroundColor: colors.primary,
     borderRadius: 20,
     padding: spacing.lg,
-    elevation: 2,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.07,
-    shadowRadius: 4,
   },
   sectionBoxHeader: {
     flexDirection: 'row',
@@ -503,7 +498,7 @@ const styles = StyleSheet.create({
   sectionBoxTitle: {
     fontFamily: fonts.serifBold,
     fontSize: fontSizes.xl,
-    color: colors.onSurface,
+    color: colors.white,
     flex: 1,
     flexWrap: 'wrap',
   },
@@ -515,7 +510,7 @@ const styles = StyleSheet.create({
   seeAllText: {
     fontFamily: fonts.sansMedium,
     fontSize: fontSizes.sm,
-    color: colors.primary,
+    color: colors.white,
   },
   // ── Genre chips (search mode preview) ────────────────────────────────────
   genreChips: {


### PR DESCRIPTION
## What does this PR do?
Removes the empty image placeholder layout from variety cards on the search page and refactors all three search section cards (genres, varieties, recipes) to use a consistent text-based style with no wasted whitespace.

## How to test
1. Open the Search tab
2. Verify variety cards show name, description, and genre tag without any empty image box
3. Verify genre section shows 3 rows (row-list style, not bento grid)
4. Verify recipe cards without images show a fork-knife icon instead of a blank area
5. Verify all three section boxes have a dark-brown outer background with white inner cards

## Related issue
Closes #572