### PR TITLE
[Mobile/Fix] Video guide: seek video to step timestamp on Next/Previous

### DIFF
--- a/mobile/src/__tests__/VideoPlayer.test.tsx
+++ b/mobile/src/__tests__/VideoPlayer.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { VideoPlayer } from '../components/video-guide/VideoPlayer';
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+const mockPlayer: { currentTime: number; loop: boolean; play: jest.Mock } = {
+  currentTime: 0,
+  loop: false,
+  play: jest.fn(),
+};
+
+jest.mock('expo-video', () => ({
+  useVideoPlayer: jest.fn((_source, setup) => {
+    if (typeof setup === 'function') setup(mockPlayer);
+    return mockPlayer;
+  }),
+  VideoView: 'VideoView',
+}));
+
+beforeEach(() => {
+  mockPlayer.currentTime = 0;
+  mockPlayer.loop = false;
+  mockPlayer.play.mockClear();
+});
+
+describe('VideoPlayer seek-to-timestamp behavior', () => {
+  it('seeks to videoTimestamp and plays on mount when timestamp is provided', () => {
+    render(
+      <VideoPlayer
+        videoUrl="https://example.com/video.mp4"
+        stepNumber={1}
+        stepDescription="Mix the dough"
+        videoTimestamp={42}
+      />,
+    );
+
+    expect(mockPlayer.currentTime).toBe(42);
+    expect(mockPlayer.play).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not seek or play when videoTimestamp is undefined', () => {
+    render(
+      <VideoPlayer
+        videoUrl="https://example.com/video.mp4"
+        stepNumber={1}
+        stepDescription="Mix the dough"
+      />,
+    );
+
+    expect(mockPlayer.currentTime).toBe(0);
+    expect(mockPlayer.play).not.toHaveBeenCalled();
+  });
+
+  it('seeks to the new timestamp when videoTimestamp prop changes', () => {
+    const { rerender } = render(
+      <VideoPlayer
+        videoUrl="https://example.com/video.mp4"
+        stepNumber={1}
+        stepDescription="Step one"
+        videoTimestamp={10}
+      />,
+    );
+
+    expect(mockPlayer.currentTime).toBe(10);
+    expect(mockPlayer.play).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <VideoPlayer
+        videoUrl="https://example.com/video.mp4"
+        stepNumber={2}
+        stepDescription="Step two"
+        videoTimestamp={75}
+      />,
+    );
+
+    expect(mockPlayer.currentTime).toBe(75);
+    expect(mockPlayer.play).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mobile/src/components/video-guide/VideoGuideScreen.tsx
+++ b/mobile/src/components/video-guide/VideoGuideScreen.tsx
@@ -45,6 +45,7 @@ export function VideoGuideScreen({ recipe, onClose }: VideoGuideScreenProps) {
           videoUrl={currentStep.videoUrl}
           stepNumber={currentStep.stepNumber}
           stepDescription={currentStep.description}
+          videoTimestamp={currentStep.videoTimestamp}
         />
 
         <StepNavigation

--- a/mobile/src/components/video-guide/VideoPlayer.tsx
+++ b/mobile/src/components/video-guide/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
@@ -8,17 +8,24 @@ interface VideoPlayerProps {
   videoUrl?: string;
   stepNumber: number;
   stepDescription: string;
+  videoTimestamp?: number;
 }
 
 export function VideoPlayer({
   videoUrl,
   stepNumber,
   stepDescription,
+  videoTimestamp,
 }: VideoPlayerProps) {
-  console.log('[VideoPlayer] videoUrl:', videoUrl);
   const player = useVideoPlayer(videoUrl ?? null, (p) => {
     p.loop = true;
   });
+
+  useEffect(() => {
+    if (videoTimestamp == null) return;
+    player.currentTime = videoTimestamp;
+    player.play();
+  }, [player, videoTimestamp]);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## What does this PR do?

Fixes the video guide on the mobile Recipe Detail screen so that pressing **Next** / **Previous** actually moves the underlying video to the new step's `videoTimestamp` (and resumes playback), instead of just swapping the step description while the video plays on unchanged.

Implementation: `VideoPlayer` now takes an optional `videoTimestamp` prop and runs a `useEffect` that sets `player.currentTime = videoTimestamp` and calls `player.play()` whenever the timestamp changes. `VideoGuideScreen` passes `currentStep.videoTimestamp` through. When a step has no timestamp, the video is left where it is — no surprising jumps. Unit tests cover all three branches (timestamp set, undefined, prop change).

## How to test?

1. Check out the branch, `cd mobile && npm start`, open on a device/simulator.
2. Open a recipe whose steps have `videoTimestamp` values populated and tap the cooking-mode / Start Cooking button to open the Video Guide.
3. On step 1 the video starts at step 1's timestamp and plays.
4. Tap **Next**: video jumps to step 2's timestamp and continues playing (verify via the native scrubber).
5. Tap **Previous**: video jumps back to step 1's timestamp and plays.
6. For a step intentionally missing `videoTimestamp`, navigating to/from it does not reset the video.
7. Tap **Finish** on the last step — modal closes (regression check).
8. `cd mobile && npx jest src/__tests__/VideoPlayer.test.tsx` — all 3 tests pass.

## Related issue

Closes #579