### PR TITLE
[Frontend/Feature] Show allergens in Recipe Detail tags

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -380,6 +380,8 @@
     "substituteLoadError": "Could not load substitutes.",
     "substituteClose": "Close",
     "substituteConfidence": "Confidence: {{pct}}%",
+    "allergenTagLabel": "⚠ {{name}}",
+    "allergenTagAria": "Contains allergen: {{name}}",
     "videoAnnotations": {
       "seekAria": "Jump to {{start}}: {{note}}"
     },

--- a/frontend/src/locales/tr/common.json
+++ b/frontend/src/locales/tr/common.json
@@ -380,6 +380,8 @@
     "substituteLoadError": "Alternatifler yüklenemedi.",
     "substituteClose": "Kapat",
     "substituteConfidence": "Güven: %{{pct}}",
+    "allergenTagLabel": "⚠ {{name}}",
+    "allergenTagAria": "Alerjen içerir: {{name}}",
     "videoAnnotations": {
       "seekAria": "{{start}} zamanına git: {{note}}"
     },

--- a/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
+++ b/frontend/src/pages/RecipeDetail/RecipeDetailPage.tsx
@@ -320,6 +320,24 @@ export function RecipeDetailPage() {
   const authorInitial = (recipe.creatorUsername ?? '?').slice(0, 1).toUpperCase()
   const badgeLabel = recipe.type === 'cultural' ? t('recipeDetail.cultural') : t('recipeDetail.community')
 
+  const existingAllergenTagNames = new Set(
+    recipe.tags
+      .filter((tag) => tag.category === 'allergen')
+      .map((tag) => tag.name.trim().toLowerCase())
+  )
+  const ingredientAllergenNames: string[] = []
+  const seenAllergens = new Set<string>()
+  for (const ing of recipe.ingredients) {
+    for (const raw of ing.allergens) {
+      const name = raw?.trim()
+      if (!name) continue
+      const key = name.toLowerCase()
+      if (seenAllergens.has(key) || existingAllergenTagNames.has(key)) continue
+      seenAllergens.add(key)
+      ingredientAllergenNames.push(name)
+    }
+  }
+
   return (
     <div className="recipe-detail">
       {/* Hero — web-design: full-bleed image + gradient + overlay toolbar */}
@@ -384,7 +402,7 @@ export function RecipeDetailPage() {
           )}
         </div>
 
-        {(recipe.tags.length > 0 || recipe.culturalTags.length > 0) && (
+        {(recipe.tags.length > 0 || recipe.culturalTags.length > 0 || ingredientAllergenNames.length > 0) && (
           <div className="recipe-detail__tags">
             {recipe.culturalTags.map((tag) => {
               const label =
@@ -406,7 +424,18 @@ export function RecipeDetailPage() {
                 key={tag.id}
                 className={`recipe-detail__tag recipe-detail__tag--${tag.category}`}
               >
-                {tag.name}
+                {tag.category === 'allergen'
+                  ? t('recipeDetail.allergenTagLabel', { name: tag.name })
+                  : tag.name}
+              </span>
+            ))}
+            {ingredientAllergenNames.map((name) => (
+              <span
+                key={`ing-allergen-${name}`}
+                className="recipe-detail__tag recipe-detail__tag--allergen"
+                aria-label={t('recipeDetail.allergenTagAria', { name })}
+              >
+                {t('recipeDetail.allergenTagLabel', { name })}
               </span>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Aggregate unique ingredient-level allergens on the Recipe Detail screen and render them as tag chips in the existing tags strip
- De-dup against allergen-category tags already present in `recipe.tags` (case-insensitive)
- Add EN/TR i18n keys for the allergen tag label (`⚠ {{name}}`) and screen-reader aria text

## How to test
- [ ] Open a recipe whose ingredients carry allergens (e.g. dairy/nuts) → the tags strip shows each unique allergen as a `⚠ {{name}}` chip
- [ ] Open a recipe with no ingredient allergens and no other tags → the tags strip is hidden, no broken UI
- [ ] Verify there are no duplicate allergen chips when `recipe.tags` already includes the same allergen
- [ ] Switch language to TR → chips use Turkish aria label
- [ ] `cd frontend && npm run build` passes

## Related issue
Closes #580