### PR TITLE
[Mobile/Fix] Center variety card text and wrap recipe detail badges

### DIFF
--- a/mobile/src/__tests__/GenreCard.test.tsx
+++ b/mobile/src/__tests__/GenreCard.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import { GenreCard } from '../components/home/GenreCard';
+
+
+jest.mock('@expo/vector-icons', () => ({
+  MaterialCommunityIcons: 'MaterialCommunityIcons',
+}));
+
+describe('GenreCard', () => {
+  it('renders the genre name', () => {
+    const { getByText } = render(<GenreCard id={1} name="Soups" />);
+    expect(getByText('Soups')).toBeTruthy();
+  });
+
+  it('renders a long genre name without crashing', () => {
+    const { getByText } = render(<GenreCard id={2} name="Fermente Gıdalar" />);
+    expect(getByText('Fermente Gıdalar')).toBeTruthy();
+  });
+
+  it('calls onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<GenreCard id={1} name="Kebabs" onPress={onPress} />);
+    fireEvent.press(getByText('Kebabs'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without onPress without crashing', () => {
+    const { getByText } = render(<GenreCard id={1} name="Pastries" />);
+    expect(getByText('Pastries')).toBeTruthy();
+  });
+
+  it('label text style includes textAlign center', () => {
+    const { getByText } = render(<GenreCard id={1} name="Soups" />);
+    const label = getByText('Soups');
+    const style = StyleSheet.flatten(label.props.style);
+    expect(style?.textAlign).toBe('center');
+  });
+});

--- a/mobile/src/__tests__/RecipeHeader.test.tsx
+++ b/mobile/src/__tests__/RecipeHeader.test.tsx
@@ -37,6 +37,39 @@ function renderHeader(overrides: Partial<React.ComponentProps<typeof RecipeHeade
   return { ...render(<RecipeHeader {...props} />), props };
 }
 
+describe('RecipeHeader badge row', () => {
+  it('renders dish variety badge with a long name', () => {
+    const { getByText } = renderHeader({
+      dishVarietyName: 'Geleneksel Mercimek Çorbası',
+    });
+    expect(getByText('Geleneksel Mercimek Çorbası')).toBeTruthy();
+  });
+
+  it('renders type, region, and dishVarietyName badges together', () => {
+    const { getByText } = renderHeader({
+      type: 'CULTURAL',
+      region: 'Adana, Turkey',
+      dishVarietyName: 'Mercimek Çorbası',
+    });
+    expect(getByText('CULTURAL')).toBeTruthy();
+    expect(getByText('Adana, Turkey')).toBeTruthy();
+    expect(getByText('Mercimek Çorbası')).toBeTruthy();
+  });
+
+  it('does not render region badge when region is empty', () => {
+    const { queryByText } = renderHeader({ region: '' });
+    expect(queryByText('Adana, Turkey')).toBeNull();
+  });
+
+  it('does not render dishVarietyName badge when absent', () => {
+    const { queryByText } = renderHeader({
+      title: 'Some Recipe',
+      dishVarietyName: undefined,
+    });
+    expect(queryByText('Mercimek Çorbası')).toBeNull();
+  });
+});
+
 describe('RecipeHeader favorite button', () => {
   it('renders the heart-outline icon when not favorited', () => {
     const { UNSAFE_getAllByType } = renderHeader({ isFavorited: false });

--- a/mobile/src/components/home/GenreCard.tsx
+++ b/mobile/src/components/home/GenreCard.tsx
@@ -42,8 +42,11 @@ const styles = StyleSheet.create({
   },
   labelContainer: {
     position: 'absolute',
+    left: 0,
+    right: 0,
     alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
   },
   label: {
     fontFamily: fonts.sansBold,
@@ -51,5 +54,6 @@ const styles = StyleSheet.create({
     color: colors.onSurface,
     textTransform: 'uppercase',
     letterSpacing: -0.3,
+    textAlign: 'center',
   },
 });

--- a/mobile/src/components/recipe-detail/RecipeHeader.tsx
+++ b/mobile/src/components/recipe-detail/RecipeHeader.tsx
@@ -161,6 +161,7 @@ const styles = StyleSheet.create({
   },
   badgeRow: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     gap: spacing.sm,
     marginTop: spacing.md,
   },


### PR DESCRIPTION
## What does this PR do?
Fixes two layout bugs: genre names on the Home screen are now horizontally centered inside GenreCard, and long dish variety badge labels in RecipeDetail no longer overflow the screen.

## How to test
1. Open the Home screen — observe that genre names (e.g. "Fermente Gıdalar") are centered inside their cards
2. Open a Recipe Detail with a long dish variety name — badge row should wrap to a new line instead of clipping off-screen
3. Test on a small screen size (iPhone SE) to confirm no overflow

## Related issue
Closes #578