### PR TITLE
[Frontend/Test] Unit tests for UI polish batch (#586)

### DIFF
--- a/frontend/src/__tests__/integration/create-recipe-step-label.test.ts
+++ b/frontend/src/__tests__/integration/create-recipe-step-label.test.ts
@@ -1,0 +1,26 @@
+import i18n from '@/i18n/i18n'
+
+describe('create.stepLabel i18n interpolation', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it('renders "Step N of M" when total is provided (EN)', () => {
+    const label = i18n.t('create.stepLabel', { step: 5, total: 5, label: 'Review & Publish' })
+    expect(label).toBe('Step 5 of 5: Review & Publish')
+  })
+
+  it('interpolates with arbitrary totals — no longer hardcoded to 4', () => {
+    const six = i18n.t('create.stepLabel', { step: 3, total: 6, label: 'Anything' })
+    expect(six).toBe('Step 3 of 6: Anything')
+
+    const seven = i18n.t('create.stepLabel', { step: 7, total: 7, label: 'Last' })
+    expect(seven).toBe('Step 7 of 7: Last')
+  })
+
+  it('renders "Adım N / M" in Turkish locale', async () => {
+    await i18n.changeLanguage('tr')
+    const label = i18n.t('create.stepLabel', { step: 2, total: 5, label: 'Malzemeler' })
+    expect(label).toBe('Adım 2 / 5: Malzemeler')
+  })
+})

--- a/frontend/src/__tests__/integration/recipe-card-badge.test.tsx
+++ b/frontend/src/__tests__/integration/recipe-card-badge.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import { MemoryRouter } from 'react-router-dom'
+import i18n from '@/i18n/i18n'
+import { RecipeCard } from '@/components/UiComponents/RecipeCard'
+import type { RecipeSummary } from '@/services/discovery-service'
+
+function makeRecipe(overrides: Partial<RecipeSummary> = {}): RecipeSummary {
+  return {
+    id: '1',
+    title: 'Test Recipe',
+    recipeType: 'community',
+    averageRating: 4.2,
+    ratingCount: 5,
+    author: { username: 'tester' },
+    ...overrides,
+  }
+}
+
+function renderCard(recipe: RecipeSummary) {
+  return render(
+    <MemoryRouter>
+      <I18nextProvider i18n={i18n}>
+        {/* badge is only rendered in the hero variant */}
+        <RecipeCard recipe={recipe} variant="hero" />
+      </I18nextProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('RecipeCard type badge i18n', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it('renders English label for a community recipe when locale is en', () => {
+    renderCard(makeRecipe({ recipeType: 'community' }))
+    expect(screen.getByText('Community')).toBeInTheDocument()
+    expect(screen.queryByText('Topluluk')).not.toBeInTheDocument()
+  })
+
+  it('renders English label for a cultural recipe when locale is en', () => {
+    renderCard(makeRecipe({ recipeType: 'cultural' }))
+    expect(screen.getByText('Cultural')).toBeInTheDocument()
+    expect(screen.queryByText('Kültürel')).not.toBeInTheDocument()
+  })
+
+  it('renders Turkish label for a community recipe when locale is tr', async () => {
+    await i18n.changeLanguage('tr')
+    renderCard(makeRecipe({ recipeType: 'community' }))
+    expect(screen.getByText('Topluluk')).toBeInTheDocument()
+    expect(screen.queryByText('Community')).not.toBeInTheDocument()
+  })
+
+  it('renders Turkish label for a cultural recipe when locale is tr', async () => {
+    await i18n.changeLanguage('tr')
+    renderCard(makeRecipe({ recipeType: 'cultural' }))
+    expect(screen.getByText('Kültürel')).toBeInTheDocument()
+    expect(screen.queryByText('Cultural')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/integration/recipe-detail-meta.test.tsx
+++ b/frontend/src/__tests__/integration/recipe-detail-meta.test.tsx
@@ -1,0 +1,119 @@
+import { http, HttpResponse } from 'msw'
+import { waitFor } from '@testing-library/react'
+import { server } from '@/test/mocks/server'
+import { renderWithProviders } from '@/test/render-with-providers'
+
+interface MetaOverrides {
+  country?: string | null
+  city?: string | null
+  district?: string | null
+  dishVarietyName?: string | null
+  genreName?: string | null
+}
+
+function mockRecipeWithMeta(overrides: MetaOverrides = {}) {
+  server.use(
+    http.get('/api/recipes/:id', () =>
+      HttpResponse.json({
+        success: true,
+        data: {
+          id: 101,
+          title: 'Recipe Under Test',
+          story: null,
+          videoUrl: null,
+          servingSize: 2,
+          type: 'community',
+          isPublished: true,
+          averageRating: null,
+          ratingCount: 0,
+          creatorId: '1',
+          creatorUsername: 'tester',
+          dishVarietyId: null,
+          dishVarietyName: overrides.dishVarietyName ?? null,
+          genreName: overrides.genreName ?? null,
+          country: overrides.country ?? null,
+          city: overrides.city ?? null,
+          district: overrides.district ?? null,
+          ingredients: [],
+          steps: [],
+          tools: [],
+          media: [],
+          tags: [],
+          culturalTags: [],
+          videoAnnotations: [],
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-02T00:00:00Z',
+        },
+        error: null,
+      }),
+    ),
+    http.get('/api/recipes/:id/ratings/me', () =>
+      HttpResponse.json({ success: true, data: null, error: null }),
+    ),
+  )
+}
+
+async function renderRecipeDetail() {
+  const result = renderWithProviders(undefined, { initialEntries: ['/recipes/101'] })
+  // Wait for the recipe title to appear — confirms the page resolved.
+  await waitFor(() => {
+    expect(result.getByText('Recipe Under Test')).toBeInTheDocument()
+  })
+  return result
+}
+
+describe('RecipeDetailPage meta lines', () => {
+  it('renders both taxonomy line and location line when all four fields are present', async () => {
+    mockRecipeWithMeta({
+      genreName: 'Soups',
+      dishVarietyName: 'Lentil Soup',
+      city: 'Istanbul',
+      country: 'Turkey',
+    })
+
+    const { getByText } = await renderRecipeDetail()
+    expect(getByText('Soups · Lentil Soup')).toBeInTheDocument()
+    expect(getByText('Istanbul, Turkey')).toBeInTheDocument()
+  })
+
+  it('renders only the country when city is missing', async () => {
+    mockRecipeWithMeta({
+      genreName: 'Soups',
+      dishVarietyName: 'Lentil Soup',
+      country: 'Japan',
+      city: null,
+    })
+
+    const { getByText, queryByText } = await renderRecipeDetail()
+    expect(getByText('Japan')).toBeInTheDocument()
+    // Comma separator only shown when both city and country exist
+    expect(queryByText(/,/)).not.toBeInTheDocument()
+  })
+
+  it('renders only the genre when variety is missing', async () => {
+    mockRecipeWithMeta({
+      genreName: 'Soups',
+      dishVarietyName: null,
+      country: 'Turkey',
+    })
+
+    const { getByText, queryByText } = await renderRecipeDetail()
+    expect(getByText('Soups')).toBeInTheDocument()
+    expect(queryByText(/·/)).not.toBeInTheDocument()
+  })
+
+  it('omits the location line entirely when both city and country are null', async () => {
+    mockRecipeWithMeta({
+      genreName: 'Soups',
+      dishVarietyName: 'Lentil Soup',
+      country: null,
+      city: null,
+    })
+
+    const { getByText, queryByText } = await renderRecipeDetail()
+    expect(getByText('Soups · Lentil Soup')).toBeInTheDocument()
+    // No location line — no country word visible
+    expect(queryByText('Turkey')).not.toBeInTheDocument()
+    expect(queryByText('Istanbul')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Adds vitest coverage for the UI polish fixes shipped in #576 (now on main). New tests live under `src/__tests__/integration/` to match the existing project convention (i18n provider wrap + render-and-assert).

Three files, 11 cases, ~206 lines:

- **`recipe-card-badge.test.tsx`** — verifies the hero `RecipeCard` renders the Cultural / Community badge through `useTranslation`, and switches to Kültürel / Topluluk on the Turkish locale. Covers #567.
- **`recipe-detail-meta.test.tsx`** — drives `RecipeDetailPage` through MSW with four permutations (all fields, country-only, genre-only, neither) and asserts the taxonomy and location lines render independently. Covers #566.
- **`create-recipe-step-label.test.ts`** — pure i18n interpolation test for the new `{{total}}` placeholder; pins the EN / TR output so step indicators stay correct for any flow length. Covers #568.

## Test plan

- [x] `cd frontend && npm run test:run` clean (22 files / 103 tests; +11 from this PR)
- [x] No product code changes — tests only

## Out of scope

The CreateRecipe review step listing (#569) is not unit-tested in this PR because reaching step 5 with valid local-state ingredients/tools/steps requires driving the full multi-step wizard via the UI. A focused refactor that extracts the review block into a presentational component would unlock that test cheaply — can be tracked separately if we decide to.

Closes #586