### PR TITLE
[Mobile/Feature] Add edit recipe action to Library screen

### DIFF
--- a/mobile/src/__tests__/MyLibraryScreen.test.tsx
+++ b/mobile/src/__tests__/MyLibraryScreen.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import { MyLibraryScreen } from '../screens/MyLibraryScreen';
+import * as RecipeFormContext from '../context/RecipeFormContext';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('@expo/vector-icons/Ionicons', () => 'Ionicons');
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const mockNavigate = jest.fn();
+const mockGetParent = jest.fn(() => ({ navigate: jest.fn() }));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    getParent: mockGetParent,
+  }),
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.title) return `${key}:${opts.title}`;
+      if (opts?.name) return `${key}:${opts.name}`;
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+const mockGetMyRecipes = jest.fn();
+const mockGetFavorites = jest.fn();
+const mockGetRecipeById = jest.fn();
+const mockDeleteRecipe = jest.fn();
+
+jest.mock('../api/recipes', () => ({
+  getMyRecipes: (...args: unknown[]) => mockGetMyRecipes(...args),
+  getFavorites: (...args: unknown[]) => mockGetFavorites(...args),
+  getRecipeById: (...args: unknown[]) => mockGetRecipeById(...args),
+  deleteRecipe: (...args: unknown[]) => mockDeleteRecipe(...args),
+}));
+
+jest.mock('../utils/draftHelpers', () => ({
+  mapBackendToDraft: jest.fn((recipe) => ({ recipeId: recipe.id, title: recipe.title })),
+}));
+
+const mockUpdateDraft = jest.fn();
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const publishedRecipe = {
+  id: 'recipe-pub-1',
+  title: 'Published Recipe',
+  type: 'community' as const,
+  isPublished: true,
+  averageRating: 4.2,
+  ratingCount: 5,
+  createdAt: '2025-01-01T00:00:00Z',
+  coverImageUrl: null,
+  country: 'Turkey',
+  city: 'Istanbul',
+};
+
+const draftRecipe = {
+  id: 'recipe-draft-1',
+  title: 'Draft Recipe',
+  type: 'community' as const,
+  isPublished: false,
+  averageRating: null,
+  ratingCount: 0,
+  createdAt: '2025-01-02T00:00:00Z',
+  coverImageUrl: null,
+  country: null,
+  city: null,
+};
+
+const backendDetail = {
+  id: 'recipe-pub-1',
+  title: 'Published Recipe',
+  type: 'community',
+  tags: [],
+  allergens: [],
+  country: 'Turkey',
+  city: 'Istanbul',
+  district: '',
+  dishVarietyId: 1,
+  story: '',
+  servingSize: 4,
+  ingredients: [],
+  tools: [],
+  media: [],
+  steps: [],
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function renderAndFlush() {
+  const result = render(<MyLibraryScreen />);
+  await waitFor(() => expect(mockGetMyRecipes).toHaveBeenCalled());
+  return result;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('MyLibraryScreen — edit recipe', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMyRecipes.mockResolvedValue([publishedRecipe, draftRecipe]);
+    mockGetFavorites.mockResolvedValue({ recipes: [] });
+    mockGetRecipeById.mockResolvedValue(backendDetail);
+
+    jest.spyOn(RecipeFormContext, 'useRecipeForm').mockReturnValue({
+      draft: {} as any,
+      updateDraft: mockUpdateDraft,
+      resetDraft: jest.fn(),
+      saveDraft: jest.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it('renders Edit button for each recipe card', async () => {
+    const { getAllByText } = await renderAndFlush();
+    const editButtons = getAllByText('library.edit');
+    expect(editButtons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('tapping Edit on a recipe loads it into context and navigates to CreateTab', async () => {
+    const { getAllByText } = await renderAndFlush();
+    const editButtons = getAllByText('library.edit');
+    expect(editButtons.length).toBeGreaterThanOrEqual(1);
+
+    // Press first available edit button
+    fireEvent.press(editButtons[0]);
+
+    await waitFor(() => {
+      expect(mockGetRecipeById).toHaveBeenCalled();
+      expect(mockUpdateDraft).toHaveBeenCalled();
+    });
+
+    const parentNavCall = mockGetParent.mock.results[0]?.value;
+    expect(parentNavCall.navigate).toHaveBeenCalledWith('CreateTab');
+  });
+
+  it('tapping the draft card loads it into context and navigates to CreateTab', async () => {
+    const { getByText } = await renderAndFlush();
+
+    // Press the draft card by title
+    fireEvent.press(getByText('Draft Recipe'));
+
+    await waitFor(() => {
+      expect(mockGetRecipeById).toHaveBeenCalledWith(draftRecipe.id);
+      expect(mockUpdateDraft).toHaveBeenCalled();
+    });
+  });
+
+  it('shows error message when edit fetch fails', async () => {
+    mockGetRecipeById.mockRejectedValue(new Error('network error'));
+
+    const { getAllByText, findByText } = await renderAndFlush();
+    const editButtons = getAllByText('library.edit');
+
+    fireEvent.press(editButtons[0]);
+
+    const errorMsg = await findByText('library.editError');
+    expect(errorMsg).toBeTruthy();
+  });
+
+  it('tapping a published recipe card (not the edit button) navigates to RecipeDetail', async () => {
+    const { getAllByText } = await renderAndFlush();
+
+    fireEvent.press(getAllByText('Published Recipe')[0]);
+
+    expect(mockNavigate).toHaveBeenCalledWith('RecipeDetail', {
+      recipeId: publishedRecipe.id,
+    });
+  });
+});

--- a/mobile/src/components/create-review/CreateReviewScreen.tsx
+++ b/mobile/src/components/create-review/CreateReviewScreen.tsx
@@ -95,8 +95,12 @@ export function CreateReviewScreen() {
       }
 
       await attachMedia(targetId);
-      const published = await publishRecipe(targetId);
-      console.log("[publish] recipe published:", published);
+      if (!draft.isAlreadyPublished) {
+        const published = await publishRecipe(targetId);
+        console.log("[publish] recipe published:", published);
+      } else {
+        console.log("[publish] recipe already published, skipping publish call:", targetId);
+      }
       Alert.alert(t("create.published"), t("create.publishedMsg"), [
         { text: "OK", onPress: goHome },
       ]);

--- a/mobile/src/context/RecipeFormContext.tsx
+++ b/mobile/src/context/RecipeFormContext.tsx
@@ -11,6 +11,7 @@ export interface ReviewStep {
 
 export interface RecipeFormState {
   recipeId?: string;
+  isAlreadyPublished?: boolean;
   // Screen 12 — Basic Info
   title: string;
   type: RecipeType;

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -167,6 +167,8 @@ export const en = {
     publish: 'Publish',
     publishing: 'Publishing…',
     publishError: 'Could not publish recipe. Please try again.',
+    edit: 'Edit',
+    editError: 'Could not load recipe for editing. Please try again.',
     delete: 'Delete',
     deleteError: 'Could not delete recipe. Please try again.',
     deleteConfirmTitle: 'Delete recipe?',

--- a/mobile/src/i18n/tr.ts
+++ b/mobile/src/i18n/tr.ts
@@ -169,6 +169,8 @@ export const tr: Translations = {
     publish: 'Yayınla',
     publishing: 'Yayınlanıyor…',
     publishError: 'Tarif yayınlanamadı. Lütfen tekrar deneyin.',
+    edit: 'Düzenle',
+    editError: 'Tarif düzenleme için yüklenemedi. Lütfen tekrar deneyin.',
     delete: 'Sil',
     deleteError: 'Tarif silinemedi. Lütfen tekrar deneyin.',
     deleteConfirmTitle: 'Tarifi sil?',

--- a/mobile/src/screens/MyLibraryScreen.tsx
+++ b/mobile/src/screens/MyLibraryScreen.tsx
@@ -77,7 +77,7 @@ export function MyLibraryScreen() {
   const [cityModalOpen, setCityModalOpen] = useState(false);
 
   const { updateDraft } = useRecipeForm();
-  const [resumingId, setResumingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   const isFavoritesTab = filter === 'favorites';
 
@@ -180,6 +180,21 @@ export function MyLibraryScreen() {
     setDeleteTarget({ id: recipe.id, title: recipe.title });
   }
 
+  async function handleEdit(recipe: MyRecipeSummary) {
+    setActionError(null);
+    try {
+      setEditingId(recipe.id);
+      const detail = await getRecipeById(recipe.id);
+      const draftState = mapBackendToDraft(detail);
+      updateDraft(draftState);
+      navigation.getParent()?.navigate('CreateTab' as never);
+    } catch {
+      setActionError(t('library.editError'));
+    } finally {
+      setEditingId(null);
+    }
+  }
+
   function renderFavoriteItem({ item }: { item: FavoriteRecipe }) {
     const subtitle = [item.dishVarietyName, item.genreName]
       .filter(Boolean)
@@ -263,33 +278,22 @@ export function MyLibraryScreen() {
 
   function renderItem({ item }: { item: MyRecipeSummary }) {
     const location = [item.city, item.country].filter(Boolean).join(', ');
-    const isResuming = resumingId === item.id;
+    const isEditing = editingId === item.id;
     return (
       <TouchableOpacity
         activeOpacity={0.85}
         style={styles.card}
-        disabled={isResuming}
-        onPress={async () => {
+        disabled={isEditing}
+        onPress={() => {
           if (!item.isPublished) {
-            try {
-              setResumingId(item.id);
-              const detail = await getRecipeById(item.id);
-              const draftState = mapBackendToDraft(detail);
-              updateDraft(draftState);
-              navigation.getParent()?.navigate('CreateTab' as never);
-            } catch (err) {
-              console.error(err);
-              setActionError(t('library.errorRetry'));
-            } finally {
-              setResumingId(null);
-            }
+            handleEdit(item);
           } else {
             navigation.navigate('RecipeDetail', { recipeId: item.id });
           }
         }}
       >
         <View style={styles.thumb}>
-          {isResuming ? (
+          {isEditing ? (
             <View style={styles.thumbPlaceholder}>
               <ActivityIndicator color={colors.primary} />
             </View>
@@ -387,7 +391,19 @@ export function MyLibraryScreen() {
 
           <View style={styles.actionsRow}>
             <TouchableOpacity
+              style={[styles.actionBtn, styles.editBtn]}
+              disabled={isEditing}
+              onPress={() => handleEdit(item)}
+            >
+              {isEditing ? (
+                <ActivityIndicator size="small" color={colors.primary} />
+              ) : (
+                <Text style={styles.editBtnText}>{t('library.edit')}</Text>
+              )}
+            </TouchableOpacity>
+            <TouchableOpacity
               style={[styles.actionBtn, styles.deleteBtn]}
+              disabled={isEditing}
               onPress={() => openDeleteConfirm(item)}
             >
               <Text style={styles.deleteBtnText}>{t('library.delete')}</Text>
@@ -882,6 +898,15 @@ const styles = StyleSheet.create({
     borderColor: colors.primary,
   },
   publishBtnText: { color: colors.white, fontSize: 12, fontWeight: '600' },
+  editBtn: {
+    backgroundColor: colors.white,
+    borderColor: colors.primary,
+  },
+  editBtnText: {
+    color: colors.primary,
+    fontSize: 12,
+    fontWeight: '600',
+  },
   deleteBtn: {
     backgroundColor: colors.white,
     borderColor: colors.negative,

--- a/mobile/src/utils/draftHelpers.ts
+++ b/mobile/src/utils/draftHelpers.ts
@@ -7,6 +7,7 @@ export function mapBackendToDraft(recipe: BackendRecipeDetail): RecipeFormState 
 
   return {
     recipeId: recipe.id,
+    isAlreadyPublished: recipe.isPublished,
     title: recipe.title,
     type: recipe.type === 'cultural' ? 'CULTURAL' : 'COMMUNITY',
     originCountry: recipe.country || '',


### PR DESCRIPTION
## What does this PR do?
Adds an Edit button to each recipe card in the Library screen. Tapping it pre-populates the 4-step creation wizard with the existing recipe data, allowing the user to update and re-publish (or save as draft).

Also fixes a bug where editing an already-published recipe caused a `CONFLICT` error on the publish step — the publish endpoint is now skipped when the recipe was already published before editing.

## How to test
1. Log in as a cook or expert with at least one published recipe in My Library
2. Go to My Library → tap **Edit** on a published recipe
3. Confirm the wizard opens pre-filled with the recipe's data
4. Make a change (e.g. edit the title) → proceed to Review → tap Publish
5. Verify no CONFLICT error and changes are reflected on the recipe detail page
6. Repeat for a draft recipe (Edit button and card tap should both open the wizard)

## Related issue
Closes #587