### PR TITLE
Localize allergens, units, and cultural tags in recipe detail

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -123,8 +123,9 @@ Database is managed via Supabase (no migration files in repo). Key tables:
 ### Reference Tables
 
 - **ingredients** — `id`, `name`, `name_en`, `name_tr` (`name` mirrors `name_en` for backward compat; see migration 002)
-- **allergens** — `id`, `name`
+- **allergens** — `id`, `name`, `name_en`, `name_tr` (added in migration `009_localize_allergens_and_units.sql`; `name_en` seeded from `name` for existing rows)
 - **ingredient_allergens** — `ingredient_id` (FK), `allergen_id` (FK)
+- **units** — `id`, `name` (unique, lowercase canonical), `name_en`, `name_tr`. Reference table introduced in `009_localize_allergens_and_units.sql`. `recipe_ingredients.unit` is free text and joins case-insensitively on `LOWER(units.name)`; the row is used to resolve the unit string into the caller's preferred language on `GET /recipes/:id` when `?lang=` is set and no `recipe_ingredient_translations` row exists for the recipe.
 - **ingredient_substitutions** — `id`, `ingredient_id` (FK ingredients), `substitute_id` (FK ingredients), `source_amount` NUMERIC(10,3), `source_unit` TEXT, `sub_amount` NUMERIC(10,3), `sub_unit` TEXT, `confidence` NUMERIC(3,2), `description` TEXT — unique on (ingredient_id, substitute_id), no self-substitution
 - **dietary_tags** — `id`, `name`, `name_en`, `name_tr`, `category` (dietary|allergen)
 - **cultural_tags** — `id`, `key` (unique slug e.g. `"social-gathering"`), `label_en`, `label_tr`, `country` (nullable — NULL = global, otherwise country-scoped e.g. `"Turkey"`). Seeded with 10 curated tags: 7 global (`social-gathering`, `religious-feast`, `wedding`, `funeral`, `birth`, `new-year`, `harvest`) + 3 region-specific (`sira-gecesi`/Turkey, `iftar`/Turkey, `mochitsuki`/Japan). Migration: `migrations/004_cultural_tags.sql`.
@@ -423,6 +424,21 @@ Use `successResponse(data)` and `errorResponse(code, message)` from `src/utils/r
 - **No source:** `req.lang = null` — downstream handlers skip translation lookups
 
 `GET /recipes/:id` reads `req.lang` instead of parsing `?lang=` directly, converts to uppercase (`'en'` → `'EN'`) for the DB column, and fetches translations from `recipe_translations`, `recipe_step_translations`, and `recipe_ingredient_translations` when `req.lang` is non-null, falling back to original content when no translation row exists.
+
+When `?lang=` is set, the recipe-detail handler also resolves these reference-table fields via `resolveLocalizedName()` (`src/utils/i18n.ts`) so the response matches the caller's UI language without depending on the per-recipe DeepL pipeline:
+
+- **dietary tags** (`tags[].name`) — from `dietary_tags.name_en` / `name_tr`
+- **top-level allergens** (`allergens[].name`) — from `allergens.name_en` / `name_tr` (rows fetched by `allergen_ids` on the recipe)
+- **per-ingredient allergens** (`ingredients[].allergens`) — from the joined `allergens.name_en` / `name_tr` on `ingredient_allergens`
+- **ingredient unit** (`ingredients[].unit`) — resolved through the `units` reference table when no `recipe_ingredient_translations` row matches. The handler collects the recipe's distinct unit strings, queries `units` by lower-cased `name`, and resolves to `name_en`/`name_tr` based on lang. `recipe_ingredient_translations` always takes precedence so per-recipe DeepL output isn't overridden.
+
+All four fall back through the standard chain (preferred lang → other lang → `name`) and silently degrade to the raw stored value when no reference row exists, so legacy recipes never lose data.
+
+In addition, three response-shape fields don't map to a DB column at all and are localized via static in-code tables (additive — the raw values stay on the response so frontend filters / CSS hooks never break):
+
+- **`typeName`** — display label for the recipe `type` enum (`community` → `"Community"` / `"Topluluk"`, `cultural` → `"Cultural"` / `"Kültürel"`). Resolved by `resolveRecipeTypeLabel()` in `utils/i18n.ts`. Without `?lang=` the field carries the raw enum so the response is self-consistent.
+- **`countryName`** — display label for the stored canonical English `country` value. Resolved by `resolveCountryName()` in `utils/locations.ts` against `COUNTRY_LOCALIZATIONS` (Turkey, Japan, Germany, France, etc.). Countries not in the table fall back to the raw value, so unknown countries never disappear.
+- **`culturalTags[].label`** — single localized label that mirrors `tags[].name`. The existing `labelEn` / `labelTr` are kept on each entry for callers that need both forms (admin moderation, frontend language toggles).
 
 **Listing endpoints** also honor `req.lang` so cards on home, discovery, library, and profile pages render in the active UI language: `GET /recipes`, `GET /recipes/mine`, `GET /discovery/recipes`, `GET /discovery/recipes/by-ingredients`, `GET /users/me/favorites`, and `GET /users/me/drafts`. They use `fetchRecipeTitleTranslations(recipeIds, langCode)` from `translationService.ts` — a single batch query against `recipe_translations` for the current page — and resolve `dish_variety` / `dish_genre` names via `resolveLocalizedName()` (`src/utils/i18n.ts`) off the `name_en` / `name_tr` columns. Rows without a translation row fall back to the authored title.
 

--- a/backend/migrations/009_localize_allergens_and_units.sql
+++ b/backend/migrations/009_localize_allergens_and_units.sql
@@ -1,0 +1,100 @@
+-- Migration 009: localize allergens + units in recipe detail
+-- Adds the EN/TR `name_en` / `name_tr` columns the API now expects on
+-- allergens and introduces a `units` reference table that mirrors the
+-- ingredients pattern (id, name, name_en, name_tr) so the `/recipes/:id`
+-- endpoint can resolve a recipe-ingredient's free-text unit to the caller's
+-- preferred language.
+
+-- ─── allergens ────────────────────────────────────────────────────────────────
+ALTER TABLE public.allergens
+  ADD COLUMN IF NOT EXISTS name_en text,
+  ADD COLUMN IF NOT EXISTS name_tr text;
+
+UPDATE public.allergens
+  SET name_en = name
+  WHERE name_en IS NULL;
+
+-- ─── units ────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.units (
+  id         serial      PRIMARY KEY,
+  name       text        NOT NULL UNIQUE,
+  name_en    text,
+  name_tr    text,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Lower-case lookup index: recipe_ingredients.unit is free text, so the API
+-- joins on a case-insensitive match against units.name.
+CREATE INDEX IF NOT EXISTS units_name_lower_idx
+  ON public.units (LOWER(name));
+
+-- Read is public; nothing in the app writes to this table at runtime.
+ALTER TABLE public.units ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'units' AND policyname = 'Anyone can read units'
+  ) THEN
+    CREATE POLICY "Anyone can read units"
+      ON public.units FOR SELECT
+      USING (true);
+  END IF;
+END $$;
+
+-- Seed the units we already see in recipe_ingredients today plus the common
+-- TR-locale variants. ON CONFLICT keeps re-runs safe.
+INSERT INTO public.units (name, name_en, name_tr) VALUES
+  ('g',           'g',           'g'),
+  ('gr',          'g',           'gr'),
+  ('gram',        'gram',        'gram'),
+  ('grams',       'grams',       'gram'),
+  ('kg',          'kg',          'kg'),
+  ('kilogram',    'kilogram',    'kilogram'),
+  ('mg',          'mg',          'mg'),
+  ('ml',          'ml',          'ml'),
+  ('milliliter',  'milliliter',  'mililitre'),
+  ('l',           'L',           'L'),
+  ('liter',       'liter',       'litre'),
+  ('cup',         'cup',         'su bardağı'),
+  ('cups',        'cups',        'su bardağı'),
+  ('tbsp',        'tbsp',        'yemek kaşığı'),
+  ('tablespoon',  'tablespoon',  'yemek kaşığı'),
+  ('tablespoons', 'tablespoons', 'yemek kaşığı'),
+  ('tsp',         'tsp',         'tatlı kaşığı'),
+  ('teaspoon',    'teaspoon',    'tatlı kaşığı'),
+  ('teaspoons',   'teaspoons',   'tatlı kaşığı'),
+  ('pinch',       'pinch',       'tutam'),
+  ('pinches',     'pinches',     'tutam'),
+  ('dash',        'dash',        'tutam'),
+  ('piece',       'piece',       'adet'),
+  ('pieces',      'pieces',      'adet'),
+  ('slice',       'slice',       'dilim'),
+  ('slices',      'slices',      'dilim'),
+  ('clove',       'clove',       'diş'),
+  ('cloves',      'cloves',      'diş'),
+  ('bunch',       'bunch',       'demet'),
+  ('handful',     'handful',     'avuç'),
+  ('drop',        'drop',        'damla'),
+  ('drops',       'drops',       'damla'),
+  ('oz',          'oz',          'ons'),
+  ('ounce',       'ounce',       'ons'),
+  ('lb',          'lb',          'libre'),
+  ('pound',       'pound',       'libre'),
+  -- TR-authored units mapped back to EN
+  ('su bardağı',     'cup',                 'su bardağı'),
+  ('çay bardağı',    'tea glass',           'çay bardağı'),
+  ('yemek kaşığı',   'tablespoon',          'yemek kaşığı'),
+  ('tatlı kaşığı',   'dessert spoon',       'tatlı kaşığı'),
+  ('çay kaşığı',     'teaspoon',            'çay kaşığı'),
+  ('tutam',          'pinch',               'tutam'),
+  ('adet',           'piece',               'adet'),
+  ('dilim',          'slice',               'dilim'),
+  ('diş',            'clove',               'diş'),
+  ('demet',          'bunch',               'demet'),
+  ('avuç',           'handful',             'avuç'),
+  ('damla',          'drop',                'damla'),
+  ('paket',          'pack',                'paket'),
+  ('kutu',           'box',                 'kutu')
+ON CONFLICT (name) DO NOTHING;

--- a/backend/src/__tests__/translation.test.ts
+++ b/backend/src/__tests__/translation.test.ts
@@ -772,6 +772,298 @@ describe("GET /recipes/:id?lang=", () => {
     expect(res.status).toBe(200);
     expect(res.body.data.tools[0].name).toBe("Oven");
   });
+
+  // ─── allergens (top-level + per-ingredient) lang resolution ───────────────────
+
+  const mockRecipeWithAllergens = {
+    ...mockRecipeData,
+    allergen_ids: [10, 11],
+    recipe_ingredients: [
+      {
+        id: "ri-1",
+        quantity: 2,
+        unit: "cup",
+        ingredient: {
+          id: 1, name: "Flour", name_en: "Flour", name_tr: "Un",
+          ingredient_allergens: [
+            { allergen: { id: 10, name: "Gluten", name_en: "Gluten", name_tr: "Glüten" } },
+          ],
+        },
+      },
+    ],
+  };
+
+  it("top-level allergens are returned in TR when ?lang=tr", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithAllergens, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: {
+        data: [
+          { id: 10, name: "Gluten", name_en: "Gluten", name_tr: "Glüten" },
+          { id: 11, name: "Dairy", name_en: "Dairy", name_tr: "Süt Ürünleri" },
+        ],
+        error: null,
+      },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.allergens.map((a: any) => a.name)).toEqual(
+      expect.arrayContaining(["Glüten", "Süt Ürünleri"])
+    );
+  });
+
+  it("top-level allergens are returned in EN when ?lang=en", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithAllergens, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: {
+        data: [
+          { id: 10, name: "Gluten", name_en: "Gluten", name_tr: "Glüten" },
+          { id: 11, name: "Dairy", name_en: "Dairy", name_tr: "Süt Ürünleri" },
+        ],
+        error: null,
+      },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=en");
+    expect(res.status).toBe(200);
+    expect(res.body.data.allergens.map((a: any) => a.name)).toEqual(
+      expect.arrayContaining(["Gluten", "Dairy"])
+    );
+  });
+
+  it("top-level allergens fall back to name_en when name_tr is null and ?lang=tr", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithAllergens, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: {
+        data: [
+          { id: 10, name: "Gluten", name_en: "Gluten", name_tr: null },
+        ],
+        error: null,
+      },
+    });
+    const res = await request(app)
+      .get("/recipes/recipe-1?lang=tr")
+      .send();
+    expect(res.status).toBe(200);
+    expect(res.body.data.allergens[0].name).toBe("Gluten");
+  });
+
+  it("per-ingredient allergens are returned in TR when ?lang=tr", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithAllergens, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].allergens).toEqual(["Glüten"]);
+  });
+
+  // ─── units localization via the `units` reference table ───────────────────────
+
+  it("ingredient unit is resolved via the units table when ?lang=tr and no DeepL translation exists", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithAllergens, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+      units: {
+        data: [{ name: "cup", name_en: "cup", name_tr: "su bardağı" }],
+        error: null,
+      },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].unit).toBe("su bardağı");
+  });
+
+  it("ingredient unit falls back to the stored value when no units row matches", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithAllergens, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+      units: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].unit).toBe("cup");
+  });
+
+  it("recipe_ingredient_translations still takes precedence over the units table", async () => {
+    setupMock({
+      recipes: { data: mockRecipeWithAllergens, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: {
+        data: [{ recipe_ingredient_id: "ri-1", unit: "bardak" }],
+        error: null,
+      },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+      units: {
+        data: [{ name: "cup", name_en: "cup", name_tr: "su bardağı" }],
+        error: null,
+      },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.ingredients[0].unit).toBe("bardak");
+  });
+
+  // ─── typeName / countryName / culturalTag label lang resolution ─────────────
+
+  const mockRecipeForTypeCountry = {
+    ...mockRecipeData,
+    type: "community",
+    country: "Japan",
+    recipe_cultural_tags: [
+      { cultural_tag: { id: 5, key: "birth", label_en: "Birth Celebration", label_tr: "Doğum Kutlaması", country: null } },
+    ],
+  };
+
+  it("typeName returns the TR label when ?lang=tr", async () => {
+    setupMock({
+      recipes: { data: mockRecipeForTypeCountry, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.type).toBe("community");
+    expect(res.body.data.typeName).toBe("Topluluk");
+  });
+
+  it("typeName returns the EN label when ?lang=en", async () => {
+    setupMock({
+      recipes: { data: { ...mockRecipeForTypeCountry, type: "cultural" }, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=en");
+    expect(res.status).toBe(200);
+    expect(res.body.data.type).toBe("cultural");
+    expect(res.body.data.typeName).toBe("Cultural");
+  });
+
+  it("typeName falls back to the raw enum when ?lang= is absent", async () => {
+    setupMock({
+      recipes: { data: mockRecipeForTypeCountry, error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1");
+    expect(res.status).toBe(200);
+    expect(res.body.data.typeName).toBe("community");
+  });
+
+  it("countryName returns the TR display name when ?lang=tr", async () => {
+    setupMock({
+      recipes: { data: mockRecipeForTypeCountry, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.country).toBe("Japan");
+    expect(res.body.data.countryName).toBe("Japonya");
+  });
+
+  it("countryName falls back to the raw value for countries not in the localization map", async () => {
+    setupMock({
+      recipes: { data: { ...mockRecipeForTypeCountry, country: "Atlantis" }, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.country).toBe("Atlantis");
+    expect(res.body.data.countryName).toBe("Atlantis");
+  });
+
+  it("culturalTags[].label is the TR label when ?lang=tr, alongside labelEn / labelTr", async () => {
+    setupMock({
+      recipes: { data: mockRecipeForTypeCountry, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    const tag = res.body.data.culturalTags[0];
+    expect(tag.label).toBe("Doğum Kutlaması");
+    expect(tag.labelEn).toBe("Birth Celebration");
+    expect(tag.labelTr).toBe("Doğum Kutlaması");
+  });
+
+  it("culturalTags[].label is the EN label when ?lang=en", async () => {
+    setupMock({
+      recipes: { data: mockRecipeForTypeCountry, error: null },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=en");
+    expect(res.status).toBe(200);
+    expect(res.body.data.culturalTags[0].label).toBe("Birth Celebration");
+  });
+
+  // ─── tags lang resolution — sanity check (already wired via resolveLocalizedName)
+  it("tags[].name returns name_tr when ?lang=tr", async () => {
+    setupMock({
+      recipes: {
+        data: {
+          ...mockRecipeWithAllergens,
+          recipe_dietary_tags: [
+            { dietary_tag: { id: 1, name: "Vegan", name_en: "Vegan", name_tr: "Vegan", category: "dietary" } },
+            { dietary_tag: { id: 2, name: "Gluten-Free", name_en: "Gluten-Free", name_tr: "Glütensiz", category: "allergen" } },
+          ],
+        },
+        error: null,
+      },
+      recipe_translations: { data: null, error: null },
+      recipe_step_translations: { data: [], error: null },
+      recipe_ingredient_translations: { data: [], error: null },
+      recipe_tool_translations: { data: [], error: null },
+      allergens: { data: [], error: null },
+    });
+    const res = await request(app).get("/recipes/recipe-1?lang=tr");
+    expect(res.status).toBe(200);
+    expect(res.body.data.tags.map((t: any) => t.name)).toEqual(
+      expect.arrayContaining(["Vegan", "Glütensiz"])
+    );
+  });
 });
 
 // ─── POST /recipes/:id/publish — additional edge cases ────────────────────────

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -724,7 +724,7 @@ export const openApiSpec = {
         tags: ["Recipes"],
         parameters: [
           { name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } },
-          { name: "lang", in: "query", schema: { type: "string", enum: ["en", "tr"] }, description: "Return translated fields if available" },
+          { name: "lang", in: "query", schema: { type: "string", enum: ["en", "tr"] }, description: "Resolve translated fields when available. Title/story/steps/units use the per-recipe `recipe_*_translations` rows (DeepL). Allergens (top-level + per-ingredient), dietary tags, dish variety / genre, and ingredient names resolve via the `name_en` / `name_tr` reference-table columns; units fall back to the global `units` reference table when no per-recipe translation row exists. The raw `type` enum and `country` value are preserved; the response also carries `typeName` (static EN/TR labels for community/cultural) and `countryName` (static EN/TR labels for known countries). Each `culturalTags[]` entry includes a single resolved `label` alongside the existing `labelEn`/`labelTr` pair." },
         ],
         responses: {
           "200": { description: "Recipe detail with ingredients, steps, tools, media, and tags" },

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -5,10 +5,10 @@ import { requireAuth, requireRole } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import type { AuthenticatedRequest, LanguageRequest } from "../types/index.js";
 import { errorResponse, successResponse } from "../utils/response.js";
-import { canonicalizeLocationForWrite } from "../utils/locations.js";
+import { canonicalizeLocationForWrite, resolveCountryName } from "../utils/locations.js";
 import { normalizeText } from "../utils/text.js";
 import { translateRecipe, fetchRecipeTitleTranslations } from "../services/translationService.js";
-import { resolveLocalizedName } from "../utils/i18n.js";
+import { resolveLocalizedName, resolveRecipeTypeLabel } from "../utils/i18n.js";
 
 const router = Router();
 
@@ -253,7 +253,7 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       `id, title, story, video_url, serving_size, type, is_published, average_rating, rating_count, allergen_ids, country, city, district, created_at, updated_at,
        creator:profiles!recipes_creator_id_fkey(id, username),
        dish_variety:dish_varieties(id, name, name_en, name_tr, dish_genre:dish_genres(id, name, name_en, name_tr)),
-       recipe_ingredients(id, quantity, unit, ingredient:ingredients(id, name, name_en, name_tr, ingredient_allergens(allergen:allergens(name)))),
+       recipe_ingredients(id, quantity, unit, ingredient:ingredients(id, name, name_en, name_tr, ingredient_allergens(allergen:allergens(id, name, name_en, name_tr)))),
        recipe_steps(id, step_order, description, video_timestamp),
        recipe_tools(id, name),
        recipe_media(id, url, type),
@@ -334,16 +334,49 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
     }
   }
 
-  // Resolve top-level allergen names from stored allergen_ids
+  // Resolve top-level allergen names from stored allergen_ids, localized per
+  // ?lang= when supplied (falls back to the legacy `name` column).
   const storedAllergenIds: number[] = (data as any).allergen_ids ?? [];
   let topLevelAllergens: { id: number; name: string }[] = [];
   if (storedAllergenIds.length > 0) {
     const { data: allergenData } = await supabase
       .from("allergens")
-      .select("id, name")
+      .select("id, name, name_en, name_tr")
       .in("id", storedAllergenIds);
-    topLevelAllergens = (allergenData ?? []) as { id: number; name: string }[];
+    topLevelAllergens = ((allergenData ?? []) as any[]).map((a) => ({
+      id: a.id,
+      name: resolveLocalizedName(a, langParam) ?? a.name,
+    }));
   }
+
+  // Resolve units against the `units` reference table when ?lang= is set.
+  // Per-recipe DeepL translations in `recipe_ingredient_translations` still
+  // take precedence; this map is the fallback for recipes that haven't been
+  // translated yet (or units DeepL doesn't change).
+  const unitLocalizationMap = new Map<string, string>();
+  if (langParam) {
+    const rawUnits = ((data as any).recipe_ingredients ?? [])
+      .map((ri: any) => (ri.unit ?? "").trim())
+      .filter((u: string) => u.length > 0);
+    const uniqueUnits = [...new Set(rawUnits.map((u: string) => u.toLowerCase()))] as string[];
+    if (uniqueUnits.length > 0) {
+      const { data: unitRows } = await supabase
+        .from("units")
+        .select("name, name_en, name_tr")
+        .in("name", uniqueUnits);
+      for (const row of (unitRows ?? []) as any[]) {
+        const localized = resolveLocalizedName(row, langParam);
+        if (localized) {
+          unitLocalizationMap.set(String(row.name).toLowerCase(), localized);
+        }
+      }
+    }
+  }
+  const localizeUnit = (raw: string | null | undefined): string => {
+    const value = (raw ?? "").toString();
+    if (!langParam) return value;
+    return unitLocalizationMap.get(value.trim().toLowerCase()) ?? value;
+  };
 
   // Optionally resolve isFavorited for authenticated callers
   let isFavorited = false;
@@ -380,8 +413,17 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
       videoUrl: (data as any).video_url ?? null,
       servingSize: (data as any).serving_size ?? null,
       type: data.type,
+      // `type` is a fixed enum (community|cultural) — frontend filters/CSS
+      // hooks rely on the raw value, so we keep it untouched and surface the
+      // localized display label as `typeName` (matches ingredientName /
+      // dishVarietyName naming).
+      typeName: resolveRecipeTypeLabel(data.type, langParam),
       isPublished: (data as any).is_published,
       country: (data as any).country ?? null,
+      // `country` is stored as the canonical English display name (see
+      // utils/locations.ts). `countryName` is the lang-resolved label;
+      // callers without `?lang=` get the raw value here too.
+      countryName: resolveCountryName((data as any).country, langParam),
       city: (data as any).city ?? null,
       district: (data as any).district ?? null,
       averageRating: (data as any).average_rating ?? null,
@@ -393,10 +435,12 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
         ingredientId: ri.ingredient?.id ?? null,
         ingredientName: resolveLocalizedName(ri.ingredient, langParam),
         quantity: ri.quantity,
-        unit: ingredientUnitMap[ri.id] ?? ri.unit,
+        unit: ingredientUnitMap[ri.id] ?? localizeUnit(ri.unit),
         allergens: (ri.ingredient?.ingredient_allergens ?? [])
-          .map((ia: any) => ia.allergen?.name)
-          .filter(Boolean),
+          .map((ia: any) =>
+            ia.allergen ? resolveLocalizedName(ia.allergen, langParam) ?? ia.allergen.name : null
+          )
+          .filter((n: string | null): n is string => Boolean(n)),
       })),
       steps: steps.map((s: any) => ({
         id: s.id,
@@ -418,13 +462,27 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
         name: resolveLocalizedName(rt.dietary_tag, langParam),
         category: rt.dietary_tag?.category ?? null,
       })),
-      culturalTags: ((data as any).recipe_cultural_tags ?? []).map((rt: any) => ({
-        id: rt.cultural_tag?.id ?? null,
-        key: rt.cultural_tag?.key ?? null,
-        labelEn: rt.cultural_tag?.label_en ?? null,
-        labelTr: rt.cultural_tag?.label_tr ?? null,
-        country: rt.cultural_tag?.country ?? null,
-      })),
+      culturalTags: ((data as any).recipe_cultural_tags ?? []).map((rt: any) => {
+        const tag = rt.cultural_tag ?? null;
+        // Single resolved `label` mirrors the tags[].name shape so the
+        // frontend can render either tag list with the same code. labelEn /
+        // labelTr stay on the response for callers that need both forms
+        // (admin moderation, frontend toggles) — additive only.
+        const label = tag
+          ? resolveLocalizedName(
+              { name: tag.label_en ?? null, name_en: tag.label_en, name_tr: tag.label_tr },
+              langParam
+            )
+          : null;
+        return {
+          id: tag?.id ?? null,
+          key: tag?.key ?? null,
+          label,
+          labelEn: tag?.label_en ?? null,
+          labelTr: tag?.label_tr ?? null,
+          country: tag?.country ?? null,
+        };
+      }),
       videoAnnotations: [...((data as any).video_annotations ?? [])]
         .sort((a: any, b: any) => Number(a.start_time) - Number(b.start_time))
         .map((a: any) => ({

--- a/backend/src/utils/i18n.ts
+++ b/backend/src/utils/i18n.ts
@@ -41,3 +41,30 @@ export function resolveLocalizedName(
   const fallback = langParam === "EN" ? obj.name_tr : obj.name_en;
   return preferred ?? fallback ?? obj.name ?? null;
 }
+
+/**
+ * Recipe `type` enum values don't live in a reference table — they're a
+ * fixed two-element column (community | cultural). When `?lang=` is set the
+ * detail endpoint surfaces `typeName` with these static labels so the
+ * response is self-contained and the frontend can render without a
+ * per-language i18n lookup. The raw `type` enum is preserved separately for
+ * filtering / CSS class hooks.
+ */
+const TYPE_LABELS: Record<"community" | "cultural", { en: string; tr: string }> = {
+  community: { en: "Community", tr: "Topluluk" },
+  cultural:  { en: "Cultural",  tr: "Kültürel" },
+};
+
+export function resolveRecipeTypeLabel(
+  type: string | null | undefined,
+  langParam: "EN" | "TR" | null
+): string | null {
+  if (!type) return null;
+  const entry = TYPE_LABELS[type as "community" | "cultural"];
+  if (!entry) return type; // unknown enum — return raw value
+  if (langParam === "TR") return entry.tr;
+  if (langParam === "EN") return entry.en;
+  // No language preference: keep the raw enum value so callers without
+  // ?lang= still get the historical shape.
+  return type;
+}

--- a/backend/src/utils/locations.ts
+++ b/backend/src/utils/locations.ts
@@ -72,6 +72,27 @@ export function getLocationVariants(input: string): string[] {
 }
 
 /**
+ * Resolve a country label into the caller's preferred language. The stored
+ * value is the canonical English display name (e.g. "Japan", "Turkey"); the
+ * lookup folds + alias-resolves the input so a row stored as "tr" or
+ * "Türkiye" still matches the canonical "Turkey" key. Falls back to the raw
+ * trimmed input when the country isn't in the table or `lang` is null, so
+ * countries we haven't enumerated never disappear from the response.
+ */
+export function resolveCountryName(
+  input: string | null | undefined,
+  lang: "EN" | "TR" | null
+): string | null {
+  const trimmed = normalizeLocation(input);
+  if (trimmed == null) return null;
+  if (!lang) return trimmed;
+  const canonical = getCanonicalDisplay(foldLocation(trimmed)) ?? trimmed;
+  const entry = COUNTRY_LOCALIZATIONS[canonical];
+  if (!entry) return trimmed;
+  return lang === "TR" ? entry.tr : entry.en;
+}
+
+/**
  * Deduplicate a list of location labels, treating values that share a
  * canonical key (after folding + alias resolution) as the same entry.
  * The canonical display name wins when present; otherwise the first-seen
@@ -186,4 +207,23 @@ const LOCATION_ALIASES: Record<string, string> = {
   "azerbaycan": "Azerbaijan",
   "az": "Azerbaijan",
   "aze": "Azerbaijan",
+};
+
+/**
+ * Canonical English display name → localized labels. Used by
+ * `resolveCountryName()` on `GET /recipes/:id?lang=` so the `countryName`
+ * field renders in the caller's language without requiring a frontend
+ * lookup. Add entries when a new country shows up in `recipes.country`.
+ */
+const COUNTRY_LOCALIZATIONS: Record<string, { en: string; tr: string }> = {
+  "Turkey":         { en: "Turkey",         tr: "Türkiye" },
+  "United States":  { en: "United States",  tr: "Amerika Birleşik Devletleri" },
+  "United Kingdom": { en: "United Kingdom", tr: "Birleşik Krallık" },
+  "Germany":        { en: "Germany",        tr: "Almanya" },
+  "Italy":          { en: "Italy",          tr: "İtalya" },
+  "France":         { en: "France",         tr: "Fransa" },
+  "Spain":          { en: "Spain",          tr: "İspanya" },
+  "Japan":          { en: "Japan",          tr: "Japonya" },
+  "Greece":         { en: "Greece",         tr: "Yunanistan" },
+  "Azerbaijan":     { en: "Azerbaijan",     tr: "Azerbaycan" },
 };


### PR DESCRIPTION
This pull request implements full localization of reference-table fields and static labels in the recipe detail API, enabling the `/recipes/:id` endpoint to return allergens, units, dietary tags, and other metadata in the caller's preferred language (`en` or `tr`). It introduces a new `units` reference table, localizes the `allergens` table, and updates the backend logic and tests to ensure correct language resolution and fallback behavior. Additionally, static UI labels such as `typeName` and `countryName` are now localized, and the OpenAPI docs are updated to reflect these changes.

**Database schema and reference data changes:**

* Added `name_en` and `name_tr` columns to the `allergens` table and seeded `name_en` from `name` for existing rows.
* Introduced a new `units` reference table with `name`, `name_en`, and `name_tr` columns, seeded with common units and Turkish variants. The API now resolves ingredient units via this table for localization.
* Updated documentation in `CLAUDE.md` to describe the new columns and tables, including how units and allergens are now localized.

**API response localization improvements:**

* The `/recipes/:id` endpoint now resolves the following fields in the caller's language when `?lang=` is set: dietary tags, top-level and per-ingredient allergens, ingredient units (via the new `units` table), `typeName`, `countryName`, and `culturalTags[].label`. Each field has a documented fallback chain to ensure legacy data is preserved.
* Static labels for `typeName` and `countryName` are now localized using in-code tables, and `culturalTags[].label` is resolved per language while preserving the raw values for frontend compatibility. [[1]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR428-R442) [[2]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baL8-R11)

**Backend logic and test updates:**

* The recipe detail handler and related utilities are updated to use new localization helpers, and the Supabase query now fetches all necessary localized columns for allergens. [[1]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baL8-R11) [[2]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baL256-R256)
* Comprehensive tests are added to verify correct language resolution and fallback for allergens, units, tags, `typeName`, `countryName`, and `culturalTags[].label` in the API response.

**Documentation and OpenAPI updates:**

* The OpenAPI spec is updated to document the new localization behavior for reference-table fields and static labels in the recipe detail response.

---

**Database schema and data localization:**

- Added `name_en` and `name_tr` to `allergens`, seeded `name_en`, and introduced a `units` table for ingredient unit localization.
- Updated `CLAUDE.md` to document new columns and the units localization mechanism.

**API logic and field resolution:**

- `/recipes/:id` now localizes dietary tags, allergens (top-level and per-ingredient), and ingredient units using the new schema, with robust fallback logic.
- Static labels for `typeName`, `countryName`, and `culturalTags[].label` are now localized and included in the response. [[1]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eR428-R442) [[2]](diffhunk://#diff-b6020eeb3b45e40bc5ea929ae49f5268316b3454976cba77da0fa0652298b3baL8-R11)

**Testing and documentation:**

- Added extensive tests for language resolution and fallback for all affected fields in the recipe detail API.
- Updated OpenAPI docs to reflect the new localization behavior and response shape. Closes #591 